### PR TITLE
[ENH] Unify spectral transforms preprocessor editor

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -1,0 +1,110 @@
+from enum import Enum
+
+import numpy as np
+import Orange.data
+from Orange.preprocess.preprocess import Preprocess
+
+from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDomain
+
+class SpecTypes(Enum):
+    """
+    Spectral types possibly supported by spectral transforms
+    """
+    ABSORBANCE = "Absorbance"
+    TRANSMITTANCE = "Transmittance"
+    SINGLECHANNEL = "Single Channel"
+
+class AbsorbanceFeature(SelectColumn):
+    pass
+
+
+class _AbsorbanceCommon(CommonDomain):
+
+    def __init__(self, ref, domain):
+        super().__init__(domain)
+        self.ref = ref
+
+    def transformed(self, data):
+        if self.ref:
+            # Calculate from single-channel data
+            absd = self.ref.X / data.X
+            np.log10(absd, absd)
+        else:
+            # Calculate from transmittance data
+            absd = np.log10(data.X)
+            absd *= -1
+        return absd
+
+
+class Absorbance(Preprocess):
+    """
+    Convert data to absorbance.
+
+    Set ref to calculate from single-channel spectra, otherwise convert from transmittance.
+
+    Parameters
+    ----------
+    ref : reference single-channel (Orange.data.Table)
+    """
+
+    from_types = (SpecTypes.TRANSMITTANCE, SpecTypes.SINGLECHANNEL)
+
+    def __init__(self, ref=None):
+        self.ref = ref
+
+    def __call__(self, data):
+        common = _AbsorbanceCommon(self.ref, data.domain)
+        newattrs = [Orange.data.ContinuousVariable(
+            name=var.name, compute_value=AbsorbanceFeature(i, common))
+                    for i, var in enumerate(data.domain.attributes)]
+        domain = Orange.data.Domain(
+            newattrs, data.domain.class_vars, data.domain.metas)
+        return data.from_table(domain, data)
+
+
+class TransmittanceFeature(SelectColumn):
+    pass
+
+
+class _TransmittanceCommon(CommonDomain):
+
+    def __init__(self, ref, domain):
+        super().__init__(domain)
+        self.ref = ref
+
+    def transformed(self, data):
+        if self.ref:
+            # Calculate from single-channel data
+            transd = data.X / self.ref.X
+        else:
+            # Calculate from absorbance data
+            transd = data.X.copy()
+            transd *= -1
+            np.power(10, transd, transd)
+        return transd
+
+
+class Transmittance(Preprocess):
+    """
+    Convert data to transmittance.
+
+    Set ref to calculate from single-channel spectra, otherwise convert from absorbance.
+
+    Parameters
+    ----------
+    ref : reference single-channel (Orange.data.Table)
+    """
+
+    from_types = (SpecTypes.ABSORBANCE, SpecTypes.SINGLECHANNEL)
+
+    def __init__(self, ref=None):
+        self.ref = ref
+
+    def __call__(self, data):
+        common = _TransmittanceCommon(self.ref, data.domain)
+        newattrs = [Orange.data.ContinuousVariable(
+            name=var.name, compute_value=TransmittanceFeature(i, common))
+                    for i, var in enumerate(data.domain.attributes)]
+        domain = Orange.data.Domain(
+            newattrs, data.domain.class_vars, data.domain.metas)
+        return data.from_table(domain, data)

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -65,7 +65,11 @@ class Absorbance(Preprocess):
     from_types = (SpecTypes.TRANSMITTANCE, SpecTypes.SINGLECHANNEL)
 
     def __init__(self, ref=None):
-        self.ref = ref
+        if ref:
+            # Only single reference spectra are supported
+            self.ref = ref[0:1]
+        else:
+            self.ref = ref
 
     def __call__(self, data):
         common = _AbsorbanceCommon(self.ref, data.domain)
@@ -109,7 +113,11 @@ class Transmittance(Preprocess):
     from_types = (SpecTypes.ABSORBANCE, SpecTypes.SINGLECHANNEL)
 
     def __init__(self, ref=None):
