### PR TITLE
[ENH] OWFFT: use laser wavenumber and sampling interval metadata if present

### DIFF
--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.3.0"
 from pathlib import Path
 import struct
 
@@ -98,8 +98,9 @@ def _get_params(f):
         return val
 
     def _get_prop_str(dat, param):
-        part = dat.partition(bytes(param, encoding='utf8'))
-        val = part[2][:100].lstrip(STRP).split(b'\x00')[0].strip(STRP)
+        b_param = b'\x00' + bytes(param, encoding='utf8') + b'\x04'
+        part = dat.partition(b_param)
+        val = part[2][:100].lstrip(STRP + b'\n').split(b'\x00')[0].strip(STRP)
         return val.decode('utf8', errors='replace')
 
     d = {}
@@ -110,11 +111,54 @@ def _get_params(f):
     d['FPA Pixel Size'] = _get_prop_d(dat, 'FPA Pixel Size')
     d['Rapid Stingray'] = _get_section(dat, 'Rapid Stingray')
     d['Time Stamp'] = d['Rapid Stingray']['Time Stamp']
-    try:
-        d['PixelAggregationSize'] = int(_get_prop_str(dat, 'PixelAggregationSize'))
-    except ValueError:
-        pass
 
+    k_int = ['PixelAggregationSize',
+             'Resolution',
+             'Under Sampling Ratio',
+    ]
+    for k in k_int:
+        try:
+            d[k] = int(_get_prop_str(dat, k))
+        except ValueError:
+            pass
+
+    k_float = ['Effective Laser Wavenumber',
+    ]
+    for k in k_float:
+        try:
+            d[k] = float(_get_prop_str(dat, k))
+        except ValueError as e:
+            pass
+
+    k_str = ['Symmetry',
+    ]
+    for k in k_str:
+        d[k] = _get_prop_str(dat, k)
+
+    return d
+
+def _get_ifg_params(f):
+    """
+    Takes an open file handle and reads a preset selection of parameters
+    returns in a dictionary
+    """
+    def _get_proptype_data(dat, param):
+        part = dat.partition(bytes(param, encoding='utf8'))
+        val_b = part[2].partition(bytes("1.00", encoding='utf8'))[2]
+        PtSep = struct.unpack("d", val_b[12:20])[0]
+        StartPt = struct.unpack("i", val_b[24:28])[0]
+        Npts = struct.unpack("i", val_b[32:36])[0]
+        return PtSep, StartPt, Npts
+
+    d = {}
+    f.seek(0)
+    dat = f.read()
+
+    d['PtSep'], d['StartPt'], d['Npts'] = _get_proptype_data(dat, 'Interferogram')
+
+    if DEBUG:
+        for k,v in d.items():
+            print(k,v, type(v))
     return d
 
 
@@ -221,8 +265,72 @@ class agilentImage(DataObject):
         if DEBUG:
             print("FPA Size is {}".format(fpasize))
 
