### PR TITLE
OWAverage: Fix average group handling of metas and unknowns

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owaverage.py
+++ b/orangecontrib/spectroscopy/tests/test_owaverage.py
@@ -122,10 +122,13 @@ class TestOWAverage(WidgetTest):
         str_var = Orange.data.StringVariable.make(name="stringtest")
         n_domain = Orange.data.Domain(c_domain.attributes,
                                       None,
-                                      [c_domain.attributes[0], c_domain.class_var, str_var])
+                                      [c_domain.class_var, str_var])
         collagen = self.collagen.transform(n_domain)
-
+        # collagen.metas[:, 1] = np.atleast_2d(self.collagen.Y)
         self.send_signal("Data", collagen)
         self.widget.group_var = gvar
         self.widget.grouping_changed()
         out = self.get_output("Averages")
+        # First 195 rows are labelled "collagen"
+        collagen_avg = np.mean(self.collagen.X[:195], axis=0)
+        np.testing.assert_equal(out.X[1,], collagen_avg)

--- a/orangecontrib/spectroscopy/tests/test_owaverage.py
+++ b/orangecontrib/spectroscopy/tests/test_owaverage.py
@@ -114,3 +114,18 @@ class TestOWAverage(WidgetTest):
         self.widget.grouping_changed()
         out = self.get_output("Averages")
         self.assertEqual(out.X.shape[0], len(gvar.values) - 1)
+
+    def test_average_by_group_objectvar(self):
+        # Test with group_var in metas (object array)
+        gvar = self.collagen.domain.class_var
+        c_domain = self.collagen.domain
+        str_var = Orange.data.StringVariable.make(name="stringtest")
+        n_domain = Orange.data.Domain(c_domain.attributes,
+                                      None,
+                                      [c_domain.attributes[0], c_domain.class_var, str_var])
+        collagen = self.collagen.transform(n_domain)
+
+        self.send_signal("Data", collagen)
+        self.widget.group_var = gvar
+        self.widget.grouping_changed()
+        out = self.get_output("Averages")

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -87,7 +87,15 @@ class OWAverage(OWWidget):
         for var in cont_vars:
             index = table.domain.index(var)
             col, _ = table.get_column_view(index)
-            avg_table[0, index] = np.nanmean(col)
+            try:
+                avg_table[0, index] = np.nanmean(col)
+            except AttributeError:
+                # numpy.lib.nanfunctions._replace_nan just guesses and returns
+                # a boolean array mask for object arrays because object arrays
+                # do not support `isnan` (numpy-gh-9009)
+                # Since we know that ContinuousVariable values must be np.float64
+                # do an explicit cast here
+                avg_table[0, index] = np.nanmean(col, dtype=np.float64)
 
         other_vars = [var for var in table.domain.class_vars + table.domain.metas
                       if not isinstance(var, Orange.data.ContinuousVariable)]

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 
 import Orange.data
-from Orange.data.filter import SameValue
+from Orange.data.filter import SameValue, IsDefined
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets import gui, settings
 from Orange.widgets.utils.itemmodels import DomainModel
@@ -77,6 +77,8 @@ class OWAverage(OWWidget):
             if all are the same.
           - return unknown otherwise.
         """
+        if len(table) == 0:
+            return table
         mean = np.nanmean(table.X, axis=0, keepdims=True)
         avg_table = Orange.data.Table.from_numpy(table.domain,
                                                  X=mean,
@@ -123,6 +125,9 @@ class OWAverage(OWWidget):
                     svfilter = SameValue(self.group_var, value)
                     v_table = self.average_table(svfilter(self.data))
                     averages.extend(v_table)
+                deffilter = IsDefined(columns=[self.group_var], negate=True)
+                v_table = self.average_table(deffilter(self.data))
+                averages.extend(v_table)
         self.Outputs.averages.send(averages)
 
 

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -82,8 +82,8 @@ class OWAverage(OWWidget):
         mean = np.nanmean(table.X, axis=0, keepdims=True)
         avg_table = Orange.data.Table.from_numpy(table.domain,
                                                  X=mean,
-                                                 Y=np.atleast_2d(table.Y.copy()[0]),
-                                                 metas=np.atleast_2d(table.metas.copy()[0]))
+                                                 Y=np.atleast_2d(table.Y[0].copy()),
+                                                 metas=np.atleast_2d(table.metas[0].copy()))
         cont_vars = [var for var in table.domain.class_vars + table.domain.metas
                      if isinstance(var, Orange.data.ContinuousVariable)]
         for var in cont_vars:

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -82,8 +82,8 @@ class OWAverage(OWWidget):
         mean = np.nanmean(table.X, axis=0, keepdims=True)
         avg_table = Orange.data.Table.from_numpy(table.domain,
                                                  X=mean,
-                                                 Y=np.atleast_2d(table.Y[0]),
-                                                 metas=np.atleast_2d(table.metas[0]))
+                                                 Y=np.atleast_2d(table.Y.copy()[0]),
+                                                 metas=np.atleast_2d(table.metas.copy()[0]))
         cont_vars = [var for var in table.domain.class_vars + table.domain.metas
                      if isinstance(var, Orange.data.ContinuousVariable)]
         for var in cont_vars:

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 
 import Orange.data
-from Orange.data.filter import SameValue, IsDefined
+from Orange.data.filter import SameValue, FilterDiscrete, Values
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets import gui, settings
 from Orange.widgets.utils.itemmodels import DomainModel
@@ -125,7 +125,11 @@ class OWAverage(OWWidget):
                     svfilter = SameValue(self.group_var, value)
                     v_table = self.average_table(svfilter(self.data))
                     averages.extend(v_table)
-                deffilter = IsDefined(columns=[self.group_var], negate=True)
+                # Using "None" as in OWSelectRows
+                # Values is required because FilterDiscrete doesn't have
+                # negate keyword or IsDefined method
+                deffilter = Values(conditions=[FilterDiscrete(self.group_var, None)],
+                                   negate=True)
                 v_table = self.average_table(deffilter(self.data))
                 averages.extend(v_table)
         self.Outputs.averages.send(averages)


### PR DESCRIPTION
A couple of fixes to work around issues with numpy / Orange handling of object arrays (which the meta arrays are whenever a `StringVariable` is present).

Implemented handling of unknown group_var values and group_var values with no members.

Related #237, #238 

