### PR TITLE
A utility that can relate two settings: gui.connect_settings

### DIFF
--- a/orangecontrib/spectroscopy/tests/example_connect_settings.py
+++ b/orangecontrib/spectroscopy/tests/example_connect_settings.py
@@ -1,0 +1,88 @@
+"""
+Example for orangecontrib.spectroscopy.widgets.gui.connect_settings
+
+In this example widget, two settings are connected according to a function
+that depends on another setting.
+"""
+
+import sys
+from decimal import Decimal
+
+import Orange
+from Orange.widgets.widget import OWWidget
+
+from orangecontrib.spectroscopy.widgets.gui import connect_settings, lineEditFloatRange, \
+    ValueTransform, connect_line, MovableVline
+from orangecontrib.spectroscopy.widgets.owspectra import CurvePlot
+
+
+class PlusAdd(ValueTransform):
+
+    def __init__(self, contains_add):
+        self.contains_add = contains_add
+
+    def transform(self, v):
+        return v + self.contains_add.add
+
+    def inverse(self, v):
+        return v - self.contains_add.add
+
+
+class TestConnected(OWWidget):
+
+    name = "Test"
+
+    want_main_area = True
+
+    def __init__(self):
+        super().__init__()
+
+        self.v = Decimal(1111)
+        le = lineEditFloatRange(self, self, "v")
+        self.controlArea.layout().addWidget(le)
+
+        self.vplus = Decimal(0)
+        le100 = lineEditFloatRange(self, self, "vplus")
+        self.controlArea.layout().addWidget(le100)
+
+        self.add = Decimal(100)
+
+        def refresh():
+            self.v = self.v  # just set one main so that dependant values are refreshed
+            # self.vplus = self.vplus  # this would have the opposite effect
+
+        leadd = lineEditFloatRange(self, self, "add", callback=refresh)
+
+        self.controlArea.layout().addWidget(leadd)
+
+        connect_settings(self, "v", "vplus", transform=PlusAdd(self))
+
+        #
+        # add MovableVLines ajd test this with spectra
+        #
+
+        self.curveplot = CurvePlot(self)
+        self.mainArea.layout().addWidget(self.curveplot)
+        self.curveplot.set_data(Orange.data.Table("collagen"))
+
+        self.line1 = MovableVline(label="Value")
+        connect_line(self.line1, self, "v")
+        self.line2 = MovableVline(label="Value + something")
+        connect_line(self.line2, self, "vplus")
+
+        self.curveplot.add_marking(self.line1)
+        self.curveplot.add_marking(self.line2)
+
+
+def main():
+    from AnyQt.QtWidgets import QApplication
+    app = QApplication(sys.argv)
+    ow = TestConnected()
+    ow.show()
+    ow.raise_()
+    app.exec_()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orangecontrib/spectroscopy/widgets/gui.py
+++ b/orangecontrib/spectroscopy/widgets/gui.py
@@ -1,5 +1,6 @@
 import math
 from decimal import Decimal
+from abc import ABCMeta, abstractmethod
 
 from AnyQt.QtCore import QLocale, Qt
 from AnyQt.QtGui import QDoubleValidator, QIntValidator, QValidator
@@ -339,6 +340,44 @@ class LineCallFront(gui.ControlledCallFront):
 
     def action(self, value):
         self.control.setValue(floatornone(value))
+
+
+class ValueTransform(metaclass=ABCMeta):
+
+    @abstractmethod
+    def transform(self, v):
+        """Transform the argument"""
+
+    @abstractmethod
+    def inverse(self, v):
+        """Inverse transform"""
+
+
+class ValueCallbackTransform(gui.ControlledCallback):
+
+    def __call__(self, value):
+        self.acyclic_setattr(value)
+
+
+def connect_settings(master, value, value2, transform=None):
+    """
+    Connect two Orange settings, so that both will be mutually updated. One value
+    can be a function of the other. This sets value of the value2 as a function of value.
+
+    :param master: a settings controller
+    :param value: name of the first value
+    :param value2: name of the second value
+    :param transform: a transform from value to value2 (an instance of ValueTransform)
+    """
+    update_value = ValueCallbackTransform(master, value,
+                                          f=transform.inverse if transform is not None else None)
+    update_value2 = ValueCallbackTransform(master, value2,
+                                           f=transform.transform if transform is not None else None)
+    update_value.opposite = update_value2
+    update_value2.opposite = update_value
+    update_value2(getdeepattr(master, value))
+    master.connect_control(value, update_value2)
+    master.connect_control(value2, update_value)
 
 
 def connect_line(line, master, value):

--- a/orangecontrib/spectroscopy/widgets/gui.py
+++ b/orangecontrib/spectroscopy/widgets/gui.py
@@ -299,6 +299,7 @@ class MovableVline(pg.UIGraphicsItem):
             self.report = rep
             self.line.show()
             self.label.show()
+            self._move_label()
         else:
             self.line.hide()
             self.label.hide()


### PR DESCRIPTION
Someone programming a preprocessor requested a way to have movable lines that are relative to some value. Here is a short utility to do it with an example.