+class agilentMosaicTiles(DataObject):
+    """
+    UNSTABLE API
 
-class agilentMosaic(DataObject):
+    This class provides an array of _get_dmd() closures to allow lazy tile-by-tile
+    file loading by consumers.
+
+    The API is not considered stable at this time, so if you are wish to load
+    mosiac files with a stable interface, use agilentMosaic as in previous
+    versions.
+    """
+
+    def __init__(self, filename, MAT=False):
+        super().__init__()
+        p = _check_files(filename, [".dmt", ".dmd"])
+        self.MAT = MAT
+        self._get_dmt_info(p)
+        self._get_tiles(p)
+
+        self.wavenumbers = self.info['wavenumbers']
+        self.width = self.tiles.shape[0] * self.info['fpasize']
+        self.height = self.tiles.shape[1] * self.info['fpasize']
+        self.filename = p.with_suffix(".dmt").as_posix()
+        self.acqdate = self.info['Time Stamp']
+
+    def _get_dmt_info(self, p_in):
+        # .dmt is always lowercase
+        p = p_in.parent.joinpath(p_in.with_suffix(".dmt").name.lower())
+        with p.open(mode='rb') as f:
+            self.info.update(_get_wavenumbers(f))
+            self.info.update(_get_params(f))
+
+    def _get_tiles(self, p_in):
+        # Determine mosiac dimensions by counting .dmd files
+        xtiles = sum(1 for _ in
+                p_in.parent.glob(p_in.stem + "_[0-9][0-9][0-9][0-9]_0000.dmd"))
+        ytiles = sum(1 for _ in
+                p_in.parent.glob(p_in.stem + "_0000_[0-9][0-9][0-9][0-9].dmd"))
+        # _0000_0000.dmd primary file
+        p = p_in.parent.joinpath(p_in.stem + "_0000_0000.dmd")
+        Npts = self.info['Npts']
+        fpasize = self.info['fpasize'] = _fpa_size(p.stat().st_size / 4, Npts)
+
+        if DEBUG:
+            print("{0} x {1} tiles found".format(xtiles, ytiles))
+            print("FPA size is {}".format(fpasize))
+            print("Total dimensions are {0} x {1} or {2} spectra.".format(
+                xtiles*fpasize, ytiles*fpasize, xtiles*ytiles*fpasize**2))
+
+        tiles = np.zeros((xtiles, ytiles), dtype=object)
+        for (x, y) in np.ndindex(tiles.shape):
+            p_dmd = p_in.parent.joinpath(p_in.stem + "_{0:04d}_{1:04d}.dmd".format(x,y))
+            tiles[x, y] = self._get_dmd(p_dmd, Npts, fpasize)
+        self.tiles = tiles
+
+    @staticmethod
+    def _get_dmd(p_dmd, Npts, fpasize):
+        def _get_dmd_data(p_dmd=p_dmd):
+            with p_dmd.open(mode='rb') as f:
+                tile = np.fromfile(f, dtype=np.float32)
+            tile = _reshape_tile(tile, (Npts, fpasize, fpasize))
+            return tile
+        return _get_dmd_data
+
+
+class agilentMosaic(agilentMosaicTiles):
     """
     Extracts the spectra from an Agilent mosaic FPA image.
 
@@ -246,61 +354,185 @@ class agilentMosaic(DataObject):
     """
 
     def __init__(self, filename, MAT=False):
+        super().__init__(filename, MAT)
+        self._get_data()
+
+    def _get_data(self):
+        xtiles = self.tiles.shape[0]
+        ytiles = self.tiles.shape[1]
+        Npts = self.info['Npts']
+        fpasize = self.info['fpasize']
+        # Allocate array
+        # (rows, columns, wavenumbers)
+        data = np.zeros((ytiles*fpasize, xtiles*fpasize, Npts),
+                        dtype=np.float32)
+        if DEBUG:
+            print("self.tiles: ", self.tiles.shape)
+            print("self.data: ", data.shape)
+
+        for (x, y) in np.ndindex(self.tiles.shape):
+            tile = self.tiles[x, y]()
+            if self.MAT:
+                # Rotate and flip tile to match matplotlib/MATLAB image coordinates
+                tile = np.flipud(tile)
+                data[y*fpasize:(y+1)*fpasize, x*fpasize:(x+1)*fpasize, :] = tile
+            else:
+                # Tile data is in normal cartesian coordinates
+                # but tile numbering (000x_000y)
+                # is left-to-right, top-to-bottom (image coordinates)
+                data[(ytiles-y-1)*fpasize:(ytiles-y)*fpasize, (x)*fpasize:(x+1)*fpasize, :] = tile
+
+        self.data = data
+
+
+class agilentImageIFG(DataObject):
+    """
+    Extracts the interferograms from an Agilent single tile FPA image.
+
+    Args:
+        filename (str): full path to .seq file
+        MAT (bool):     Output array using image coordinates (matplotlib/MATLAB)
+
+    Attributes:
+        info (dict):            Dictionary of acquisition information
+        data (:obj:`ndarray`):  3-dimensional array (height x width x wavenumbers)
+        filename (str):         Full path to .bsp file
+    """
+
+    def __init__(self, filename, MAT=False):
         super().__init__()
