### PR TITLE
Remove automatic interpolation with some readers

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -57,8 +57,7 @@ class DatReader(FileFormat):
     def read(self):
         tbl = np.loadtxt(self.filename, ndmin=2)
         domvals = tbl.T[0]  # first column is attribute name
-        from orangecontrib.spectroscopy.preprocess import features_with_interpolation
-        domain = Orange.data.Domain(features_with_interpolation(domvals), None)
+        domain = Orange.data.Domain([ContinuousVariable.make("%f" % f) for f in domvals], None)
         datavals = tbl.T[1:]
         return Orange.data.Table(domain, datavals)
 
@@ -85,8 +84,7 @@ class AsciiMapReader(FileFormat):
             header = [a.strip() for a in header]
             assert header[0] == header[1] == ""
             dom_vals = [float(v) for v in header[2:]]
-            from orangecontrib.spectroscopy.preprocess import features_with_interpolation
-            domain = Orange.data.Domain(features_with_interpolation(dom_vals), None)
+            domain = Orange.data.Domain([ContinuousVariable.make("%f" % f) for f in dom_vals], None)
             tbl = np.loadtxt(f, ndmin=2)
             data = Orange.data.Table(domain, tbl[:, 2:])
             metas = [ContinuousVariable.make('map_x'), ContinuousVariable.make('map_y')]

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -1,6 +1,4 @@
 import unittest
-import tempfile
-import os
 
 import numpy as np
 import Orange
@@ -20,24 +18,11 @@ except ImportError:
 class TestReaders(unittest.TestCase):
 
     def test_autointerpolate(self):
-        d1 = Orange.data.Table("peach_juice.dpt")
         d2 = Orange.data.Table("collagen.csv")
-        d3 = Orange.data.Table(d1.domain, d2)
-        d1x = getx(d1)
         d2x = getx(d2)
-
-        #have the correct number of non-nan elements
-        validx = np.where(d1x >= min(d2x), d1x, np.nan)
-        validx = np.where(d1x <= max(d2x), validx, np.nan)
-        self.assertEqual(np.sum(~np.isnan(validx)),
-                         np.sum(~np.isnan(d3.X[0])))
-
-        #check roundtrip
-        atts = features_with_interpolation(d2x)
-        ndom = Orange.data.Domain(atts, None)
-        dround = Orange.data.Table(ndom, d3)
-        #edges are unknown, the rest roughly the same
-        np.testing.assert_allclose(dround.X[:, 1:-1], d2.X[:, 1:-1], rtol=0.011)
+        ndom = Orange.data.Domain(features_with_interpolation(d2x), None)
+        dround = Orange.data.Table(ndom, d2)
+        np.testing.assert_allclose(dround.X, d2.X)
 
 
 class TestDat(unittest.TestCase):


### PR DESCRIPTION
It was inconsistent to automatically interpolate only two formats
Also, concatenating such files was impossible,
which led to problems if multiple of these files were read.