### PR TITLE
owspectra: use less memory for computing averages

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -91,6 +91,11 @@ class TestOWSpectra(WidgetTest):
 
         self.widget.curveplot.MOUSE_RADIUS = mr
 
+    def test_average(self):
+        for data in self.normal_data + self.strange_data:
+            self.send_signal("Data", data)
+            self.widget.curveplot.show_average()
+
     def test_empty(self):
         self.send_signal("Data", None)
         self.do_mousemove()

--- a/orangecontrib/spectroscopy/utils.py
+++ b/orangecontrib/spectroscopy/utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def apply_columns_numpy(array, function, selector=None, chunk_size=10 ** 7):
+    """Split the array by columns, applies selection and then the function.
+    Returns output equivalent to function(array[selector])
+    """
+    chunks_needed = array.size // chunk_size
+    # min chunks is 1, max chunks is the number of columns
+    chunks = max(min(chunks_needed, array.shape[1]), 1)
+    parts = np.array_split(array, chunks, axis=1)
+    res = []
+    for p in parts:
+        res.append(function(p[selector]))
+    return np.hstack(res)

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -40,6 +40,7 @@ except ImportError:
 
 
 from orangecontrib.spectroscopy.data import getx
+from orangecontrib.spectroscopy.utils import apply_columns_numpy
 from orangecontrib.spectroscopy.widgets.line_geometry import \
     distance_curves, intersect_curves_chunked
 from orangecontrib.spectroscopy.widgets.gui import lineEditFloatOrNone, pixel_decimals, \
@@ -1267,9 +1268,12 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
                         part_selection = indices & self.subset_indices
                         pen = self.pen_subset
                     if np.any(part_selection):
-                        ys = self.data.X[part_selection]
-                        std = np.nanstd(ys, axis=0)
-                        mean = np.nanmean(ys, axis=0)
+                        std = apply_columns_numpy(self.data.X,
+                                                  lambda x: np.nanstd(x, axis=0),
+                                                  part_selection)
+                        mean = apply_columns_numpy(self.data.X,
+                                                   lambda x: np.nanmean(x, axis=0),
+                                                   part_selection)
                         std = std[self.data_xsind]
                         mean = mean[self.data_xsind]
                         ysall.append(mean)


### PR DESCRIPTION
Averages temporarily allocated lots of memory, both for selection and for the nanmean/nanstd. That computation was split column-wise into smaller chunks.