### PR TITLE
Test and handle (-) infs in preprocessors

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -334,7 +334,7 @@ class _NormalizeReferenceCommon(CommonDomainRef):
 
     def transformed(self, data):
         if len(data):  # numpy does not like to divide shapes (0, b) by (a, b)
-            ref_X = self.interpolate_extend_to(self.ref, getx(data))
+            ref_X = self.interpolate_extend_to(self.reference, getx(data))
             return replace_infs(data.X / ref_X)
         else:
             return data

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -6,7 +6,7 @@ from Orange.preprocess.preprocess import Preprocess
 
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDomainRef,\
-    WrongReferenceException
+    WrongReferenceException, replace_infs
 
 
 class SpecTypes(Enum):
@@ -37,7 +37,8 @@ class _AbsorbanceCommon(CommonDomainRef):
             # Calculate from transmittance data
             absd = np.log10(data.X)
             absd *= -1
-        return absd
+        # Replace infs from either np.true_divide or np.log10
+        return replace_infs(absd)
 
 
 class TransformOptionalReference(Preprocess):
@@ -93,7 +94,8 @@ class _TransmittanceCommon(CommonDomainRef):
             transd = data.X.copy()
             transd *= -1
             np.power(10, transd, transd)
-        return transd
+        # Replace infs from either np.true_divide or np.log10
+        return replace_infs(transd)
 
 
 class Transmittance(TransformOptionalReference):

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -25,9 +25,9 @@ class AbsorbanceFeature(SelectColumn):
 class _AbsorbanceCommon(CommonDomainRef):
 
     def transformed(self, data):
-        if self.ref is not None:
+        if self.reference is not None:
             # Calculate from single-channel data
-            ref_X = self.interpolate_extend_to(self.ref, getx(data))
+            ref_X = self.interpolate_extend_to(self.reference, getx(data))
             if len(data):  # numpy does not like to divide shapes (0, b) by (a, b)
                 absd = ref_X / data.X
                 np.log10(absd, absd)
@@ -43,13 +43,13 @@ class _AbsorbanceCommon(CommonDomainRef):
 
 class TransformOptionalReference(Preprocess):
 
-    def __init__(self, ref=None):
-        if ref is not None and len(ref) != 1:
+    def __init__(self, reference=None):
+        if reference is not None and len(reference) != 1:
             raise WrongReferenceException("Reference data should have length 1")
-        self.ref = ref
+        self.reference = reference
 
     def __call__(self, data):
-        common = self._cl_common(self.ref, data.domain)
+        common = self._cl_common(self.reference, data.domain)
         newattrs = [Orange.data.ContinuousVariable(
             name=var.name, compute_value=self._cl_feature(i, common))
             for i, var in enumerate(data.domain.attributes)]
@@ -62,11 +62,11 @@ class Absorbance(TransformOptionalReference):
     """
     Convert data to absorbance.
 
-    Set ref to calculate from single-channel spectra, otherwise convert from transmittance.
+    Set reference to calculate from single-channel spectra, otherwise convert from transmittance.
 
     Parameters
     ----------
-    ref : reference single-channel (Orange.data.Table)
+    reference : reference single-channel (Orange.data.Table)
     """
 
     _cl_common = _AbsorbanceCommon
@@ -82,10 +82,10 @@ class TransmittanceFeature(SelectColumn):
 class _TransmittanceCommon(CommonDomainRef):
 
     def transformed(self, data):
-        if self.ref is not None:
+        if self.reference is not None:
             # Calculate from single-channel data
             if len(data):  # numpy does not like to divide shapes (0, b) by (a, b)
-                ref_X = self.interpolate_extend_to(self.ref, getx(data))
+                ref_X = self.interpolate_extend_to(self.reference, getx(data))
                 transd = data.X / ref_X
             else:
                 transd = data
