### PR TITLE
[FIX] Preprocessors in the Preprocess Spectra widget also preprocess the reference

### DIFF
--- a/doc/widgets/preprocess-spectra.rst
+++ b/doc/widgets/preprocess-spectra.rst
@@ -13,14 +13,16 @@ Outputs
     Preprocessed Data
         transformed data set
     Preprocessor
-    	  preprocessing methods
+        preprocessing methods
 
 
 The **Preprocess Spectra** widget applied several preprocessing methods to spectral data. You select the preprocessing method from the list and press the triangle button on the right to apply it. The order of the preprocessing matters, so to change the order of the preprocessing, just drag and drop the method to its proper place.
 
 The input data for the selected method are displayed in the top plot, while the preprocessed data are displayed in the bottom plot.
 
-You can observe each preprocessing step by pressing the triangle button on the right. To apply all of then and observe the final result in a spactra plot, press *Final preview*. To output the data, press *Commit*.
+You can observe each preprocessing step by pressing the triangle button on the right. To apply all of then and observe the final result plot, press *Final preview*. To output the data, press *Commit*.
+
+The reference data set is processed along the input data: only the first preprocessor uses the reference as on the input. If the reference needs to stay fixed, split your preprocessing methods among multiple **Preprocess Spectra** widgets and connect references accordingly.
 
 .. figure:: images/Preprocess-Spectra-stamped.png
 

--- a/orangecontrib/spectroscopy/tests/test_owintegrate.py
+++ b/orangecontrib/spectroscopy/tests/test_owintegrate.py
@@ -32,9 +32,11 @@ class TestOWIntegrate(WidgetTest):
             self.widget.apply()
         # no attributes
         data = Orange.data.Table("peach_juice.dpt")
-        data = Orange.data.Table(Orange.data.Domain([],
-                class_vars=data.domain.class_vars,
-                metas=data.domain.metas), data)
+        data = Orange.data.Table(
+            Orange.data.Domain([],
+                               class_vars=data.domain.class_vars,
+                               metas=data.domain.metas),
+            data)
         for p in PREPROCESSORS:
             self.widget = self.create_widget(OWIntegrate)
             self.send_signal("Data", data)

--- a/orangecontrib/spectroscopy/tests/test_owintegrate.py
+++ b/orangecontrib/spectroscopy/tests/test_owintegrate.py
@@ -14,20 +14,20 @@ class TestOWIntegrate(WidgetTest):
 
     def test_allint_indv(self):
         data = Orange.data.Table("peach_juice.dpt")
-        for i,p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWIntegrate)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
             self.widget.apply()
 
     def test_allint_indv_empty(self):
         data = Orange.data.Table("peach_juice.dpt")[:0]
-        for i, p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWIntegrate)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             self.widget.show_preview()  # direct call
             self.widget.apply()
         # no attributes
@@ -35,9 +35,9 @@ class TestOWIntegrate(WidgetTest):
         data = Orange.data.Table(Orange.data.Domain([],
                 class_vars=data.domain.class_vars,
                 metas=data.domain.metas), data)
-        for i, p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWIntegrate)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             self.widget.show_preview()  # direct call
             self.widget.apply()

--- a/orangecontrib/spectroscopy/tests/test_owintegrate.py
+++ b/orangecontrib/spectroscopy/tests/test_owintegrate.py
@@ -20,6 +20,7 @@ class TestOWIntegrate(WidgetTest):
             self.widget.add_preprocessor(i)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
+            self.widget.apply()
 
     def test_allint_indv_empty(self):
         data = Orange.data.Table("peach_juice.dpt")[:0]
@@ -28,6 +29,7 @@ class TestOWIntegrate(WidgetTest):
             self.send_signal("Data", data)
             self.widget.add_preprocessor(i)
             self.widget.show_preview()  # direct call
