### PR TITLE
CurvePlot: fix select_at_least_1

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -457,3 +457,13 @@ class TestOWSpectra(WidgetTest):
         selected = self.get_output(OWSpectra.Outputs.selected_data)
         self.assertEqual(1, len(selected))
         self.assertEqual(self.iris[0], selected[0])
+
+    def test_new_data_clear_graph(self):
+        curveplot = self.widget.curveplot
+        curveplot.set_data(self.iris[:3], auto_update=False)
+        curveplot.update_view()
+        self.assertEqual(3, len(curveplot.curves[0][1]))
+        curveplot.set_data(self.iris[:3], auto_update=False)
+        self.assertEqual([], curveplot.curves)
+        curveplot.update_view()
+        self.assertEqual(3, len(curveplot.curves[0][1]))

--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -446,3 +446,14 @@ class TestOWSpectra(WidgetTest):
             curveplot.highlight(-1)
         with self.assertRaises(NoSuchCurve):
             curveplot.highlight(10)
+
+    def test_select_at_least_1(self):
+        self.widget.curveplot.select_at_least_1 = True
+        self.send_signal(OWSpectra.Inputs.data, self.iris[:3])
+        selected = self.get_output(OWSpectra.Outputs.selected_data)
+        self.assertEqual(1, len(selected))
+        self.assertEqual(self.iris[0], selected[0])
+        self.send_signal(OWSpectra.Inputs.data, self.iris[:2])
+        selected = self.get_output(OWSpectra.Outputs.selected_data)
+        self.assertEqual(1, len(selected))
+        self.assertEqual(self.iris[0], selected[0])

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1344,6 +1344,9 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
             self.data = data
 
+            # new data implies that the graph is outdated
+            self.clear_graph()
+
             self.restore_selection_settings()
 
             # get and sort input data

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -949,7 +949,10 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
             self.selection_group[data_indices] = selnum
             redraw_curve_indices.update(
                 icurve for idata, icurve in invd.items() if idata in data_indices_set)
-        self.make_selection_valid()
+
+        fixes = self.make_selection_valid()
+        redraw_curve_indices.update(
+            icurve for idata, icurve in invd.items() if idata in fixes)
 
         new_sel_ci = current_selection()
 
@@ -962,11 +965,12 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         self.selection_changed_confirm()
 
     def make_selection_valid(self):
+        """ Make the selection valid and return the changed positions. """
         if self.select_at_least_1 and not len(np.flatnonzero(self.selection_group)) \
                 and len(self.data) > 0:  # no selection
             self.selection_group[0] = 1
-            if 0 in self.sampled_indices_inverse:  # refresh if shown
-                self.set_curve_pens([self.sampled_indices_inverse[0]])
+            return set([0])
+        return set()
 
     def selection_changed_confirm(self):
         # reset average view; individual was already handled in make_selection


### PR DESCRIPTION
I introduced this bug with the thick/thin selected curve optimization.