@@ -102,11 +102,11 @@ class Transmittance(TransformOptionalReference):
     """
     Convert data to transmittance.
 
-    Set ref to calculate from single-channel spectra, otherwise convert from absorbance.
+    Set reference to calculate from single-channel spectra, otherwise convert from absorbance.
 
     Parameters
     ----------
-    ref : reference single-channel (Orange.data.Table)
+    reference : reference single-channel (Orange.data.Table)
     """
 
     from_types = (SpecTypes.ABSORBANCE, SpecTypes.SINGLECHANNEL)

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -215,3 +215,10 @@ def interp1d_wo_unknowns_scipy(x, ys, points, kind="linear"):
 def edge_baseline(x, y):
     i = np.array([0, -1])
     return interp1d(x[i], y[:, i], axis=1)(x) if len(x) else 0
+
+
+def replace_infs(array):
+    """ Replaces inf and -inf with nan.
+    This should be used anywhere a divide-by-zero can happen (/, np.log10, etc)"""
+    array[np.isinf(array)] = np.nan
+    return array

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -59,9 +59,9 @@ class CommonDomain:
 
 class CommonDomainRef(CommonDomain):
     """CommonDomain which also ensures reference domain transformation"""
-    def __init__(self, ref, domain):
+    def __init__(self, reference, domain):
         super().__init__(domain)
