### PR TITLE
Fix Travis to actually try the oldest supported Orange

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ matrix:
       env: PYQT5=true ORANGE="release"  RUN_PYLINT=true
 
     - python: '3.4'
-      env: PYQT4=true ORANGE="3.7.0"
+      env: PYQT4=true ORANGE="3.11.0"
 
     - python: '3.5'
-      env: PYQT5=true ORANGE="3.7.0"
+      env: PYQT5=true ORANGE="3.11.0"
 
     - python: '3.5'
       env: PYQT5=true ORANGE="release"


### PR DESCRIPTION
Before, because the version was set to 3.7.0, and the oldest supported version was 3.11.0, Travis would uninstall 3.7.0 and install the current release for the tests, so the oldest version was never tested.