-        p = _check_files(filename, [".dmt", ".dmd"])
+        p = _check_files(filename, [".seq", ".bsp"])
+        self.MAT = MAT
+        self._get_bsp_info(p)
+        self._get_seq(p)
+
+        self.filename = p.with_suffix(".bsp").as_posix()
+
+    def _get_bsp_info(self, p_in):
+        p = p_in.with_suffix(".bsp")
+        with p.open(mode='rb') as f:
+            self.info.update(_get_ifg_params(f))
+            self.info.update(_get_params(f))
+
+    def _get_seq(self, p_in):
+        p = p_in.with_suffix(".seq")
+        with p.open(mode='rb') as f:
+            data = np.fromfile(f, dtype=np.float32)
+        fpasize = _fpa_size(data.size, self.info['Npts'])
+        data = _reshape_tile(data, (self.info['Npts'], fpasize, fpasize))
+
+        if self.MAT:
+            # Rotate and flip tile to match matplotlib/MATLAB image coordinates
+            data = np.flipud(data)
+
+        self.data = data
+
+        if DEBUG:
+            print("FPA Size is {}".format(fpasize))
+
+
+class agilentMosaicIFGTiles(DataObject):
+    """
+    UNSTABLE API
+
+    This class provides an array of _get_drd() closures to allow lazy tile-by-tile
+    file loading by consumers.
+
+    The API is not considered stable at this time, so if you are wish to load
+    mosiac files with a stable interface, use agilentMosaic as in previous
+    versions.
+    """
+
+    def __init__(self, filename, MAT=False):
+        super().__init__()
+        p = _check_files(filename, [".dmt", ".drd"])
         self.MAT = MAT
         self._get_dmt_info(p)
-        self._get_dmd(p)
+        self._get_tiles(p)
 
-        self.wavenumbers = self.info['wavenumbers']
-        self.width = self.data.shape[0]
-        self.height = self.data.shape[1]
         self.filename = p.with_suffix(".dmt").as_posix()
-        self.acqdate = self.info['Time Stamp']
 
     def _get_dmt_info(self, p_in):
         # .dmt is always lowercase
         p = p_in.parent.joinpath(p_in.with_suffix(".dmt").name.lower())
         with p.open(mode='rb') as f:
-            self.info.update(_get_wavenumbers(f))
+            self.info.update(_get_ifg_params(f))
             self.info.update(_get_params(f))
 
-    def _get_dmd(self, p_in):
-        # Determine mosiac dimensions by counting .dmd files
+    def _get_tiles(self, p_in):
+        # Determine mosiac dimensions by counting .drd files
         xtiles = sum(1 for _ in
-                p_in.parent.glob(p_in.stem + "_[0-9][0-9][0-9][0-9]_0000.dmd"))
+                p_in.parent.glob(p_in.stem + "_[0-9][0-9][0-9][0-9]_0000.drd"))
         ytiles = sum(1 for _ in
-                p_in.parent.glob(p_in.stem + "_0000_[0-9][0-9][0-9][0-9].dmd"))
-        # _0000_0000.dmd primary file
-        p = p_in.parent.joinpath(p_in.stem + "_0000_0000.dmd")
+                p_in.parent.glob(p_in.stem + "_0000_[0-9][0-9][0-9][0-9].drd"))
+        # _0000_0000.drd primary file
+        p = p_in.parent.joinpath(p_in.stem + "_0000_0000.drd")
         Npts = self.info['Npts']
-        fpasize = _fpa_size(p.stat().st_size / 4, Npts)
-        # Allocate array
-        # (rows, columns, wavenumbers)
-        data = np.zeros((ytiles*fpasize, xtiles*fpasize, Npts),
-                        dtype=np.float32)
+        fpasize = self.info['fpasize'] = _fpa_size(p.stat().st_size / 4, Npts)
 
         if DEBUG:
             print("{0} x {1} tiles found".format(xtiles, ytiles))
             print("FPA size is {}".format(fpasize))
             print("Total dimensions are {0} x {1} or {2} spectra.".format(
                 xtiles*fpasize, ytiles*fpasize, xtiles*ytiles*fpasize**2))
-            print(data.shape)
 
