### PR TITLE
[ENH] Increase shown spectra limit from 100 to 1000 

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1070,7 +1070,8 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         elif self.color_individual:
             value = idc % len(self._color_individual_cycle)
         self.curves_cont.objs[idc].setPen(thispen[value])
-        self.curves_cont.objs[idc].setZValue(int(insubset) + int(inselected))
+        # to always draw selected above subset, multiply with 2
+        self.curves_cont.objs[idc].setZValue(int(insubset) + 2*int(inselected))
 
     def set_curve_pens(self, curves=None):
         if self.viewtype == INDIVIDUAL and self.curves:

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1131,7 +1131,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         phigh = pg.PlotCurveItem(x, yhigh, pen=pen)
         plow = pg.PlotCurveItem(x, ylow, pen=pen)
         color = pen.color()
-        color.setAlphaF(0.2)
+        color.setAlphaF(color.alphaF() * 0.3)
         cc = pg.mkBrush(color)
         pfill = pg.FillBetweenItem(plow, phigh, brush=cc)
         pfill.setZValue(10)
@@ -1152,8 +1152,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         pen_subset = pg.mkPen(color=color, width=1)
         pen_selected = pg.mkPen(color=color, width=2, style=Qt.DotLine)
         if color_unselected is None:
-            color_unselected = color.lighter(150)
-            color_unselected.setAlphaF(0.5)
+            color_unselected = color.lighter(160)
         pen_normal = pg.mkPen(color=color_unselected, width=1)
         return pen_normal, pen_selected, pen_subset
 

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -545,8 +545,9 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         self.plot.vb.sigRangeChanged.connect(self.resized)
         self.plot.vb.sigResized.connect(self.resized)
         self.pen_mouse = pg.mkPen(color=(0, 0, 255), width=2)
-        pen_normal, pen_selected, pen_subset = self._generate_pens(QColor(0, 0, 0, 127),
-                                                                   QColor(200, 200, 200, 127))
+        pen_normal, pen_selected, pen_subset = self._generate_pens(QColor(60, 60, 60, 200),
+                                                                   QColor(200, 200, 200, 127),
+                                                                   QColor(0, 0, 0, 255))
         self.pen_normal = defaultdict(lambda: pen_normal)
         self.pen_subset = defaultdict(lambda: pen_subset)
         self.pen_selected = defaultdict(lambda: pen_selected)
@@ -1148,9 +1149,12 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         return color_var
 
     @staticmethod
-    def _generate_pens(color, color_unselected=None):
+    def _generate_pens(color, color_unselected=None, color_selected=None):
         pen_subset = pg.mkPen(color=color, width=1)
-        pen_selected = pg.mkPen(color=color, width=2, style=Qt.DotLine)
+        if color_selected is None:
+            color_selected = color.darker(135)
+            color_selected.setAlphaF(1.0)  # only gains in a sparse space
+        pen_selected = pg.mkPen(color=color_selected, width=2, style=Qt.DotLine)
         if color_unselected is None:
             color_unselected = color.lighter(160)
         pen_normal = pg.mkPen(color=color_unselected, width=1)

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -222,6 +222,9 @@ class InteractiveViewBox(ViewBox):
         if self.tiptexts:  # if initialized
             self.scene().select_tooltip.setPos(10, self.height())
 
+    def enableAutoRange(self, axis=None, enable=True, x=None, y=None):
+        super().enableAutoRange(axis=axis, enable=False, x=x, y=y)
+
     def update_selection_tooltip(self, modifiers=Qt.NoModifier):
         if not self.tiptexts:
             self._create_select_tooltip()
@@ -525,6 +528,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
         self.plotview = pg.PlotWidget(background="w", viewBox=InteractiveViewBoxC(self))
         self.plot = self.plotview.getPlotItem()
+        self.plot.hideButtons()  # hide the autorange button
         self.plot.setDownsampling(auto=True, mode="peak")
 
         for pos in ["top", "right"]:
@@ -882,7 +886,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         self.highlighted_curve = pg.PlotCurveItem(pen=self.pen_mouse)
         self.highlighted_curve.setZValue(10)
         self.highlighted_curve.hide()
-        self.plot.addItem(self.highlighted_curve)
+        self.plot.addItem(self.highlighted_curve, ignoreBounds=True)
         self.plot.addItem(self.vLine, ignoreBounds=True)
         self.plot.addItem(self.hLine, ignoreBounds=True)
         self.viewhelpers = True


### PR DESCRIPTION
CurvePlots now only use thick pen for selections up to 10 curves because drawing paths with width != 1 is very slow in Qt. Because CurvePlot now never draws more that 10 thick curves, we increased the previous limit to 1000.

Also, some other optimizations were needed.