-        self.ref = ref
+        if ref:
+            # Only single reference spectra are supported
+            self.ref = ref[0:1]
+        else:
+            self.ref = ref
 
     def __call__(self, data):
         common = _TransmittanceCommon(self.ref, data.domain)

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -99,16 +99,21 @@ def nan_extend_edges_and_interpolate(xs, X):
     if np.any(np.isnan(X)):
         nans = np.isnan(X)
         X = X.copy()
+        xs, xsind, mon, X = transform_to_sorted_wavenumbers(xs, X)
         fill_edges(X)
-        X = interp1d_with_unknowns_numpy(xs, X, xs)
+        X = interp1d_with_unknowns_numpy(xs[xsind], X, xs[xsind])
+        X = transform_back_to_features(xsind, mon, X)
     return X, nans
 
 
 def transform_to_sorted_features(data):
     xs = getx(data)
+    return transform_to_sorted_wavenumbers(xs, data.X)
+
+
+def transform_to_sorted_wavenumbers(xs, X):
     xsind = np.argsort(xs)
     mon = is_increasing(xsind)
-    X = data.X
     X = X if mon else X[:, xsind]
     return xs, xsind, mon, X
 

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -39,6 +39,16 @@ class TestOWPreprocess(WidgetTest):
             self.widget.add_preprocessor(i)
             self.widget.show_preview()  # direct call
 
+    def test_allpreproc_indv_ref(self):
+        data = Orange.data.Table("peach_juice.dpt")
+        for i,p in enumerate(PREPROCESSORS):
+            self.widget = self.create_widget(OWPreprocess)
+            self.send_signal("Data", data)
+            self.send_signal("Reference", data)
+            self.widget.add_preprocessor(i)
+            # direct calls the preview so that exceptions do not get lost in Qt
+            self.widget.show_preview()
+
     def test_migrate_rubberbard(self):
         settings = {"storedsettings": {"preprocessors":
             [("orangecontrib.infrared.rubberband", {})]}}

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -1,7 +1,9 @@
 import Orange
 from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.spectroscopy.widgets.owpreprocess import OWPreprocess, PREPROCESSORS
+from orangecontrib.spectroscopy.tests.util import smaller_data
 
+SMALL_COLLAGEN = smaller_data(Orange.data.Table("collagen"), 70, 4)
 
 class TestOWPreprocess(WidgetTest):
 
@@ -41,6 +43,18 @@ class TestOWPreprocess(WidgetTest):
 
     def test_allpreproc_indv_ref(self):
         data = Orange.data.Table("peach_juice.dpt")
+        for i,p in enumerate(PREPROCESSORS):
+            self.widget = self.create_widget(OWPreprocess)
+            self.send_signal("Data", data)
+            self.send_signal("Reference", data)
+            self.widget.add_preprocessor(i)
+            # direct calls the preview so that exceptions do not get lost in Qt
+            self.widget.show_preview()
+
+    def test_allpreproc_indv_ref_multi(self):
+        """Test that preprocessors can handle references with multiple instances"""
+        # len(data) must be > maximum preview size (10) to ensure test failure
+        data = SMALL_COLLAGEN
         for i,p in enumerate(PREPROCESSORS):
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -78,3 +78,16 @@ class TestOWPreprocess(WidgetTest):
         OWPreprocess.migrate_settings(settings, 3)
         self.assertEqual(obtain_setting(settings),
                          {'deriv': 2, 'polyorder': 2, 'window': 3})
+
+    def test_migrate_spectral_transforms(self):
+        settings = {"storedsettings": {
+            "preprocessors": [("orangecontrib.infrared.transmittance", {}),
+                              ("orangecontrib.infrared.absorbance", {})]}}
+        OWPreprocess.migrate_settings(settings, 3)
+        self.assertEqual(
+            settings["storedsettings"]["preprocessors"],
+            [("orangecontrib.spectroscopy.transforms",
+              {'from_type': 0, 'to_type': 1}),
+             ("orangecontrib.spectroscopy.transforms",
+              {'from_type': 1, 'to_type': 0})])
+

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -81,6 +81,8 @@ def add_different_reference(class_, reference_arg_name, reference, *args, **kwar
 
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_different_reference(EMSC, "reference", SMALL_COLLAGEN[0:1]))
 
