### PR TITLE
Travis: temporary CommonMark fix

### DIFF
--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -1,3 +1,9 @@
+# CommonMark changed their interface in 0.8.0. Because older
+# Orange is imcompatible with newer CommonMark, 
+# install the module manually so that it does not get installed.
+# Remove this when the minimum supported Orange is 3.16.
+pip install CommonMark==0.7.5
+
 if [ $ORANGE == "release" ]; then
     echo "Orange: Skipping separate Orange install"
     return 0


### PR DESCRIPTION
Manually install CommonMark 0.7.5, because automatically installed CommonMark does not work for pre-3.16 Orange.