### PR TITLE
owpreprocess: highlight pairs of spectra 

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -63,6 +63,15 @@ class TestOWPreprocess(WidgetTest):
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
 
+    def test_transfer_highlight(self):
+        data = SMALL_COLLAGEN
+        self.widget = self.create_widget(OWPreprocess)
+        self.send_signal("Data", data)
+        self.widget.curveplot.highlight(1)
+        self.assertEqual(self.widget.curveplot_after.highlighted, 1)
+        self.widget.curveplot.highlight(None)
+        self.assertIsNone(self.widget.curveplot_after.highlighted)
+
     def test_migrate_rubberbard(self):
         settings = {"storedsettings": {"preprocessors":
             [("orangecontrib.infrared.rubberband", {})]}}

--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from AnyQt.QtCore import QRectF, QPoint, Qt
 from AnyQt.QtTest import QTest
 import numpy as np
@@ -8,7 +10,7 @@ from Orange.data import Table, Domain, ContinuousVariable
 from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME, ANNOTATED_DATA_FEATURE_NAME
 
 from orangecontrib.spectroscopy.widgets.owspectra import OWSpectra, MAX_INSTANCES_DRAWN, \
-    PlotCurvesItem
+    PlotCurvesItem, NoSuchCurve
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.widgets.line_geometry import intersect_curves, \
     distance_line_segment
@@ -385,3 +387,22 @@ class TestOWSpectra(WidgetTest):
         self.widget.curveplot.cycle_color_attr()
         self.assertEqual(self.widget.curveplot.feature_color, "iris")
         self.widget.curveplot.show_average()
+
+    def test_curveplot_highlight(self):
+        data = self.iris[:10]
+        curveplot = self.widget.curveplot
+        self.send_signal("Data", data)
+        self.assertIsNone(curveplot.highlighted)
+
+        m = Mock()
+        curveplot.highlight_changed.connect(m)
+        curveplot.highlight(4)
+        self.assertEqual(curveplot.highlighted, 4)
+        self.assertEqual(m.call_count, 1)
+
+        curveplot.highlight(0)
+        curveplot.highlight(9)
+        with self.assertRaises(NoSuchCurve):
+            curveplot.highlight(-1)
+        with self.assertRaises(NoSuchCurve):
+            curveplot.highlight(10)

--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -1,18 +1,19 @@
+from AnyQt.QtCore import QRectF, QPoint, Qt
+from AnyQt.QtTest import QTest
 import numpy as np
-import Orange
 import pyqtgraph as pg
+
 from Orange.widgets.tests.base import WidgetTest
 from Orange.data import Table, Domain, ContinuousVariable
+from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME, ANNOTATED_DATA_FEATURE_NAME
+
 from orangecontrib.spectroscopy.widgets.owspectra import OWSpectra, MAX_INSTANCES_DRAWN, \
     PlotCurvesItem
-from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME, ANNOTATED_DATA_FEATURE_NAME
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.widgets.line_geometry import intersect_curves, \
     distance_line_segment
 from orangecontrib.spectroscopy.tests.util import hold_modifiers
 from orangecontrib.spectroscopy.preprocess import Interpolate
-from AnyQt.QtCore import QRectF, QPoint, Qt
-from AnyQt.QtTest import QTest
 
 try:
     qWaitForWindow = QTest.qWaitForWindowShown
@@ -121,14 +122,14 @@ class TestOWSpectra(WidgetTest):
             out = self.get_output("Selection")
             self.assertIsNone(out, None)
             out = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
-            sa = out.transform(Orange.data.Domain([out.domain[ANNOTATED_DATA_FEATURE_NAME]]))
+            sa = out.transform(Domain([out.domain[ANNOTATED_DATA_FEATURE_NAME]]))
             np.testing.assert_equal(sa.X, 0)
             self.select_diagonal()
             out = self.get_output("Selection")
             self.assertEqual(len(data), len(out))
             out = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
             self.assertEqual(len(data), len(out))
-            sa = out.transform(Orange.data.Domain([out.domain[ANNOTATED_DATA_FEATURE_NAME]]))
+            sa = out.transform(Domain([out.domain[ANNOTATED_DATA_FEATURE_NAME]]))
             np.testing.assert_equal(sa.X, 1)
         self.widget.hide()
 
