### PR TITLE
[FIX] Multi file widget: fix showing wrong sheet

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owmultifile.py
+++ b/orangecontrib/spectroscopy/tests/test_owmultifile.py
@@ -17,11 +17,6 @@ from Orange.data.io import TabReader
 from orangecontrib.spectroscopy.data import SPAReader
 from orangecontrib.spectroscopy.widgets.owmultifile import OWMultifile, numpy_union_keep_order
 
-try:
-    import opusFC
-except ImportError:
-    opusFC = None
-
 
 class TestOWFilesAuxiliary(unittest.TestCase):
 
@@ -107,12 +102,6 @@ class TestOWMultifile(WidgetTest):
         self.widget.remove_item()
         out = self.get_output("Data")
         self.assertIsNone(out)
-
-    @unittest.skipIf(opusFC is None, "opusFC module not installed")
-    def test_sheet_file(self):
-        self.load_files("peach_juice.0")
-        self.widget.sheet_combo.setCurrentIndex(1)
-        self.widget.select_sheet()
 
     def test_saving_setting(self):
         self.load_files("iris")
@@ -258,3 +247,17 @@ class TestOWMultifile(WidgetTest):
             self.assertIsNone(self.get_output(OWMultifile.Outputs.data))
             self.assertEqual("Read error:\ntest", self.widget.lb.item(0).toolTip())
             self.assertEqual(Qt.red, self.widget.lb.item(0).foreground())
+
+    def test_sheet_setting(self):
+        self.load_files("rock.txt")
+        self.widget.sheet_combo.setCurrentIndex(2)
+        self.widget.select_sheet()
+        self.assertEqual(self.widget.sheet, "3")
+        out = self.get_output(OWMultifile.Outputs.data)
+        self.assertAlmostEqual(0.91213142, out.X[0][0])
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+        self.widget = self.create_widget(OWMultifile, stored_settings=settings)
+        self.assertEqual(self.widget.sheet, "3")
+        self.assertEqual(2, self.widget.sheet_combo.currentIndex())
+        out = self.get_output(OWMultifile.Outputs.data)
+        self.assertAlmostEqual(0.91213142, out.X[0][0])

--- a/orangecontrib/spectroscopy/widgets/owmultifile.py
+++ b/orangecontrib/spectroscopy/widgets/owmultifile.py
@@ -157,7 +157,6 @@ class OWMultifile(widget.OWWidget, RelocatablePathsWidgetMixin):
     sheet = Setting(None, schema_only=True)
     label = Setting("", schema_only=True)
     recent_paths = Setting([], schema_only=True)
-    xls_sheet = ContextSetting("", schema_only=True)
     variables = ContextSetting([], schema_only=True)
 
     class Error(widget.OWWidget.Error):
@@ -205,9 +204,9 @@ class OWMultifile(widget.OWWidget, RelocatablePathsWidgetMixin):
         layout.addWidget(reload_button, 0, 7)
 
         self.sheet_box = gui.hBox(None, addToLayout=False, margin=0)
-        self.sheet_combo = gui.comboBox(None, self, "xls_sheet",
-                                        callback=self.select_sheet,
-                                        sendSelectedValue=True)
+        self.sheet_index = 0
+        self.sheet_combo = gui.comboBox(None, self, "sheet_index",
+                                        callback=self.select_sheet)
         self.sheet_combo.setSizePolicy(
             Policy.MinimumExpanding, Policy.Fixed)
         self.sheet_label = QLabel()
@@ -471,4 +470,4 @@ def _get_reader(rp):
 if __name__ == "__main__":  # pragma: no cover
     # pylint: disable=ungrouped-imports
     from Orange.widgets.utils.widgetpreview import WidgetPreview
-    WidgetPreview(OWMultifile).run(Table("collagen.csv"))
+    WidgetPreview(OWMultifile).run()


### PR DESCRIPTION
The sheet combo box was linked to an used context setting which caused the combo box to show wrong value.  Hopefully fixes #266