-        for y in range(ytiles):
-            for x in range(xtiles):
-                p_dmd = p_in.parent.joinpath(p_in.stem + "_{0:04d}_{1:04d}.dmd".format(x,y))
-                with p_dmd.open(mode='rb') as f:
-                    tile = np.fromfile(f, dtype=np.float32)
-                tile = _reshape_tile(tile, (Npts, fpasize, fpasize))
-                if self.MAT:
-                    # Rotate and flip tile to match matplotlib/MATLAB image coordinates
-                    tile = np.flipud(tile)
-                    data[y*fpasize:(y+1)*fpasize, x*fpasize:(x+1)*fpasize, :] = tile
-                else:
-                    # Tile data is in normal cartesian coordinates
-                    # but tile numbering (000x_000y)
-                    # is left-to-right, top-to-bottom (image coordinates)
-                    data[(ytiles-y-1)*fpasize:(ytiles-y)*fpasize, (x)*fpasize:(x+1)*fpasize, :] = tile
+        tiles = np.zeros((xtiles, ytiles), dtype=object)
+        for (x, y) in np.ndindex(tiles.shape):
+            p_drd = p_in.parent.joinpath(p_in.stem + "_{0:04d}_{1:04d}.drd".format(x,y))
+            tiles[x, y] = self._get_drd(p_drd, Npts, fpasize)
+        self.tiles = tiles
+
+    @staticmethod
+    def _get_drd(p_drd, Npts, fpasize):
+        def _get_drd_data(p_drd=p_drd):
+            with p_drd.open(mode='rb') as f:
+                tile = np.fromfile(f, dtype=np.float32)
+            tile = _reshape_tile(tile, (Npts, fpasize, fpasize))
+            return tile
+        return _get_drd_data
+
+
+class agilentMosaicIFG(agilentMosaicIFGTiles):
+    """
+    Extracts the interferograms from an Agilent mosaic FPA image.
+
+    Args:
+        filename (str): full path to .dmt file
+        MAT (bool):     Output array using image coordinates (matplotlib/MATLAB)
+
+    Attributes:
+        info (dict):            Dictionary of acquisition information
+        data (:obj:`ndarray`):  3-dimensional array (height x width x wavenumbers)
+        filename (str):         Full path to .dmt file
+    """
+
+    def __init__(self, filename, MAT=False):
+        super().__init__(filename, MAT)
+        self._get_data()
+
+    def _get_data(self):
+        xtiles = self.tiles.shape[0]
+        ytiles = self.tiles.shape[1]
+        Npts = self.info['Npts']
+        fpasize = self.info['fpasize']
+        # Allocate array
+        # (rows, columns, wavenumbers)
+        data = np.zeros((ytiles*fpasize, xtiles*fpasize, Npts),
+                        dtype=np.float32)
+        if DEBUG:
+            print("self.tiles: ", self.tiles.shape)
+            print("self.data: ", data.shape)
+
+        for (x, y) in np.ndindex(self.tiles.shape):
+            tile = self.tiles[x, y]()
+            if self.MAT:
+                # Rotate and flip tile to match matplotlib/MATLAB image coordinates
+                tile = np.flipud(tile)
+                data[y*fpasize:(y+1)*fpasize, x*fpasize:(x+1)*fpasize, :] = tile
+            else:
+                # Tile data is in normal cartesian coordinates
+                # but tile numbering (000x_000y)
+                # is left-to-right, top-to-bottom (image coordinates)
+                data[(ytiles-y-1)*fpasize:(ytiles-y)*fpasize, (x)*fpasize:(x+1)*fpasize, :] = tile
 
         self.data = data

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -339,7 +339,29 @@ class AgilentImageIFGReader(FileFormat, SpectralFileFormat):
         x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
         y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
-        return _spectra_from_image(X, features, x_locs, y_locs)
+        features, data, additional_table = _spectra_from_image(X, features, x_locs, y_locs)
+
+        import_params = ['Effective Laser Wavenumber',
+                         'Under Sampling Ratio',
+        ]
+        new_attributes = []
+        new_columns = []
+        for param_key in import_params:
+            try:
+                param = info[param_key]
+            except KeyError:
+                pass
+            else:
+                new_attributes.append(ContinuousVariable.make(param_key))
+                new_columns.append(np.full((len(data),), param))
+
+        domain = Domain(additional_table.domain.attributes,
+                        additional_table.domain.class_vars,
+                        additional_table.domain.metas + tuple(new_attributes))
+        table = additional_table.transform(domain)
+        table[:, new_attributes] = np.asarray(new_columns).T
+
+        return (features, data, table)
 
 
 class agilentMosaicReader(FileFormat, SpectralFileFormat):
