### PR TITLE
Disable peak direction selection list box for linear baseline

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -495,6 +495,13 @@ class BaselineEditor(BaseEditor):
         self.peakcb.setCurrentIndex(peak_dir)
         self.subcb.setCurrentIndex(sub)
 
+        if self.baselinecb.currentIndex() == 0:
+            self.peakcb.setEnabled(False)
+        elif self.baselinecb.currentIndex() == 1:
+            self.peakcb.setEnabled(True)
+        else:
+            self.peakcb.setEnabled(True)
+
     def parameters(self):
         return {"baseline_type": self.baselinecb.currentIndex(),
                 "peak_dir": self.peakcb.currentIndex(),

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -495,12 +495,8 @@ class BaselineEditor(BaseEditor):
         self.peakcb.setCurrentIndex(peak_dir)
         self.subcb.setCurrentIndex(sub)
 
-        if self.baselinecb.currentIndex() == 0:
-            self.peakcb.setEnabled(False)
-        elif self.baselinecb.currentIndex() == 1:
-            self.peakcb.setEnabled(True)
-        else:
-            self.peakcb.setEnabled(True)
+        # peak direction is only relevant for rubberband
+        self.peakcb.setEnabled(baseline_type == 1)
 
     def parameters(self):
         return {"baseline_type": self.baselinecb.currentIndex(),


### PR DESCRIPTION
Peak direction makes no difference and also not implemented, so we should disable the listbox.