### PR TITLE
[FIX] AgilentReaders: use correct file extensions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 # Ref https://docs.python.org/2/distutils/sourcedist.html#commands
 recursive-include orangecontrib *.ows icons/* datasets/*
 recursive-include orangecontrib/spectroscopy/datasets matlab/*
+recursive-include orangecontrib/spectroscopy/datasets agilent/*
 
 global-exclude __pycache__
 

--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.1"
+__version__ = "0.1.2"
 from pathlib import Path
 import struct
 
@@ -170,7 +170,7 @@ class agilentImage(DataObject):
     Attributes beyond .info and .data are provided for consistency with MATLAB code
 
     Args:
-        filename (str): full path to .seq file
+        filename (str): full path to .dat file
         MAT (bool):     Output array using image coordinates (matplotlib/MATLAB)
 
     Attributes:
@@ -188,7 +188,7 @@ class agilentImage(DataObject):
 
     def __init__(self, filename, MAT=False):
         super().__init__()
-        p = _check_files(filename, [".seq", ".dat", ".bsp"])
+        p = _check_files(filename, [".dat", ".bsp"])
         self.MAT = MAT
         self._get_bsp_info(p)
         self._get_dat(p)
@@ -229,7 +229,7 @@ class agilentMosaic(DataObject):
     Attributes beyond .info and .data are provided for consistency with MATLAB code
 
     Args:
-        filename (str): full path to .dms file
+        filename (str): full path to .dmt file
         MAT (bool):     Output array using image coordinates (matplotlib/MATLAB)
 
     Attributes:
@@ -238,7 +238,7 @@ class agilentMosaic(DataObject):
         wavenumbers (list):     Wavenumbers in order of .data array
         width (int):            Width of mosaic in pixels (rows)
         height (int):           Width of mosaic in pixels (columns)
-        filename (str):         Full path to .dms file
+        filename (str):         Full path to .dmt file
         acqdate (str):          Date and time of acquisition
 
     Based on agilent-file-formats MATLAB code by Alex Henderson:
@@ -247,7 +247,7 @@ class agilentMosaic(DataObject):
 
     def __init__(self, filename, MAT=False):
         super().__init__()
-        p = _check_files(filename, [".dms", ".dmt", ".drd", ".dmd"])
+        p = _check_files(filename, [".dmt", ".dmd"])
         self.MAT = MAT
         self._get_dmt_info(p)
         self._get_dmd(p)
@@ -255,7 +255,7 @@ class agilentMosaic(DataObject):
         self.wavenumbers = self.info['wavenumbers']
         self.width = self.data.shape[0]
         self.height = self.data.shape[1]
-        self.filename = p.with_suffix(".dms").as_posix()
+        self.filename = p.with_suffix(".dmt").as_posix()
         self.acqdate = self.info['Time Stamp']
 
     def _get_dmt_info(self, p_in):

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -48,7 +48,7 @@ class SpectralFileFormat:
             return ret_data
 
 
-class DatReader(FileFormat):
+class AsciiColReader(FileFormat):
     """ Reader for files with multiple columns of numbers. The first column
     contains the wavelengths, the others contain the spectra. """
     EXTENSIONS = ('.dat', '.dpt', '.xy',)
@@ -293,7 +293,7 @@ class OmnicMapReader(FileFormat, SpectralFileFormat):
 
 class AgilentImageReader(FileFormat, SpectralFileFormat):
     """ Reader for Agilent FPA single tile image files"""
-    EXTENSIONS = ('.seq',)
+    EXTENSIONS = ('.dat',)
     DESCRIPTION = 'Agilent Single Tile Image'
 
     def read_spectra(self):
@@ -320,7 +320,7 @@ class AgilentImageReader(FileFormat, SpectralFileFormat):
 
 class agilentMosaicReader(FileFormat, SpectralFileFormat):
     """ Reader for Agilent FPA mosaic image files"""
-    EXTENSIONS = ('.dms',)
+    EXTENSIONS = ('.dmt',)
     DESCRIPTION = 'Agilent Mosaic Image'
 
     def read_spectra(self):
@@ -828,6 +828,21 @@ def getx(data):
     except:
         pass
     return x
+
+
+class DatMetaReader(FileFormat):
+    """ Meta-reader to handle agilentImageReader and AsciiColReader name clash
+    over .dat extension. """
+    EXTENSIONS = ('.dat',)
+    DESCRIPTION = 'Spectra ASCII or Agilent Single Tile Image'
+    PRIORITY = min(AsciiColReader.PRIORITY, AgilentImageReader.PRIORITY) - 1
+
+    def read(self):
+        try:
+            # agilentImage requires the .bsp file to be present as well
+            return AgilentImageReader(filename=self.filename).read()
+        except OSError:
+            return AsciiColReader(filename=self.filename).read()
 
 
 def spectra_mean(X):

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -78,7 +78,7 @@ class TestAsciiMapReader(unittest.TestCase):
 class TestAgilentReader(unittest.TestCase):
 
     def test_image_read(self):
-        d = Orange.data.Table("agilent/4_noimage_agg256.seq")
+        d = Orange.data.Table("agilent/4_noimage_agg256.dat")
         self.assertEqual(len(d), 64)
         # Pixel sizes are 5.5 * 16 = 88.0 (binning to reduce test data)
         self.assertAlmostEqual(
@@ -94,7 +94,7 @@ class TestAgilentReader(unittest.TestCase):
         self.assertEqual(max(getx(d)), 2113.600132)
 
     def test_mosaic_read(self):
-        d = Orange.data.Table("agilent/5_mosaic_agg1024.dms")
+        d = Orange.data.Table("agilent/5_mosaic_agg1024.dmt")
         self.assertEqual(len(d), 32)
         # Pixel sizes are 5.5 * 32 = 176.0 (binning to reduce test data)
         self.assertAlmostEqual(
@@ -112,13 +112,13 @@ class TestAgilentReader(unittest.TestCase):
 
     def test_envi_comparison(self):
         # Image
-        d1_a = Orange.data.Table("agilent/4_noimage_agg256.seq")
+        d1_a = Orange.data.Table("agilent/4_noimage_agg256.dat")
         d1_e = Orange.data.Table("agilent/4_noimage_agg256.hdr")
         np.testing.assert_equal(d1_a.X, d1_e.X)
         # Wavenumbers are rounded in .hdr files
         np.testing.assert_allclose(getx(d1_a), getx(d1_e))
         # Mosaic
-        d2_a = Orange.data.Table("agilent/5_mosaic_agg1024.dms")
+        d2_a = Orange.data.Table("agilent/5_mosaic_agg1024.dmt")
         d2_e = Orange.data.Table("agilent/5_mosaic_agg1024.hdr")
         np.testing.assert_equal(d2_a.X, d2_e.X)
         np.testing.assert_allclose(getx(d2_a), getx(d2_e))


### PR DESCRIPTION
Now the reader can load files without the interferogram tiles (*.seq / *.drd) being present (Fixes #194)

@markotoplak , can you check that I implemented the meta-reader for *.dat files properly?

Also is there anyway to hide the meta-reader in the File widget list? It's kind of ugly and distracting.