@@ -296,7 +297,7 @@ class TestOWSpectra(WidgetTest):
         self.send_signal("Data", self.iris)
         self.assertEqual(self.widget.curveplot.feature_color, None)
         self.widget.curveplot.feature_color = "iris"
-        self.send_signal("Data", Orange.data.Table("housing"))
+        self.send_signal("Data", Table("housing"))
         self.assertEqual(self.widget.curveplot.feature_color, None)
         self.send_signal("Data", self.iris)
         self.assertEqual(self.widget.curveplot.feature_color, "iris")
@@ -345,7 +346,7 @@ class TestOWSpectra(WidgetTest):
         out2 = self.get_output("Selection")
         self.assertEqual(len(out), 1)
         # while resending the same data as a different object should
-        self.send_signal("Data", Orange.data.Table("iris"))
+        self.send_signal("Data", Table("iris"))
         out = self.get_output("Selection")
         self.assertIsNone(out, None)
 
@@ -365,7 +366,7 @@ class TestOWSpectra(WidgetTest):
         oldvars = data.domain.variables + data.domain.metas
         group_at = [a for a in newvars if a not in oldvars][0]
         unselected = group_at.to_val("Unselected")
-        out = out[np.flatnonzero(out.transform(Orange.data.Domain([group_at])).X != unselected)]
+        out = out[np.flatnonzero(out.transform(Domain([group_at])).X != unselected)]
         self.assertEqual(len(out), 4)
         np.testing.assert_equal([o for o in out], [data[i] for i in [1, 2, 3, 4]])
         np.testing.assert_equal([o[group_at].value for o in out], ["G1", "G2", "G3", "G3"])

--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -260,6 +260,7 @@ def test_main(argv=sys.argv):
 
     w = OWIntegrate()
     w.set_data(Orange.data.Table("collagen.csv"))
+    w.handleNewSignals()
     w.show()
     w.raise_()
     r = app.exec_()

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1025,7 +1025,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
                 QToolTip.hideText()
             self.highlight(bd)
 
-    def highlight(self, index):
+    def highlight(self, index, emit=True):
         """
         Highlight shown curve with the given index (of the sampled curves).
         """
@@ -1042,8 +1042,20 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
                 y = self.curves[0][1][self.highlighted]
                 self.highlighted_curve.setData(x=x, y=y)
             self.highlighted_curve.show()
-        if old != self.highlighted:
+        if emit and old != self.highlighted:
             self.highlight_changed.emit()
+
+    def highlighted_index_in_data(self):
+        if self.highlighted is not None and self.viewtype == INDIVIDUAL:
+            return self.sampled_indices[self.highlighted]
+        return None
+
+    def highlight_index_in_data(self, index, emit):
+        if self.viewtype == AVERAGE:  # do not highlight average view
+            index = None
+        if index in self.sampled_indices_inverse:
+            index = self.sampled_indices_inverse[index]
+        self.highlight(index, emit)
 
     def set_curve_pen(self, idc):
         idcdata = self.sampled_indices[idc]

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1108,9 +1108,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         self.new_sampling.emit(len(self.sampled_indices))
         self.curves.append((x, ys))
         for y in ys:
-            c = pg.PlotCurveItem(x=x, y=y, pen=self.pen_normal[None])
-            self.curves_cont.add_curve(c)
-        self.curves_plotted = self.curves
+            self.add_curve(x, y)
 
     def add_curve(self, x, y, pen=None):
         c = pg.PlotCurveItem(x=x, y=y, pen=pen if pen else self.pen_normal[None])

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -29,6 +29,8 @@ from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
 from Orange.widgets.utils.plot import \
     SELECT, PANNING, ZOOMING
 from Orange.widgets.utils import saveplot
+from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME
+from Orange.widgets.visualize.owscatterplotgraph import LegendItem
 
 try:
     # since Orange 3.17
@@ -44,11 +46,6 @@ from orangecontrib.spectroscopy.widgets.gui import lineEditFloatOrNone, pixel_de
     float_to_str_decimals as strdec
 from orangecontrib.spectroscopy.widgets.utils import pack_selection, unpack_selection, \
     selections_to_length, groups_or_annotated_table
-
-from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME
-
-# legend
-from Orange.widgets.visualize.owscatterplotgraph import LegendItem
 
 
 SELECT_SQUARE = 123


### PR DESCRIPTION
In the previews, highlight both the original and the processed sprectrum together.

I was showing effects of preprocessing to students but it was hard to see which spectra belonged together.