### PR TITLE
FFT overhaul

### DIFF
--- a/orangecontrib/spectroscopy/irfft.py
+++ b/orangecontrib/spectroscopy/irfft.py
@@ -102,6 +102,12 @@ def apodize(Ix, zpd, apod_func):
 
     return Ix_apod
 
+def _zero_fill_size(N, zff):
+    # Calculate desired array size
+    Nzff = N * zff
+    # Calculate final size to next power of two for DFT efficiency
+    return int(np.exp2(np.ceil(np.log2(Nzff))))
+
 def _zero_fill_pad(Ix, zerofill):
     return np.hstack((Ix, np.zeros(zerofill, dtype=Ix.dtype)))
 
@@ -118,10 +124,8 @@ def zero_fill(Ix, zff):
         Ix_zff: 1D array of Ix + zero fill
     """
     N = Ix.shape[0]
-    # Calculate next power of two for DFT efficiency
-    N_2 = int(np.exp2(np.ceil(np.log2(N))))
-    # fill to N**2 * zff
-    zero_fill = ((N_2 - N) + (N_2 * (zff)))
+    # Calculate zero-fill to next power of two for DFT efficiency
+    zero_fill = _zero_fill_size(N, zff) - N
     # Pad array
     return _zero_fill_pad(Ix, zero_fill)
 

--- a/orangecontrib/spectroscopy/irfft.py
+++ b/orangecontrib/spectroscopy/irfft.py
@@ -240,7 +240,10 @@ class IRFFT():
             self.spectrum = Ix.real
             self.phase = Ix.imag
         else:
-            self.spectrum = np.cos(self.phase) * Ix.real + np.sin(self.phase) * Ix.imag
+            try:
+                self.spectrum = np.cos(self.phase) * Ix.real + np.sin(self.phase) * Ix.imag
+            except ValueError as e:
+                raise ValueError("Incompatible phase: {}".format(e))
 
         return self.spectrum, self.phase, self.wavenumbers
 

--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from orangecontrib.spectroscopy.irfft import (IRFFT, zero_fill, PhaseCorrection,
                                               find_zpd, PeakSearch,
-                                              )
+                                             )
 
 dx = 1.0 / 15797.337544 / 2.0
 
@@ -46,4 +46,3 @@ class TestIRFFT(unittest.TestCase):
         assert find_zpd(data, PeakSearch.ABSOLUTE) == abs(data).argmax()
         data *= -1
         assert find_zpd(data, PeakSearch.ABSOLUTE) == abs(data).argmax()
-

--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -1,0 +1,21 @@
+import unittest
+
+import Orange
+import numpy as np
+
+from orangecontrib.spectroscopy.irfft import zero_fill
+
+
+class TestIRFFT(unittest.TestCase):
+
+    def test_zero_fill(self):
+        N = 1975
+        a = np.zeros(N)
+        # Test all zff offered in OWFFT()
+        for zff in (2**n for n in range(10)):
+            a_zf = zero_fill(a, zff)
+            N_zf = a_zf.size
+            # Final array must be power of 2
+            assert np.log2(N_zf) == int(np.log2(N_zf))
+            # Final array should be >= N * zff
+            assert N_zf >= N * zff

--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -3,8 +3,9 @@ import unittest
 import Orange
 import numpy as np
 
-from orangecontrib.spectroscopy.irfft import zero_fill
+from orangecontrib.spectroscopy.irfft import IRFFT, zero_fill, PhaseCorrection
 
+dx = 1.0 / 15797.337544 / 2.0
 
 class TestIRFFT(unittest.TestCase):
 
@@ -19,3 +20,19 @@ class TestIRFFT(unittest.TestCase):
             assert np.log2(N_zf) == int(np.log2(N_zf))
             # Final array should be >= N * zff
             assert N_zf >= N * zff
+
+    def test_simple_fft(self):
+        data = Orange.data.Table("IFG_single.dpt")
+        fft = IRFFT(dx=dx)
+        fft(data.X[0])
+
+    def test_stored_phase_zpd(self):
+        data = Orange.data.Table("IFG_single.dpt")
+        fft = IRFFT(dx=dx)
+        fft(data.X[0])
+        stored_phase = fft.phase
+        zpd = fft.zpd
+        fft_stored = IRFFT(dx=dx, phase_corr=PhaseCorrection.STORED)
+        fft_stored(data.X[0], phase=stored_phase, zpd=zpd)
+        np.testing.assert_array_equal(fft.spectrum, fft_stored.spectrum)
+        np.testing.assert_array_equal(fft.phase, fft_stored.phase)

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -68,7 +68,7 @@ class OWFFT(OWWidget):
                   "Forward-Backward",
                   "Forward",
                   "Backward",
-                  )
+                 )
 
     apod_opts = ("Boxcar (None)",               # <irfft.ApodFunc.BOXCAR: 0>
                  "Blackman-Harris (3-term)",    # <irfft.ApodFunc.BLACKMAN_HARRIS_3: 1>
@@ -79,7 +79,7 @@ class OWFFT(OWWidget):
                   "Mertz Signed",       # <irfft.PhaseCorrection.MERTZSIGNED: 1>
                   "Stored Phase",       # <irfft.PhaseCorrection.STORED: 2>
                   "None (real/imag)",   # <irfft.PhaseCorrection.NONE: 3>
-                  )
+                 )
 
     # GUI definition:
     #   a simple 'single column' GUI layout
@@ -117,16 +117,16 @@ class OWFFT(OWWidget):
         grid = QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
         self.dx_edit = gui.lineEdit(
-                    self.dataBox, self, "dx",
-                    callback=self.setting_changed,
-                    valueType=float,
-                    controlWidth=100, disabled=self.dx_HeNe
-                    )
+            self.dataBox, self, "dx",
+            callback=self.setting_changed,
+            valueType=float,
+            controlWidth=100, disabled=self.dx_HeNe
+            )
         cb = gui.checkBox(
-                    self.dataBox, self, "dx_HeNe",
-                    label="HeNe laser",
-                    callback=self.dx_changed,
-                    )
+            self.dataBox, self, "dx_HeNe",
+            label="HeNe laser",
+            callback=self.dx_changed,
+            )
         lb = gui.widgetLabel(self.dataBox, "cm")
         grid.addWidget(cb, 0, 0)
         grid.addWidget(self.dx_edit, 0, 1)
@@ -141,10 +141,10 @@ class OWFFT(OWWidget):
             disabled=self.auto_sweeps
             )
         cb2 = gui.checkBox(
-                    self.dataBox, self, "auto_sweeps",
-                    label="Auto",
-                    callback=self.sweeps_changed,
-                    )
+            self.dataBox, self, "auto_sweeps",
+            label="Auto",
+            callback=self.sweeps_changed,
+            )
         grid.addWidget(wl, 1, 0, 1, 3)
         grid.addWidget(cb2, 2, 0)
         grid.addWidget(box, 2, 1)
@@ -186,16 +186,16 @@ class OWFFT(OWWidget):
         grid.setContentsMargins(0, 0, 0, 0)
 
         le1 = gui.lineEdit(
-                    self.optionsBox, self, "phase_resolution",
-                    callback=self.setting_changed,
-                    valueType=int, controlWidth=30
-                    )
+            self.optionsBox, self, "phase_resolution",
+            callback=self.setting_changed,
+            valueType=int, controlWidth=30
+            )
         cb1 = gui.checkBox(
-                    self.optionsBox, self, "phase_res_limit",
-                    label="Limit phase resolution to ",
-                    callback=self.setting_changed,
-                    disables=le1
-                    )
+            self.optionsBox, self, "phase_res_limit",
+            label="Limit phase resolution to ",
+            callback=self.setting_changed,
+            disables=le1
+            )
         lb1 = gui.widgetLabel(self.optionsBox, "cm<sup>-1<sup>")
 
         grid.addWidget(cb1, 0, 0)
@@ -210,21 +210,21 @@ class OWFFT(OWWidget):
         grid = QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
         le2 = gui.lineEdit(
-                    self.outputBox, self, "out_limit1",
-                    callback=self.out_limit_changed,
-                    valueType=float, controlWidth=50
-                    )
+            self.outputBox, self, "out_limit1",
+            callback=self.out_limit_changed,
+            valueType=float, controlWidth=50
+            )
         le3 = gui.lineEdit(
-                    self.outputBox, self, "out_limit2",
-                    callback=self.out_limit_changed,
-                    valueType=float, controlWidth=50
-                    )
+            self.outputBox, self, "out_limit2",
+            callback=self.out_limit_changed,
+            valueType=float, controlWidth=50
+            )
         cb2 = gui.checkBox(
-                    self.outputBox, self, "limit_output",
-                    label="Limit spectral region:",
-                    callback=self.setting_changed,
-                    disables=[le2,le3]
-                    )
+            self.outputBox, self, "limit_output",
+            label="Limit spectral region:",
+            callback=self.setting_changed,
+            disables=[le2, le3]
+            )
         lb2 = gui.widgetLabel(self.outputBox, "-")
         lb3 = gui.widgetLabel(self.outputBox, "cm<sup>-1</sup>")
         grid.addWidget(cb2, 0, 0, 1, 6)
@@ -279,7 +279,7 @@ class OWFFT(OWWidget):
         self.commit()
 
     def out_limit_changed(self):
-        values = [ float(self.out_limit1), float(self.out_limit2) ]
+        values = [float(self.out_limit1), float(self.out_limit2)]
         minX, maxX = min(values), max(values)
         self.out_limit1 = minX
         self.out_limit2 = maxX
@@ -328,7 +328,7 @@ class OWFFT(OWWidget):
                                  phase_res=self.phase_resolution if self.phase_res_limit else None,
                                  phase_corr=self.phase_corr,
                                  peak_search=self.peak_search,
-                                 )
+                                )
 
         stored_phase = self.stored_phase
         stored_zpd_fwd, stored_zpd_back = None, None
@@ -357,7 +357,8 @@ class OWFFT(OWWidget):
 
             if self.sweeps in [0, 2, 3]:
                 try:
-                    spectrum_out, phase_out, wavenumbers = fft_single(row, zpd=stored_zpd_fwd, phase=stored_phase)
+                    spectrum_out, phase_out, wavenumbers = fft_single(
+                        row, zpd=stored_zpd_fwd, phase=stored_phase)
                     zpd_fwd.append(fft_single.zpd)
                 except ValueError as e:
                     self.Error.fft_error(e)
@@ -377,16 +378,18 @@ class OWFFT(OWWidget):
 
                 # Calculate spectrum for both forward and backward sweeps
                 try:
-                    spectrum_fwd, phase_fwd, wavenumbers = fft_single(fwd, zpd=stored_zpd_fwd, phase=stored_phase)
+                    spectrum_fwd, phase_fwd, wavenumbers = fft_single(
+                        fwd, zpd=stored_zpd_fwd, phase=stored_phase)
                     zpd_fwd.append(fft_single.zpd)
-                    spectrum_back, phase_back, wavenumbers = fft_single(back, zpd=stored_zpd_back, phase=stored_phase)
+                    spectrum_back, phase_back, wavenumbers = fft_single(
+                        back, zpd=stored_zpd_back, phase=stored_phase)
                     zpd_back.append(fft_single.zpd)
                 except ValueError as e:
                     self.Error.fft_error(e)
                     return
 
                 # Calculate the average of the forward and backward sweeps
-                spectrum_out = np.mean( np.array([spectrum_fwd, spectrum_back]), axis=0)
+                spectrum_out = np.mean(np.array([spectrum_fwd, spectrum_back]), axis=0)
                 phase_out = np.mean(np.array([phase_fwd, phase_back]), axis=0)
             else:
                 return
@@ -399,12 +402,12 @@ class OWFFT(OWWidget):
 
         self.phases_table = build_spec_table(wavenumbers, phases)
         self.phases_table = add_meta_to_table(self.phases_table,
-                                         ContinuousVariable.make("zpd_fwd"),
-                                         zpd_fwd)
+                                              ContinuousVariable.make("zpd_fwd"),
+                                              zpd_fwd)
         if zpd_back:
             self.phases_table = add_meta_to_table(self.phases_table,
-                                         ContinuousVariable.make("zpd_back"),
-                                         zpd_back)
+                                                  ContinuousVariable.make("zpd_back"),
+                                                  zpd_back)
 
         if self.limit_output is True:
             limits = np.searchsorted(wavenumbers,
@@ -412,9 +415,9 @@ class OWFFT(OWWidget):
             wavenumbers = wavenumbers[limits[0]:limits[1]]
             # Handle 1D array if necessary
             if spectra.ndim == 1:
-                spectra = spectra[None,limits[0]:limits[1]]
+                spectra = spectra[None, limits[0]:limits[1]]
             else:
-                spectra = spectra[:,limits[0]:limits[1]]
+                spectra = spectra[:, limits[0]:limits[1]]
 
         self.spectra_table = build_spec_table(wavenumbers, spectra)
 
@@ -482,5 +485,5 @@ def main(argv=sys.argv):
     ow.handleNewSignals()
     return 0
 
-if __name__=="__main__":
+if __name__ == "__main__":
     sys.exit(main())

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -47,10 +47,10 @@ class OWFFT(OWWidget):
     out_limit2 = settings.Setting(4000)
     autocommit = settings.Setting(False)
 
-    apod_opts = ("Boxcar (None)",
-                 "Blackman-Harris (3-term)",
-                 "Blackman-Harris (4-term)",
-                 "Blackman Nuttall (EP)")
+    apod_opts = ("Boxcar (None)",               # <irfft.ApodFunc.BOXCAR: 0>
+                 "Blackman-Harris (3-term)",    # <irfft.ApodFunc.BLACKMAN_HARRIS_3: 1>
+                 "Blackman-Harris (4-term)",    # <irfft.ApodFunc.BLACKMAN_HARRIS_4: 2>
+                 "Blackman Nuttall (EP)")       # <irfft.ApodFunc.BLACKMAN_NUTTALL: 3>
 
     phase_opts = ("Mertz",              # <irfft.PhaseCorrection.MERTZ: 0>
                   "Mertz Signed",       # <irfft.PhaseCorrection.MERTZSIGNED: 1>

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -52,7 +52,11 @@ class OWFFT(OWWidget):
                  "Blackman-Harris (4-term)",
                  "Blackman Nuttall (EP)")
 
-    phase_opts = ("Mertz",)
+    phase_opts = ("Mertz",              # <irfft.PhaseCorrection.MERTZ: 0>
+                  "Mertz Signed",       # <irfft.PhaseCorrection.MERTZSIGNED: 1>
+                  "Stored Phase",       # <irfft.PhaseCorrection.STORED: 2>
+                  "None (real/imag)",   # <irfft.PhaseCorrection.NONE: 3>
+                  )
 
     # GUI definition:
     #   a simple 'single column' GUI layout
@@ -257,6 +261,7 @@ class OWFFT(OWWidget):
                                  apod_func=self.apod_func,
                                  zff=self.zff,
                                  phase_res=self.phase_resolution if self.phase_res_limit else None,
+                                 phase_corr=self.phase_corr,
                                  )
 
         for row in self.data.X:

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -345,6 +345,7 @@ class OWFFT(OWWidget):
                 stored_zpd_back = int(stored_phase["zpd_back"].value)
             except ValueError:
                 stored_zpd_back = None
+            stored_phase = stored_phase.x # lowercase x for RowInstance
 
         for row in self.data.X:
             if self.sweeps in [2, 3]:


### PR DESCRIPTION
Status: Review please :)

I am working on an overhaul of the FFT widget / `irfft` module. The main goal of this work is to support using stored phase / stored zpd values. A side benefit is cleaning up the `irfft` module.

- [x] Refactor `irfft` module into a callable class `IRFFT`
- [x] Fix bug in zero fill calculation (with test)
- [x] Implement Mertz Signed / Stored phase / None phase corrections
- [x] For double IFGs, allow selection of just forward or backward scan
- [x] Add an input for stored phase
- [x] Store zpd in phase output, use if on phase input
- [x] Add more zpd peak-search algorithms
- ~Provide user feedback on zpd (i.e. if stored value is being used)~ #250
- ~Allow manual specification of zpd~ #251
- ~Sanity check before averaging forward/backward spectra after FFT~ #252
- ~Handle (and test) multi-spectra stored phase / zpd condition~ #253
- ~Test all the things~ #252

