### PR TITLE
[RFC] Average spectra preprocessor

### DIFF
--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -719,3 +719,58 @@ class Transmittance(Preprocess):
         domain = Orange.data.Domain(
                     newattrs, data.domain.class_vars, data.domain.metas)
         return data.from_table(domain, data)
+
+
+def _split_by_value(data, avar):
+    # from owcurves.CurvePlot._split_by_color_value()
+    rd = {}
+    if isinstance(avar, str):
+        rd[None] = np.full((len(data.X),), True, dtype=bool)
+    else:
+        cvd = Orange.data.Table(Orange.data.Domain([avar]), data)
+        for v in range(len(avar.values)):
+            v1 = np.in1d(cvd.X, v)
+            if np.any(v1):
+                rd[avar.values[v]] = v1
+        nanind = np.isnan(cvd.X)
+        if np.any(nanind):
+            rd[None] = nanind
+    return rd
+
+
+class Average(Preprocess):
+    """
+    Calculate mean and (optionally) standard deviation of groups of spectra
+
+    Parameters
+    ----------
+    avar : Variable to group averages
+    std : include standard deviation
+    """
+
+    def __init__(self, avar=None, std=False):
+        self.avar = avar
+        self.std = std
+
+    def __call__(self, data):
+        avar_vals = None
+        avar_meta = None
+        avgd = []
+        if self.avar:
+            avar_vals = []
+            dsplit = _split_by_value(data, self.avar)
+            for v, indices in dsplit.items():
+                avgd.append(data.X[indices].mean(axis=0))
+                avar_vals.append(v)
+                if self.std:
+                    avgd.append(data.X[indices].std(axis=0))
+                    avar_vals.append(v + " (Std Dev)")
+            avar_vals = np.vstack(avar_vals)
+            avar_meta = [Orange.data.StringVariable.make(name=self.avar.name)]
+        else:
+            avgd.append(data.X.mean(axis=0))
+            if self.std:
+                avgd.append(data.X.std(axis=0))
+
+        domain = Orange.data.Domain(data.domain.attributes, metas=avar_meta)
+        return Orange.data.Table(domain, np.vstack(avgd), metas=avar_vals)

--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -756,7 +756,7 @@ class Average(Preprocess):
         avar_vals = None
         avar_meta = None
         avgd = []
-        if self.avar:
+        if self.avar in data.domain:
             avar_vals = []
             dsplit = _split_by_value(data, self.avar)
             for v, indices in dsplit.items():

--- a/orangecontrib/infrared/preprocess.py
+++ b/orangecontrib/infrared/preprocess.py
@@ -760,17 +760,17 @@ class Average(Preprocess):
             avar_vals = []
             dsplit = _split_by_value(data, self.avar)
             for v, indices in dsplit.items():
-                avgd.append(data.X[indices].mean(axis=0))
+                avgd.append(np.nanmean(data.X[indices], axis=0))
                 avar_vals.append(v)
                 if self.std:
-                    avgd.append(data.X[indices].std(axis=0))
+                    avgd.append(np.nanstd(data.X[indices], axis=0))
                     avar_vals.append(v + " (Std Dev)")
             avar_vals = np.vstack(avar_vals)
             avar_meta = [Orange.data.StringVariable.make(name=self.avar.name)]
         else:
-            avgd.append(data.X.mean(axis=0))
+            avgd.append(np.nanmean(data.X, axis=0))
             if self.std:
-                avgd.append(data.X.std(axis=0))
+                avgd.append(np.nanstd(data.X, axis=0))
 
         domain = Orange.data.Domain(data.domain.attributes, metas=avar_meta)
         return Orange.data.Table(domain, np.vstack(avgd), metas=avar_vals)

--- a/orangecontrib/infrared/tests/test_preprocess.py
+++ b/orangecontrib/infrared/tests/test_preprocess.py
@@ -341,3 +341,10 @@ class TestAverage(unittest.TestCase):
         self.assertEqual(p.X.shape[0], len(var.values))
         p = Average(avar=var, std=True)(data)
         self.assertEqual(p.X.shape[0], 2 * len(var.values))
+
+    def test_novar(self):
+        data = self.collagen
+        var = Orange.data.DiscreteVariable("OldVar")
+        p = Average(avar=var, std=False)(data)
+        q = Average(avar=None, std=False)(data)
+        np.testing.assert_equal(p.X, q.X)

