### PR TITLE
Use ubuntu xenial for travis to avoid static TLS limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-sudo: false
+dist: xenial
 
 matrix:
   include:


### PR DESCRIPTION
The error:
ImportError: dlopen: cannot load any more object with static TLS