### PR TITLE
Remove opusFC from requirements

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -489,16 +489,25 @@ class OPUSReader(FileFormat):
     EXTENSIONS = (".0*", ".1*", ".2*", ".3*", ".4*", ".5*", ".6*", ".7*", ".8*", ".9*")
     DESCRIPTION = 'OPUS Spectrum'
 
+    _OPUS_WARNING = "Opus files require the opusFC module (https://pypi.org/project/opusFC/)"
+
     @property
     def sheets(self):
-        import opusFC
+        try:
+            import opusFC
+        except ImportError:
+            # raising an exception here would just show an generic error in File widget
+            return ()
         dbs = []
         for db in opusFC.listContents(self.filename):
             dbs.append(db[0] + " " + db[1] + " " + db[2])
         return dbs
 
     def read(self):
-        import opusFC
+        try:
+            import opusFC
+        except ImportError:
+            raise RuntimeError(self._OPUS_WARNING)
 
         if self.sheet:
             db = self.sheet

--- a/orangecontrib/spectroscopy/tests/test_owmultifile.py
+++ b/orangecontrib/spectroscopy/tests/test_owmultifile.py
@@ -4,12 +4,12 @@ from unittest.mock import patch
 import numpy as np
 
 from Orange.widgets.tests.base import WidgetTest
-from orangecontrib.spectroscopy.widgets.owmultifile import OWMultifile, numpy_union_keep_order
 from Orange.data import FileFormat, dataset_dirs, Table
 from Orange.widgets.utils.filedialogs import format_filter
+from Orange.data.io import TabReader
 
 from orangecontrib.spectroscopy.data import SPAReader
-from Orange.data.io import TabReader
+from orangecontrib.spectroscopy.widgets.owmultifile import OWMultifile, numpy_union_keep_order
 
 try:
     import opusFC

--- a/orangecontrib/spectroscopy/tests/test_owmultifile.py
+++ b/orangecontrib/spectroscopy/tests/test_owmultifile.py
@@ -11,6 +11,11 @@ from Orange.widgets.utils.filedialogs import format_filter
 from orangecontrib.spectroscopy.data import SPAReader
 from Orange.data.io import TabReader
 
+try:
+    import opusFC
+except ImportError:
+    opusFC = None
+
 
 class TestOWFilesAuxiliary(unittest.TestCase):
 
@@ -97,6 +102,7 @@ class TestOWMultifile(WidgetTest):
         out = self.get_output("Data")
         self.assertIsNone(out)
 
+    @unittest.skipIf(opusFC is None, "opusFC module not installed")
     def test_sheet_file(self):
         self.load_files("peach_juice.0")
         self.widget.sheet_combo.setCurrentIndex(1)

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -11,6 +11,11 @@ from orangecontrib.spectroscopy.data import SPAReader, agilentMosaicIFGReader
 from orangecontrib.spectroscopy.tests.bigdata import spectra20nea
 
 try:
+    import opusFC
+except ImportError:
+    opusFC = None
+
+try:
     import spc
 except ImportError:
     spc = None
@@ -28,6 +33,7 @@ class TestReaders(unittest.TestCase):
 
 class TestDat(unittest.TestCase):
 
+    @unittest.skipIf(opusFC is None, "opusFC module not installed")
     def test_peach_juice(self):
         d1 = Orange.data.Table("peach_juice.dpt")
         d2 = Orange.data.Table("peach_juice.0")

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -174,7 +174,7 @@ class TestGSF(unittest.TestCase):
 
     def test_open_line(self):
         data = Orange.data.Table("Au168mA_nodisplacement.gsf")
-        self.assertEqual(data.X.shape, (20480,1))
+        self.assertEqual(data.X.shape, (20480, 1))
 
     def test_open_2d(self):
         data = Orange.data.Table("whitelight.gsf")
@@ -193,7 +193,7 @@ class TestNea(unittest.TestCase):
 class TestSpa(unittest.TestCase):
 
     def test_open(self):
-        data = Orange.data.Table("sample1.spa")
+        _ = Orange.data.Table("sample1.spa")
 
     def test_read_header(self):
         fn = Orange.data.Table("sample1.spa").__file__

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,6 @@ if __name__ == '__main__':
             'Orange3>=3.11.0',
             'scipy>=0.14.0',
             'spectral>=0.18',
-            'opusFC>=1.1.0',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.10.0',


### PR DESCRIPTION
Remove a binary-only module from the requirements. Opening an Opus file produces an error that instructs the user which library to install.

Fixes gh-190. Merge when Quasar packages are available.