@@ -390,7 +412,29 @@ class agilentMosaicIFGReader(FileFormat, SpectralFileFormat):
         x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
         y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
-        return _spectra_from_image(X, features, x_locs, y_locs)
+        features, data, additional_table = _spectra_from_image(X, features, x_locs, y_locs)
+
+        import_params = ['Effective Laser Wavenumber',
+                         'Under Sampling Ratio',
+        ]
+        new_attributes = []
+        new_columns = []
+        for param_key in import_params:
+            try:
+                param = info[param_key]
+            except KeyError:
+                pass
+            else:
+                new_attributes.append(ContinuousVariable.make(param_key))
+                new_columns.append(np.full((len(data),), param))
+
+        domain = Domain(additional_table.domain.attributes,
+                        additional_table.domain.class_vars,
+                        additional_table.domain.metas + tuple(new_attributes))
+        table = additional_table.transform(domain)
+        table[:, new_attributes] = np.asarray(new_columns).T
+
+        return (features, data, table)
 
 
 class SPCReader(FileFormat):

--- a/orangecontrib/spectroscopy/tests/test_owfft.py
+++ b/orangecontrib/spectroscopy/tests/test_owfft.py
@@ -7,7 +7,25 @@ class TestOWFFT(WidgetTest):
 
     def setUp(self):
         self.widget = self.create_widget(OWFFT)
+        self.ifg_single = Orange.data.Table("IFG_single.dpt")
+        self.ifg_seq = Orange.data.Table("agilent/4_noimage_agg256.seq")
 
     def test_load_unload(self):
-        self.send_signal("Interferogram", Orange.data.Table("IFG_single.dpt"))
+        self.send_signal("Interferogram", self.ifg_single)
         self.send_signal("Interferogram", None)
+
+    def test_laser_metadata(self):
+        """ Test dx in presence/absence of laser metadata """
+        self.send_signal("Interferogram", self.ifg_seq)
+        self.assertEqual(self.widget.dx, (1 / 1.57980039e+04 / 2) * 4)
+        self.send_signal("Interferogram", self.ifg_single)
+        self.assertEqual(self.widget.dx, (1 / self.widget.laser_wavenumber / 2))
+
+    def test_respect_custom_dx(self):
+        """ Setting new data should not overwrite custom dx value """
+        self.send_signal("Interferogram", self.ifg_single)
+        self.widget.dx_HeNe = False
+        self.widget.dx = 5
+        self.widget.dx_changed()
+        self.send_signal("Interferogram", self.ifg_single)
+        self.assertEqual(self.widget.dx, 5)

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -137,6 +137,9 @@ class TestAgilentReader(unittest.TestCase):
         self.assertAlmostEqual(d[-1]["map_y"], 616.0)
         self.assertAlmostEqual(d[9][0], 0.64558595)
         self.assertAlmostEqual(d[18][0], 0.5792696)
+        # Metadata
+        self.assertEqual(d.metas[0, 2], 1.57980039e+04)
+        self.assertEqual(d.metas[0, 3], 4)
 
     def test_mosaic_ifg_read(self):
         # This reader will only be selected manually due to shared .dmt extension
@@ -156,6 +159,9 @@ class TestAgilentReader(unittest.TestCase):
         self.assertAlmostEqual(d[-1]["map_y"], 1232.0)
         self.assertAlmostEqual(d[21][0], 0.7116039)
         self.assertAlmostEqual(d[26][0], 0.48532167)
+        # Metadata
+        self.assertEqual(d.metas[0, 2], 1.57980039e+04)
+        self.assertEqual(d.metas[0, 3], 4)
 
 
 class TestGSF(unittest.TestCase):


### PR DESCRIPTION
If the dataset contains laser wavenumber (and optionally, interferogram sampling interval or UDR) metadata, use that instead of the hard-coded / custom dx.

Note this builds on #262 so should wait on that being resolved first.