+for p in [Absorbance, Transmittance]:
+    PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_different_reference(p, "ref", SMALL_COLLAGEN[0:1]))
 
 # Preprocessors that use groups of input samples to infer
 # internal parameters.

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -42,7 +42,7 @@ PREPROCESSORS_INDEPENDENT_SAMPLES = [
 def make_edges_nan(data):
     s = data.copy()
     s[:, 0:3] = np.nan
-    s[:, s.X.shape[1]-1] = np.nan
+    s[:, s.X.shape[1]-3:] = np.nan
     return s
 
 
@@ -73,6 +73,7 @@ def add_different_reference(class_, reference_arg_name, reference, *args, **kwar
     modified = [reference,
                 shuffle_attr(reference),
                 make_edges_nan(reference),
+                shuffle_attr(make_edges_nan(reference)),
                 make_middle_nan(reference)]
     for d in modified:
         kwargs[reference_arg_name] = d

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -82,7 +82,10 @@ def add_different_reference(class_, reference_arg_name, reference, *args, **kwar
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_different_reference(EMSC, "reference", SMALL_COLLAGEN[0:1]))
 
 for p in [Absorbance, Transmittance]:
+    # single reference
     PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_different_reference(p, "ref", SMALL_COLLAGEN[0:1]))
+    # multi reference (many:many)
+    PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_different_reference(p, "ref", SMALL_COLLAGEN))
 
 # Preprocessors that use groups of input samples to infer
 # internal parameters.

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1020,6 +1020,50 @@ class AbsToTransEditor(BaseEditor):
         return Transmittance(ref=None)
 
 
+class SpectralTransformEditor(BaseEditorOrange):
+
+    TRANSFORMS = [Absorbance,
+                  Transmittance]
+
+    transform_names = [a.__name__ for a in TRANSFORMS]
+
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.setLayout(QVBoxLayout())
+
+        form = QFormLayout()
+
+        self.fromcb = QComboBox()
+        self.fromcb.addItems(self.transform_names)
+
+        self.tocb = QComboBox()
+        self.tocb.addItems(self.transform_names)
+
+        form.addRow("Original", self.fromcb)
+        form.addRow("Transformed", self.tocb)
+        self.layout().addLayout(form)
+
+        self.fromcb.currentIndexChanged.connect(self.changed)
+        self.fromcb.activated.connect(self.edited)
+        self.tocb.currentIndexChanged.connect(self.changed)
+        self.tocb.activated.connect(self.edited)
+
+    def setParameters(self, params):
+        from_type = params.get("from_type", 0)
+        to_type = params.get("to_type", 1)
+        self.fromcb.setCurrentIndex(from_type)
+        self.tocb.setCurrentIndex(to_type)
+
+    def parameters(self):
+        return {"from_type": self.fromcb.currentIndex(),
+                "to_type": self.tocb.currentIndex()}
+
+    @staticmethod
+    def createinstance(params):
+        to_type = params.get("to_type", 1)
+        return SpectralTransformEditor.TRANSFORMS[to_type]()
+
+
 def layout_widgets(layout):
     if not isinstance(layout, QLayout):
         layout = layout.layout()
