### PR TITLE
Add datasets/ to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Ref https://docs.python.org/2/distutils/sourcedist.html#commands
-recursive-include orangecontrib *.ows icons/*
+recursive-include orangecontrib *.ows icons/* datasets/*
 global-exclude __pycache__
 
 # Include it in the source package


### PR DESCRIPTION
Need to mention datasets manually in MANIFEST.in if I build the package on my Macbook with setuptools 38.4.0. 

I do not know why we need it there though. If I now rebuild old versions (0.3.6) that are fine on PyPi, the resulting package is missing the datasets.