### PR TITLE
Pylint fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__
 
 # Coverage reports
 htmlcov/*
+
+# check_pylint_diff
+.pylint_cache

--- a/.travis/check_pylint_diff
+++ b/.travis/check_pylint_diff
@@ -14,6 +14,7 @@ CACHE_DIR="$GIT_REPO/.pylint_cache"
 UNCOMMITED_PATCH="$TMP_REPO/uncommited.patch"
 SCRIPT=$(basename "$0")
 PYLINT="$(command -v pylint 2>/dev/null || true)"
+PYLINT3="$(command -v pylint3 2>/dev/null || true)"
 RADON="$(command -v radon 2>/dev/null || true)"
 PYLINT_ARGS="--output-format=parseable"
 RADON_ARGS='cc --min C --no-assert --show-closures --show-complexity --average'
@@ -48,6 +49,10 @@ Given the commit tree:
 }
 
 case $ARG1 in -h|--help) print_help ; esac
+
+if [ ! "$PYLINT" ]; then
+    PYLINT=$PYLINT3
+fi
 
 if [ ! "$PYLINT$RADON" ]; then
     echo 'Error: pylint and/or radon required'


### PR DESCRIPTION
gitignore: ignore .pyline_cache generated by check_pylint_diff 

check_pylint_diff: handle system pylint installed as "pylint3"

affects at least Debian