@@ -1279,6 +1323,14 @@ PREPROCESSORS = [
         Description("Absorbance to Transmittance",
                     icon_path("Discretize.svg")),
         AbsToTransEditor
+    ),
+    PreprocessAction(
+        "Spectral Transformations",
+        "orangecontrib.spectroscopy.transforms",
+        "Spectral Transformations",
+        Description("Spectral Transformations",
+                    icon_path("Discretize.svg")),
+        SpectralTransformEditor
     ),
     PreprocessAction(
         "Shift Spectra", "orangecontrib.infrared.curveshift", "Shift Spectra",

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -41,6 +41,7 @@ from orangecontrib.spectroscopy.preprocess import (
     RubberbandBaseline
 )
 from orangecontrib.spectroscopy.preprocess.emsc import ranges_to_weight_table
+from orangecontrib.spectroscopy.preprocess.transform import SpecTypes
 from orangecontrib.spectroscopy.widgets.owspectra import CurvePlot
 from orangecontrib.spectroscopy.widgets.gui import lineEditFloatRange, XPosLineEdit, \
     MovableVline, connect_line, floatornone, round_virtual_pixels
@@ -1000,6 +1001,7 @@ class SpectralTransformEditor(BaseEditorOrange):
                   Transmittance]
 
     transform_names = [a.__name__ for a in TRANSFORMS]
+    from_names = [a.value for a in SpecTypes]
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
@@ -1008,7 +1010,7 @@ class SpectralTransformEditor(BaseEditorOrange):
         form = QFormLayout()
 
         self.fromcb = QComboBox()
-        self.fromcb.addItems(self.transform_names)
+        self.fromcb.addItems(self.from_names)
 
         self.tocb = QComboBox()
         self.tocb.addItems(self.transform_names)
@@ -1034,8 +1036,14 @@ class SpectralTransformEditor(BaseEditorOrange):
 
     @staticmethod
     def createinstance(params):
+        from_type = params.get("from_type", 0)
         to_type = params.get("to_type", 1)
-        return SpectralTransformEditor.TRANSFORMS[to_type]()
+        from_spec_type = SpecTypes(SpectralTransformEditor.from_names[from_type])
+        transform = SpectralTransformEditor.TRANSFORMS[to_type]
+        if from_spec_type not in transform.from_types:
+            return lambda data: data[:0]  # return an empty data table
+        else:
+            return transform()
 
 
 def layout_widgets(layout):

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1040,10 +1040,19 @@ class SpectralTransformEditor(BaseEditorOrange):
         to_type = params.get("to_type", 1)
         from_spec_type = SpecTypes(SpectralTransformEditor.from_names[from_type])
         transform = SpectralTransformEditor.TRANSFORMS[to_type]
+        reference = params.get(REFERENCE_DATA_PARAM, None)
         if from_spec_type not in transform.from_types:
             return lambda data: data[:0]  # return an empty data table
-        else:
-            return transform()
+        try:
+            return transform(ref=reference)
+        except TypeError as e:
+            if "unexpected keyword argument \'ref\'" in str(e):
+                return transform()
+            else:
+                raise
+
+    def set_reference_data(self, ref):
+        self.reference = ref
 
 
 def layout_widgets(layout):

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1024,11 +1024,24 @@ class SpectralTransformEditor(BaseEditorOrange):
         self.tocb.currentIndexChanged.connect(self.changed)
         self.tocb.activated.connect(self.edited)
 
+        self.reference_info = QLabel("", self)
+        self.layout().addWidget(self.reference_info)
+
+        self.reference_curve = pg.PlotCurveItem()
+        self.reference_curve.setPen(pg.mkPen(color=QColor(Qt.red), width=2.))
+        self.reference_curve.setZValue(10)
+
+    def activateOptions(self):
+        self.parent_widget.curveplot.clear_markings()
+        if self.reference_curve not in self.parent_widget.curveplot.markings:
+            self.parent_widget.curveplot.add_marking(self.reference_curve)
+
     def setParameters(self, params):
         from_type = params.get("from_type", 0)
         to_type = params.get("to_type", 1)
         self.fromcb.setCurrentIndex(from_type)
         self.tocb.setCurrentIndex(to_type)
