### PR TITLE
[RFC] owpreprocess: do not commit on data change if autocommit is off

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1501,6 +1501,7 @@ class SpectralPreprocess(OWWidget):
         reference_compat = Msg("Reference is not processed for compatibility with the loaded "
                                "workflow. New instances of this widget will also process "
                                "the reference input.")
+        uncommited_changes = Msg("There are uncommited changes.")
 
     def __init__(self):
         super().__init__()
@@ -1771,7 +1772,7 @@ class SpectralPreprocess(OWWidget):
 
     def on_modelchanged(self):
         self.show_preview()
-        self.commit()
+        self.invalidate()
 
     @Inputs.data
     @check_sql_input
@@ -1781,7 +1782,7 @@ class SpectralPreprocess(OWWidget):
 
     def handleNewSignals(self):
         self.show_preview(True)
-        self.unconditional_commit()
+        self.invalidate()
 
     def add_preprocessor(self, action):
         item = QStandardItem()
@@ -1831,6 +1832,13 @@ class SpectralPreprocess(OWWidget):
         self.Outputs.preprocessor.send(preprocessor)
 
         self.Outputs.preprocessed_data.send(data)
+
+        self.Warning.uncommited_changes.clear()
+
+    def invalidate(self):
+        if not self.autocommit:  # check autocommit to avoid warning flashing
+            self.Warning.uncommited_changes()
+        self.commit()
 
     def commit(self):
         # Do not run() apply immediately: delegate it to the event loop.


### PR DESCRIPTION
This goes against the general consensus in Orange, which is to commit/apply for new data (see biolab/orange3#3455). 

The ordinary workaround to disable commit on new data (freeze a connection) prevents previews. Thus, we could make an exception Preprocess. To show this on the canvas, widget now issues a warning.

From @stuart-cls (on #287):
> I thought it worked like this:
>
> 1. Auto-commit on: any change to data input / widget settings is immediately propagated to the outputs
> 2. Auto-commit off: any change to data input is reflected in widget previewing, but the heavy-lifting / full-data calculations (i.e. Preprocessing, clustering, FFT, etc) is postponed until the user presses the "Commit" button.
>
> I think 2. is superior to freezing the connection because you can still see the preview/info boxes. It is inferior because you can't tell from the canvas which widgets are not calculating automatically.