+            self.widget.apply()
         # no attributes
         data = Orange.data.Table("peach_juice.dpt")
         data = Orange.data.Table(Orange.data.Domain([],
@@ -38,3 +40,4 @@ class TestOWIntegrate(WidgetTest):
             self.send_signal("Data", data)
             self.widget.add_preprocessor(i)
             self.widget.show_preview()  # direct call
+            self.widget.apply()

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -18,20 +18,20 @@ class TestOWPreprocess(WidgetTest):
 
     def test_allpreproc_indv(self):
         data = Orange.data.Table("peach_juice.dpt")
-        for i,p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
             self.widget.apply()
 
     def test_allpreproc_indv_empty(self):
         data = Orange.data.Table("peach_juice.dpt")[:0]
-        for i, p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             self.widget.show_preview()  # direct call
             self.widget.apply()
         # no attributes
@@ -39,20 +39,20 @@ class TestOWPreprocess(WidgetTest):
         data = Orange.data.Table(Orange.data.Domain([],
                 class_vars=data.domain.class_vars,
                 metas=data.domain.metas), data)
-        for i, p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             self.widget.show_preview()  # direct call
             self.widget.apply()
 
     def test_allpreproc_indv_ref(self):
         data = Orange.data.Table("peach_juice.dpt")
-        for i,p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
             self.send_signal("Reference", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
             self.widget.apply()
@@ -61,11 +61,11 @@ class TestOWPreprocess(WidgetTest):
         """Test that preprocessors can handle references with multiple instances"""
         # len(data) must be > maximum preview size (10) to ensure test failure
         data = SMALL_COLLAGEN
-        for i,p in enumerate(PREPROCESSORS):
+        for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
             self.send_signal("Reference", data)
-            self.widget.add_preprocessor(i)
+            self.widget.add_preprocessor(p)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
             self.widget.apply()

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -22,6 +22,7 @@ class TestOWPreprocess(WidgetTest):
             self.widget.add_preprocessor(i)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
+            self.widget.apply()
 
     def test_allpreproc_indv_empty(self):
         data = Orange.data.Table("peach_juice.dpt")[:0]
@@ -30,6 +31,7 @@ class TestOWPreprocess(WidgetTest):
             self.send_signal("Data", data)
             self.widget.add_preprocessor(i)
             self.widget.show_preview()  # direct call
+            self.widget.apply()
         # no attributes
         data = Orange.data.Table("peach_juice.dpt")
         data = Orange.data.Table(Orange.data.Domain([],
@@ -40,6 +42,7 @@ class TestOWPreprocess(WidgetTest):
             self.send_signal("Data", data)
             self.widget.add_preprocessor(i)
             self.widget.show_preview()  # direct call
+            self.widget.apply()
 
     def test_allpreproc_indv_ref(self):
         data = Orange.data.Table("peach_juice.dpt")
@@ -50,6 +53,7 @@ class TestOWPreprocess(WidgetTest):
             self.widget.add_preprocessor(i)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
+            self.widget.apply()
 
     def test_allpreproc_indv_ref_multi(self):
         """Test that preprocessors can handle references with multiple instances"""
@@ -62,6 +66,7 @@ class TestOWPreprocess(WidgetTest):
             self.widget.add_preprocessor(i)
             # direct calls the preview so that exceptions do not get lost in Qt
             self.widget.show_preview()
+            self.widget.apply()
 
     def test_transfer_highlight(self):
         data = SMALL_COLLAGEN

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -84,7 +84,7 @@ class TestOWPreprocess(WidgetTest):
         self.widget.curveplot.highlight(None)
         self.assertIsNone(self.widget.curveplot_after.highlighted)
 
-    def test_migrate_rubberbard(self):
+    def test_migrate_rubberband(self):
         settings = {"storedsettings":
                         {"preprocessors": [("orangecontrib.infrared.rubberband", {})]}}
         OWPreprocess.migrate_settings(settings, 1)

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -36,9 +36,11 @@ class TestOWPreprocess(WidgetTest):
             self.widget.apply()
         # no attributes
         data = Orange.data.Table("peach_juice.dpt")
-        data = Orange.data.Table(Orange.data.Domain([],
-                class_vars=data.domain.class_vars,
-                metas=data.domain.metas), data)
+        data = Orange.data.Table(
+            Orange.data.Domain([],
+                               class_vars=data.domain.class_vars,
+                               metas=data.domain.metas),
+            data)
         for p in PREPROCESSORS:
             self.widget = self.create_widget(OWPreprocess)
             self.send_signal("Data", data)
@@ -80,8 +82,8 @@ class TestOWPreprocess(WidgetTest):
         self.assertIsNone(self.widget.curveplot_after.highlighted)
 
     def test_migrate_rubberbard(self):
-        settings = {"storedsettings": {"preprocessors":
-            [("orangecontrib.infrared.rubberband", {})]}}
+        settings = {"storedsettings":
+                        {"preprocessors": [("orangecontrib.infrared.rubberband", {})]}}
         OWPreprocess.migrate_settings(settings, 1)
         self.assertEqual(settings["storedsettings"]["preprocessors"],
                          [("orangecontrib.infrared.baseline", {'baseline_type': 1})])

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1648,7 +1648,7 @@ class SpectralPreprocess(OWWidget):
             self.curveplot_after.hide()
 
     def _initialize(self):
-        for i, pp_def in enumerate(self.PREPROCESSORS):
+        for pp_def in self.PREPROCESSORS:
             description = pp_def.description
             if description.icon:
                 icon = QIcon(description.icon)
@@ -1661,7 +1661,7 @@ class SpectralPreprocess(OWWidget):
                           Qt.ItemIsDragEnabled)
             self.preprocessors.appendRow([item])
             action = QAction(
-                description.title, self, triggered=lambda x, id=i: self.add_preprocessor(id)
+                description.title, self, triggered=lambda x, p=pp_def: self.add_preprocessor(p)
             )
             action.setToolTip(description.summary or "")
             action.setIcon(icon)
@@ -1757,8 +1757,6 @@ class SpectralPreprocess(OWWidget):
         self.apply()
 
     def add_preprocessor(self, action):
-        if isinstance(action, int):
-            action = self.PREPROCESSORS[action]
         item = QStandardItem()
         item.setData({}, ParametersRole)
         item.setData(action.description.title, Qt.DisplayRole)

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1584,23 +1584,21 @@ class SpectralPreprocess(OWWidget):
         self._initialize()
 
     def _update_preview_number(self):
-        self.sample_preview_data()
         self.show_preview(show_info=False)
 
-    def sample_preview_data(self):
-        if self.data is not None:
-            data = self.data
-            if len(data) > self.preview_curves: #sample data
-                sampled_indices = random.Random(0).sample(range(len(data)), self.preview_curves)
-                data = data[sampled_indices]
-            self.preview_data = data
+    def sample_data(self, data):
+        if data is not None and len(data) > self.preview_curves:
+            sampled_indices = random.Random(0).sample(range(len(data)), self.preview_curves)
+            return data[sampled_indices]
+        else:
+            return self.data
 
     def show_preview(self, show_info=False):
         """ Shows preview and also passes preview data to the widgets """
         #self.storeSpecificSettings()
 
         if self.data is not None:
-            orig_data = data = self.preview_data
+            orig_data = data = self.sample_data(self.data)
             reference_data = self.reference_data
             widgets = self.flow_view.widgets()
             preview_pos = self.flow_view.preview_n()
@@ -1753,14 +1751,14 @@ class SpectralPreprocess(OWWidget):
     def set_data(self, data=None):
         """Set the input data set."""
         self.data = data
-        self.sample_preview_data()
 
     def handleNewSignals(self):
         self.show_preview(True)
         self.apply()
 
-    def add_preprocessor(self, index):
-        action = self.PREPROCESSORS[index]
+    def add_preprocessor(self, action):
+        if isinstance(action, int):
+            action = self.PREPROCESSORS[action]
         item = QStandardItem()
         item.setData({}, ParametersRole)
         item.setData(action.description.title, Qt.DisplayRole)


### PR DESCRIPTION
#### Issue

@achimkohler reported the following error with the next schema

![image003](https://user-images.githubusercontent.com/552182/50971863-679e3a80-14e5-11e9-83d7-b20ef40010fc.jpg)

The upper result looks like: EMSC pre-process spectra are flipped: I think raw spectra are averaged and used as reference, while the averaged derivated spectra should be used

![image004](https://user-images.githubusercontent.com/552182/50971886-7684ed00-14e5-11e9-965b-dbc6a68b220c.jpg)

The lower stream results in (output from Preprocess Spectra (2)): Her you can see that the EMSC preprocessed spectra are not flipped compared to the derivated spectra:

 ![image005](https://user-images.githubusercontent.com/552182/50971889-784eb080-14e5-11e9-82b9-c35ca5035d51.jpg)

#### Fix

I think that preprocessing reference data with the same preprocessors as we process input data makes sense. If someone wants old behavior, they can still have it by using 2 preprocess widget instead of one.

The older workflows should still work the old way but give a warning.