### PR TITLE
[FIX] Subtract DC value from IFG

### DIFF
--- a/orangecontrib/spectroscopy/irfft.py
+++ b/orangecontrib/spectroscopy/irfft.py
@@ -205,6 +205,9 @@ class IRFFT():
         else:
             self.zpd = find_zpd(ifg, self.peak_search)
 
+        # Subtract DC value from interferogram
+        ifg = ifg - ifg.mean()
+
         # Calculate phase on interferogram of specified size 2*L
         L = self.phase_ifg_size(ifg.shape[0])
         if L == 0: # Use full ifg for phase


### PR DESCRIPTION
I think simply subtracting the ifg.mean() should be OK as we can assume that the IFG is good quality, which will mean that the points at the DC level will be overwhelmingly more than the centerburst ones, which should be symmetric around the DC anyway.