### PR TITLE
[FIX] Fix rubberband (qhull) ValueError on all-NaN sample row

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -169,7 +169,7 @@ class _RubberbandBaselineCommon(CommonDomainOrder):
             source = source[~np.isnan(source).any(axis=1)]
             try:
                 v = ConvexHull(source).vertices
-            except QhullError:
+            except (QhullError, ValueError):
                 # FIXME notify user
                 baseline = np.zeros_like(row)
             else:

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -314,6 +314,13 @@ class TestCommon(unittest.TestCase):
         for proc in PREPROCESSORS:
             _ = proc(data)
 
+    def test_all_nans(self):
+        """ Preprocessors should not crash there are all-nan samples. """
+        data = self.collagen.copy()
+        data.X[0, :] = np.nan
+        for proc in PREPROCESSORS:
+            _ = proc(data)
+
     def test_unordered_features(self):
         data = self.collagen
         data_reversed = reverse_attr(data)


### PR DESCRIPTION
Includes test.

I didn't touch the "FIXME notify user" on this `Except` block because updating/improving the baseline subtraction editor is a rabbit-hole I don't have time for right now. Plus it's Friday afternoon :)