### PR TITLE
Documentation that can appear in canvas

### DIFF
--- a/orangecontrib/spectroscopy/widgets/__init__.py
+++ b/orangecontrib/spectroscopy/widgets/__init__.py
@@ -25,5 +25,5 @@ WIDGET_HELP_PATH = (
     # Url should point to a page with a section Widgets. This section should
     # includes links to documentation pages of each widget. Matching is
     # performed by comparing link caption to widget name.
-    ("http://orange-spectroscopy.readthedocs.io/en/latest/", "")  # FIXME upload documentation
+    ("https://orange-spectroscopy.readthedocs.io/en/latest/", "")
 )

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
         'lint': LintCommand,
     }
 
-    include_documentation('doc/build/html', 'help/orange-spectroscopy')
+    include_documentation('doc/build/htmlhelp', 'help/orange-spectroscopy')
 
     setup(
         name="Orange-Spectroscopy",


### PR DESCRIPTION
1. Modified protocol because web view fallback fails due to problems with redirects.
2. Tested htmlhelp that can be installed locally when installing the package.