-        self.ref = ref
+        self.reference = reference
 
     def interpolate_extend_to(self, interpolate, wavenumbers):
         """

--- a/orangecontrib/spectroscopy/tests/test_conversion.py
+++ b/orangecontrib/spectroscopy/tests/test_conversion.py
@@ -134,6 +134,8 @@ class TestConversion(unittest.TestCase):
         learner = LogisticRegressionLearner(preprocessors=[_RemoveNaNRows()])
 
         for proc in PREPROCESSORS:
+            if hasattr(proc, "skip_add_zeros"):
+                continue
             # LR that can not handle unknown values
             train, test = separate_learn_test(self.collagen)
             train1 = proc(train)

--- a/orangecontrib/spectroscopy/tests/test_editor_normalize.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_normalize.py
@@ -24,14 +24,14 @@ class TestNormalizeEditor(WidgetTest):
         self.assertIs(p.method, Normalize.Vector)
 
     def test_normalize_by_reference(self):
-        ref = SMALL_COLLAGEN[:1]
-        self.send_signal(OWPreprocess.Inputs.reference, ref)
+        reference = SMALL_COLLAGEN[:1]
+        self.send_signal(OWPreprocess.Inputs.reference, reference)
         self.editor._group.buttons()[3].click()
         self.widget.apply()
         out = self.get_output(OWPreprocess.Outputs.preprocessor)
         p = out.preprocessors[0]
         self.assertIsInstance(p, NormalizeReference)
-        self.assertIs(p.reference, ref)
+        self.assertIs(p.reference, reference)
 
     def test_normalize_by_reference_no_reference(self):
         self.editor._group.buttons()[3].click()
@@ -42,8 +42,8 @@ class TestNormalizeEditor(WidgetTest):
         self.assertIsNone(out)
 
     def test_normalize_by_reference_wrong_reference(self):
-        ref = SMALL_COLLAGEN[:2]
-        self.send_signal(OWPreprocess.Inputs.reference, ref)
+        reference = SMALL_COLLAGEN[:2]
+        self.send_signal(OWPreprocess.Inputs.reference, reference)
         self.editor._group.buttons()[3].click()
         self.widget.apply()
         self.assertTrue(self.widget.Error.applying.is_shown())

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -93,7 +93,7 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
 
 for p in [Absorbance, Transmittance]:
     # single reference
-    PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_edge_case_data_parameter(p, "ref", SMALL_COLLAGEN[0:1]))
+    PREPROCESSORS_INDEPENDENT_SAMPLES += list(add_edge_case_data_parameter(p, "reference", SMALL_COLLAGEN[0:1]))
 
 # EMSC with different kinds of reference
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(
@@ -291,8 +291,8 @@ class TestNormalizeReference(unittest.TestCase):
 
     def test_reference(self):
         data = Orange.data.Table([[2, 1, 3], [4, 2, 6]])
-        ref = data[:1]
-        p = NormalizeReference(reference=ref)(data)
+        reference = data[:1]
+        p = NormalizeReference(reference=reference)(data)
         np.testing.assert_almost_equal(p, [[1, 1, 1], [2, 2, 2]])
 
     def test_reference_exceptions(self):

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -91,7 +91,7 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
         p = class_(*args, **kwargs)
         # 5 is add_zeros
         if i == 5:
-            p.skip_unknown_no_propagate = True
+            p.skip_add_zeros = True
         yield p
 
 
@@ -347,7 +347,7 @@ class TestCommon(unittest.TestCase):
         for i in range(min(len(data), len(data.domain.attributes))):
             data.X[i, i] = np.nan
         for proc in PREPROCESSORS:
-            if hasattr(proc, "skip_unknown_no_propagate"):
+            if hasattr(proc, "skip_add_zeros"):
                 continue
             pdata = proc(data)
             sumnans = np.sum(np.isnan(pdata.X), axis=1)

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -86,9 +86,13 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
                 make_middle_nan(data_to_modify),
                 add_zeros(data_to_modify),
                 ]
-    for d in modified:
+    for i, d in enumerate(modified):
         kwargs[data_arg_name] = d
-        yield class_(*args, **kwargs)
+        p = class_(*args, **kwargs)
+        # 5 is add_zeros
+        if i == 5:
+            p.skip_unknown_no_propagate = True
+        yield p
 
 
 for p in [Absorbance, Transmittance]:
@@ -343,6 +347,8 @@ class TestCommon(unittest.TestCase):
         for i in range(min(len(data), len(data.domain.attributes))):
             data.X[i, i] = np.nan
         for proc in PREPROCESSORS:
+            if hasattr(proc, "skip_unknown_no_propagate"):
+                continue
             pdata = proc(data)
             sumnans = np.sum(np.isnan(pdata.X), axis=1)
             self.assertFalse(np.any(sumnans > 1), msg="Preprocessor " + str(proc))

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -637,10 +637,10 @@ class SpectralTransformEditor(BaseEditorOrange):
             return lambda data: data[:0]  # return an empty data table
         if reference:
             reference = reference[:1]
-        return transform(ref=reference)
+        return transform(reference=reference)
 
-    def set_reference_data(self, ref):
-        self.reference = ref
+    def set_reference_data(self, reference):
+        self.reference = reference
         self.update_reference_info()
 
     def update_reference_info(self):
@@ -817,8 +817,8 @@ class EMSCEditor(BaseEditorOrange):
         else:
             return EMSC(reference=reference, weights=weights, order=order, scaling=scaling, output_model=output_model)
 
-    def set_reference_data(self, ref):
-        self.reference = ref
+    def set_reference_data(self, reference):
+        self.reference = reference
         self.update_reference_info()
 
     def update_reference_info(self):
@@ -1463,8 +1463,8 @@ class SpectralPreprocessReference(SpectralPreprocess):
         reference = Input("Reference", Orange.data.Table)
 
     @Inputs.reference
-    def set_reference(self, ref):
-        self.reference_data = ref
+    def set_reference(self, reference):
+        self.reference_data = reference
 
 
 class OWPreprocess(SpectralPreprocessReference):


### PR DESCRIPTION
Part of #302 

- [x] Adding `replace_infs` around `np.log10()` made `divide_no_infs` redundant, so can probably be removed.
- [x] `test_unknown_no_propagate` fails now, since we introduce NaNs.
- [x] test_slightly_different_domain fails

Changed attribute name for Absorbance and Transmittance to "reference" to standardize naming (no longer needed in the PR but I left it in)