### PR TITLE
owpreprocess: execute preprocessors within the editor

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -7,7 +7,7 @@ import numpy as np
 import Orange.data
 from Orange import preprocess
 from Orange.widgets.data.owpreprocess import (
-    PreprocessAction, Description, icon_path, DescriptionRole, ParametersRole, BaseEditor, blocked
+    PreprocessAction, Description, icon_path, DescriptionRole, ParametersRole, blocked
 )
 from Orange.widgets import gui, settings
 from Orange.widgets.widget import Output
@@ -17,7 +17,9 @@ from orangecontrib.spectroscopy.preprocess import Integrate
 
 from orangecontrib.spectroscopy.widgets.owspectra import SELECTONE
 from orangecontrib.spectroscopy.widgets.owhyper import refresh_integral_markings
-from orangecontrib.spectroscopy.widgets.owpreprocess import SetXDoubleSpinBox, SpectralPreprocess
+from orangecontrib.spectroscopy.widgets.owpreprocess import (
+    SetXDoubleSpinBox, SpectralPreprocess, BaseEditor
+)
 
 from orangecontrib.spectroscopy.widgets.gui import MovableVline
 

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -238,6 +238,18 @@ class SequenceFlow(owpreprocess.SequenceFlow):
         return w.color
 
 
+class BaseEditor(BaseEditor):
+
+    def execute_instance(self, instance, data):
+        """Execute the preprocessor instance with the given data and return
+        the transformed data.
+
+        This function will be called when generating previews. An Editor
+        can here handle exceptions in the preprocessor and pass warnings to the interface.
+        """
+        return instance(data)
+
+
 class BaseEditorOrange(BaseEditor, OWComponent):
     """
     Base widget for editing preprocessor's parameters that works with Orange settings.
@@ -272,6 +284,9 @@ class GaussianSmoothingEditor(BaseEditorOrange):
 
     def setParameters(self, params):
         self.sd = params.get("sd", self.DEFAULT_SD)
+
+    def execute_instance(self, instance, data):
+        return instance(data)
 
     @classmethod
     def createinstance(cls, params):
@@ -1574,7 +1589,7 @@ class SpectralPreprocess(OWWidget):
 
                 item = self.preprocessormodel.item(i)
                 preproc = self._create_preprocessor(item)
-                data = preproc(data)
+                data = widgets[i].execute_instance(preproc, data)
 
                 if preview_pos == i:
                     after_data = data

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1736,11 +1736,9 @@ class SpectralPreprocess(OWWidget):
         create = desc.viewclass.createinstance
         return create(params)
 
-    def buildpreproc(self, limit=None):
+    def buildpreproc(self):
         plist = []
-        if limit == None:
-            limit = self.preprocessormodel.rowCount()
-        for i in range(limit):
+        for i in range(self.preprocessormodel.rowCount()):
             item = self.preprocessormodel.item(i)
             plist.append(self._create_preprocessor(item))
 

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -240,6 +240,10 @@ class SequenceFlow(owpreprocess.SequenceFlow):
 
 class BaseEditor(BaseEditor):
 
+    def set_preview_data(self, data):
+        """Handle the preview data (initialize parameters)"""
+        pass
+
     def execute_instance(self, instance, data):
         """Execute the preprocessor instance with the given data and return
         the transformed data.
@@ -1584,9 +1588,7 @@ class SpectralPreprocess(OWWidget):
                 if preview_pos == i:
                     preview_data = data
 
-                if hasattr(widgets[i], "set_preview_data"):
-                    widgets[i].set_preview_data(data)
-
+                widgets[i].set_preview_data(data)
                 item = self.preprocessormodel.item(i)
                 preproc = self._create_preprocessor(item)
                 data = widgets[i].execute_instance(preproc, data)


### PR DESCRIPTION
For previews, preprocessors are executed within their corresponding Editor class. This allows the preprocessors to handle their own exceptions (show warnings in the interface).

Requested by @oroue for XAS and long time ago by @stuart-cls (#30).

There are no nice ways to report errors when processing final data yet.