--- a/orangecontrib/infrared/widgets/owpreproc.py
+++ b/orangecontrib/infrared/widgets/owpreproc.py
@@ -1,5 +1,6 @@
 import random
 import sys
+from itertools import chain
 
 import Orange.data
 import Orange.widgets.data.owpreprocess as owpreprocess
@@ -21,7 +22,7 @@ from AnyQt.QtWidgets import (
     QWidget, QButtonGroup, QRadioButton, QDoubleSpinBox, QComboBox, QSpinBox,
     QListView, QVBoxLayout, QHBoxLayout, QFormLayout, QSizePolicy, QStyle,
     QStylePainter, QStyleOptionFrame, QApplication, QPushButton, QLabel,
-    QMenu, QApplication, QAction, QDockWidget, QScrollArea
+    QMenu, QApplication, QAction, QDockWidget, QScrollArea, QCheckBox
 )
 from AnyQt.QtGui import (
     QCursor, QIcon, QPainter, QPixmap, QStandardItemModel, QStandardItem,
@@ -31,7 +32,7 @@ from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from orangecontrib.infrared.data import getx
 from orangecontrib.infrared.preprocess import PCADenoising, GaussianSmoothing, Cut, SavitzkyGolayFiltering, \
-    RubberbandBaseline, Normalize, Integrate, Absorbance, Transmittance
+    RubberbandBaseline, Normalize, Integrate, Absorbance, Transmittance, Average
 from orangecontrib.infrared.widgets.owcurves import CurvePlot
 
 
@@ -1119,6 +1120,60 @@ class AbsToTransEditor(BaseEditor):
     def createinstance(params):
         return Transmittance(ref=None)
 
+class AverageEditor(BaseEditor):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.attrs = ["(All)"]
+
+        model = VariableListModel()
+        model.wrap(self.attrs)
+        attrform = QFormLayout()
+        self.attrcb = QComboBox()
+        self.attrcb.setModel(model)
+        attrform.addRow("Average:", self.attrcb)
+
+        self.stdcheck = QCheckBox()
+        attrform.addRow("Standard Deviation:", self.stdcheck)
+
+        self.setLayout(attrform)
+
+        self.attrcb.activated.connect(self.edited)
+        self.stdcheck.stateChanged.connect(self.edited)
+
+        self.user_changed = False
+
+    def setParameters(self, params):
+        if params:
+            self.user_changed = True
+        avar = params.get("avar", self.attrs[0])
+        std = params.get("std", False)
+        if self.attrs[self.attrcb.currentIndex()] != avar:
+            try:
+                self.attrcb.setCurrentIndex(self.attrs.index(avar))
+            except ValueError:
+                self.attrcb.setCurrentIndex(0)
+        if self.stdcheck.isChecked() != std:
+            self.stdcheck.setChecked(std)
+
+    def parameters(self):
+        return {"avar": self.attrs[self.attrcb.currentIndex()],
+                "std": self.stdcheck.isChecked()}
+
+    @staticmethod
+    def createinstance(params):
+        avar = params.get("avar", "(All)")
+        if avar == "(All)":
+            avar = None
+        std = params.get("std", False)
+        return Average(avar, std)
+
+    def set_preview_data(self, data):
+        self.attrs[:] = ["(All)"] + [
+            var for var in chain(data.domain, data.domain.metas)
+                if isinstance(var, str) or var.is_discrete]
+
 PREPROCESSORS = [
     PreprocessAction(
         "Cut (keep)", "orangecontrib.infrared.cut", "Cut",
@@ -1179,6 +1234,12 @@ PREPROCESSORS = [
         Description("Absorbance to Transmittance",
                     icon_path("Discretize.svg")),
         AbsToTransEditor
+    ),
+    PreprocessAction(
+        "Average", "orangecontrib.infrared.average", "Average",
+        Description("Average",
+                    icon_path("Discretize.svg")),
+        AverageEditor
     ),
     ]
 


### PR DESCRIPTION
Preprocessor to calculate the mean of either the entire group of spectra or grouped by discrete variable. Can also output the standard deviation.

This is basically stolen from the curves widget, it wasn't really setup for re-use directly.

@markotoplak the change to nanmean was required to pass the propagate unknowns test, note that if you feed the dataset from that test[1] into OWCurves and choose Average view, it has the same problem.

    [1] 
    data = self.collagen.copy()
    # one unknown in line
    for i in range(200):
        data.X[i, i] = np.nan