+        self.update_reference_info()
 
     def parameters(self):
         return {"from_type": self.fromcb.currentIndex(),
@@ -1053,6 +1066,21 @@ class SpectralTransformEditor(BaseEditorOrange):
 
     def set_reference_data(self, ref):
         self.reference = ref
+        self.update_reference_info()
+
+    def update_reference_info(self):
+        if not self.reference:
+            self.reference_info.setText("Reference: None")
+            self.reference_curve.hide()
+        else:
+            rinfo = "1st of {0:d} spectra".format(len(self.reference)) \
+                if len(self.reference) > 1 else "1 spectrum"
+            self.reference_info.setText("Reference: " + rinfo)
+            X_ref = self.reference.X[0]
+            x = getx(self.reference)
+            xsind = np.argsort(x)
+            self.reference_curve.setData(x=x[xsind], y=X_ref[xsind])
+            self.reference_curve.show()
 
 
 def layout_widgets(layout):

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -994,32 +994,6 @@ class PCADenoisingEditor(BaseEditor):
         return PCADenoising(components=components)
 
 
-class TransToAbsEditor(BaseEditor):
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def setParameters(self, params):
-        pass
-
-    @staticmethod
-    def createinstance(params):
-        return Absorbance(ref=None)
-
-
-class AbsToTransEditor(BaseEditor):
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def setParameters(self, params):
-        pass
-
-    @staticmethod
-    def createinstance(params):
-        return Transmittance(ref=None)
-
-
 class SpectralTransformEditor(BaseEditorOrange):
 
     TRANSFORMS = [Absorbance,
@@ -1313,18 +1287,6 @@ PREPROCESSORS = [
         PCADenoisingEditor
     ),
     PreprocessAction(
-        "Transmittance to Absorbance", "orangecontrib.infrared.absorbance", "Transmittance to Absorbance",
-        Description("Transmittance to Absorbance",
-                    icon_path("Discretize.svg")),
-        TransToAbsEditor
-    ),
-    PreprocessAction(
-        "Absorbance to Transmittance", "orangecontrib.infrared.transmittance", "Absorbance to Transmittance",
-        Description("Absorbance to Transmittance",
-                    icon_path("Discretize.svg")),
-        AbsToTransEditor
-    ),
-    PreprocessAction(
         "Spectral Transformations",
         "orangecontrib.spectroscopy.transforms",
         "Spectral Transformations",
@@ -1372,6 +1334,16 @@ def migrate_preprocessor(preprocessor, version):
         settings["polyorder"] = polyorder
         settings["deriv"] = deriv
         version = 4
+    if name == "orangecontrib.infrared.absorbance" and version < 5:
+        name = "orangecontrib.spectroscopy.transforms"
+        settings["from_type"] = 1
+        settings["to_type"] = 0
+        version = 5
+    if name == "orangecontrib.infrared.transmittance" and version < 5:
+        name = "orangecontrib.spectroscopy.transforms"
+        settings["from_type"] = 0
+        settings["to_type"] = 1
+        version = 5
     return [((name, settings), version)]
 
 
@@ -1833,7 +1805,7 @@ class OWPreprocess(SpectralPreprocessReference):
     replaces = ["orangecontrib.infrared.widgets.owpreproc.OWPreprocess",
                 "orangecontrib.infrared.widgets.owpreprocess.OWPreprocess"]
 
-    settings_version = 4
+    settings_version = 5
 
     BUTTON_ADD_LABEL = "Add preprocessor..."
     PREPROCESSORS = PREPROCESSORS


### PR DESCRIPTION
Here is my attempt to put #76 #149 #128 to bed. I used Feri's GUI from #128 as a starting point.

Outstanding:
- [x] @markotoplak I think I did the settings handling correctly, but I'd like a second set of eyes
- [x] `CommonDomainRef` (427c79d) ~~doesn't seem to work with Auto Interpolate the way I would expect (see figure below)~~ I was using Auto Interpolate wrong again, it goes on the target dataset
- [x] I'm also not sure how to properly test the reference domain conversion functionality
- [x] I was surprised that the error fixed in c772c61 didn't trigger a test failure (it does in 46633f1)
- [ ] many/many reference crashes in preview window since data[preview] != ref anymore
- [ ] no user feedback when they do something that makes no sense (currently just returns an empty Table) 
- [x] 46633f1 adds reference domain conversion tests, but the domain-equality assertion fails (commented out as I don't understand why)

Non-goals:
 - Handle references which are a subset of the data (like a reference FPA tile)
