### PR TITLE
[WIP][ENH] Block-view Binning Widget for hyperspectral images

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -1,0 +1,49 @@
+import numpy as np
+import Orange
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.spectroscopy.widgets.owbin import OWBin
+
+
+class TestOWBin(WidgetTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mosaic = Orange.data.Table("agilent/5_mosaic_agg1024.dmt")
+
+    def setUp(self):
+        self.widget = self.create_widget(OWBin)
+
+    def test_load_unload(self):
+        # just to load the widget (it has no inputs)
+        pass
+
+    def test_bin(self):
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
+        self.widget.bin_sqrt = 2
+        self.widget.commit()
+        m = self.get_output(OWBin.Outputs.bindata)
+        np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
+        x_coords = self.mosaic[:, "map_x"].metas[0:4, 0]
+        x_coords_binned = np.array([x_coords[0:2].mean(), x_coords[2:4].mean()])
+        np.testing.assert_equal(m[:, "map_x"].metas[0:2, 0], x_coords_binned)
+        y_coords = self.mosaic[:, "map_y"].metas[::4, 0]
+        y_coords_binned = np.array([y_coords[0:2].mean(), y_coords[2:4].mean(),
+                                    y_coords[4:6].mean(), y_coords[6:8].mean()])
+        np.testing.assert_equal(m[:, "map_y"].metas[::2, 0], y_coords_binned)
+
+    def test_invalid_bin(self):
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
+        self.widget.bin_sqrt = 3
+        self.widget._bin_changed()  # get warnings activated
+        self.widget.commit()
+        self.assertTrue(self.widget.Error.invalid_block.is_shown())
+        self.assertIsNone(self.get_output(OWBin.Outputs.bindata))
+
+    def test_invalid_axis(self):
+        data = self.mosaic.copy()
+        data.metas[:, 0] = np.nan
+        self.send_signal(OWBin.Inputs.data, data)
+        self.assertTrue(self.widget.Error.invalid_axis.is_shown())
+        self.send_signal(OWBin.Inputs.data, None)
+        self.assertFalse(self.widget.Error.invalid_axis.is_shown())

--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -35,7 +35,6 @@ class TestOWBin(WidgetTest):
     def test_invalid_bin(self):
         self.send_signal(OWBin.Inputs.data, self.mosaic)
         self.widget.bin_sqrt = 3
-        self.widget._bin_changed()  # get warnings activated
         self.widget.commit()
         self.assertTrue(self.widget.Error.invalid_block.is_shown())
         self.assertIsNone(self.get_output(OWBin.Outputs.bindata))

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -19,7 +19,6 @@ def get_coords(data, xat, yat):
 
     lsx = values_to_linspace(coorx)
     lsy = values_to_linspace(coory)
-    # lsz = data.X.shape[1]
 
     if lsx is None:
         raise InvalidAxisException("x")
@@ -35,8 +34,8 @@ def get_coords(data, xat, yat):
 
     if np.any(np.isnan(coords)):
         raise NanInsideHypercube(np.sum(np.isnan(coords)))
-    else:
-        return coords
+
+    return coords
 
 def bin_mean(data, bin_sqrt, n_attrs):
     try:
@@ -48,9 +47,8 @@ def bin_mean(data, bin_sqrt, n_attrs):
     return mean_view
 
 def bin_hypercube(in_data, xat, yat, bin_sqrt):
-    hypercube, lsx, lsy = get_hypercube(in_data, xat, yat)
+    hypercube, _, _ = get_hypercube(in_data, xat, yat)
     n_attrs = len(in_data.domain.attributes)
-    assert n_attrs == hypercube.shape[2]      # maybe -1?
     mean_view = bin_mean(hypercube, bin_sqrt, n_attrs)
 
     coords = get_coords(in_data, xat, yat)

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -6,6 +6,11 @@ from orangecontrib.spectroscopy.utils import index_values, values_to_linspace, \
     get_hypercube, NanInsideHypercube, InvalidAxisException
 from orangecontrib.spectroscopy.utils.skimage.shape import view_as_blocks
 
+
+class InvalidBlockShape(Exception):
+    pass
+
+
 def get_coords(data, xat, yat):
     ndom = Domain([xat, yat])
     datam = Table(ndom, data)
@@ -34,7 +39,10 @@ def get_coords(data, xat, yat):
         return coords
 
 def bin_mean(data, bin_sqrt, n_attrs):
-    view = view_as_blocks(data, block_shape=(bin_sqrt, bin_sqrt, n_attrs))
+    try:
+        view = view_as_blocks(data, block_shape=(bin_sqrt, bin_sqrt, n_attrs))
+    except ValueError as e:
+        raise InvalidBlockShape(str(e))
     flatten_view = view.reshape(view.shape[0], view.shape[1], -1, n_attrs)
     mean_view = np.mean(flatten_view, axis=2)
     return mean_view

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from Orange.data import Domain, Table
+
+from orangecontrib.spectroscopy.utils import index_values, values_to_linspace, \
+    get_hypercube, NanInsideHypercube, InvalidAxisException
+from orangecontrib.spectroscopy.utils.skimage.shape import view_as_blocks
+
+def get_coords(data, xat, yat):
+    ndom = Domain([xat, yat])
+    datam = Table(ndom, data)
+    coorx = datam.X[:, 0]
+    coory = datam.X[:, 1]
+
+    lsx = values_to_linspace(coorx)
+    lsy = values_to_linspace(coory)
+    # lsz = data.X.shape[1]
+
+    if lsx is None:
+        raise InvalidAxisException("x")
+    if lsy is None:
+        raise InvalidAxisException("y")
+
+    # set data
+    coords = np.ones((lsy[2], lsx[2], 2)) * np.nan
+
+    xindex = index_values(coorx, lsx)
+    yindex = index_values(coory, lsy)
+    coords[yindex, xindex] = datam.X
+
+    if np.any(np.isnan(coords)):
+        raise NanInsideHypercube(np.sum(np.isnan(coords)))
+    else:
+        return coords
+
+def bin_mean(data, bin_sqrt, n_attrs):
+    view = view_as_blocks(data, block_shape=(bin_sqrt, bin_sqrt, n_attrs))
+    flatten_view = view.reshape(view.shape[0], view.shape[1], -1, n_attrs)
+    mean_view = np.mean(flatten_view, axis=2)
+    return mean_view
+
+def bin_hypercube(in_data, xat, yat, bin_sqrt):
+    hypercube, lsx, lsy = get_hypercube(in_data, xat, yat)
+    n_attrs = len(in_data.domain.attributes)
+    assert n_attrs == hypercube.shape[2]      # maybe -1?
+    mean_view = bin_mean(hypercube, bin_sqrt, n_attrs)
+
+    coords = get_coords(in_data, xat, yat)
+    mean_coords = bin_mean(coords, bin_sqrt, 2)
+
+    table_view = mean_view.reshape(-1, n_attrs)
+    table_view_coords = mean_coords.reshape(-1, 2)
+
+    domain = Domain(in_data.domain.attributes, metas=[xat, yat])
+    return Table(domain, table_view, metas=table_view_coords)

--- a/orangecontrib/spectroscopy/utils/skimage/README.txt
+++ b/orangecontrib/spectroscopy/utils/skimage/README.txt
@@ -1,8 +1,9 @@
 This code was extracted from scikit-image to avoid another binary dependency:
 - register_translation.py: copied without changes.
+- shape.py: copied without changes (v0.15.0).
 
 
-Scikit-learn's licence follows.
+Scikit-image's licence follows.
 
 License (Modified BSD)
 Copyright (C) 2011, the scikit-image team All rights reserved.

--- a/orangecontrib/spectroscopy/utils/skimage/shape.py
+++ b/orangecontrib/spectroscopy/utils/skimage/shape.py
@@ -1,0 +1,263 @@
+import numbers
+import numpy as np
+from numpy.lib.stride_tricks import as_strided
+from warnings import warn
+
+__all__ = ['view_as_blocks', 'view_as_windows']
+
+
+def view_as_blocks(arr_in, block_shape):
+    """Block view of the input n-dimensional array (using re-striding).
+
+    Blocks are non-overlapping views of the input array.
+
+    Parameters
+    ----------
+    arr_in : ndarray
+        N-d input array.
+    block_shape : tuple
+        The shape of the block. Each dimension must divide evenly into the
+        corresponding dimensions of `arr_in`.
+
+    Returns
+    -------
+    arr_out : ndarray
+        Block view of the input array.  If `arr_in` is non-contiguous, a copy
+        is made.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.util.shape import view_as_blocks
+    >>> A = np.arange(4*4).reshape(4,4)
+    >>> A
+    array([[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15]])
+    >>> B = view_as_blocks(A, block_shape=(2, 2))
+    >>> B[0, 0]
+    array([[0, 1],
+           [4, 5]])
+    >>> B[0, 1]
+    array([[2, 3],
+           [6, 7]])
+    >>> B[1, 0, 1, 1]
+    13
+
+    >>> A = np.arange(4*4*6).reshape(4,4,6)
+    >>> A  # doctest: +NORMALIZE_WHITESPACE
+    array([[[ 0,  1,  2,  3,  4,  5],
+            [ 6,  7,  8,  9, 10, 11],
+            [12, 13, 14, 15, 16, 17],
+            [18, 19, 20, 21, 22, 23]],
+           [[24, 25, 26, 27, 28, 29],
+            [30, 31, 32, 33, 34, 35],
+            [36, 37, 38, 39, 40, 41],
+            [42, 43, 44, 45, 46, 47]],
+           [[48, 49, 50, 51, 52, 53],
+            [54, 55, 56, 57, 58, 59],
+            [60, 61, 62, 63, 64, 65],
+            [66, 67, 68, 69, 70, 71]],
+           [[72, 73, 74, 75, 76, 77],
+            [78, 79, 80, 81, 82, 83],
+            [84, 85, 86, 87, 88, 89],
+            [90, 91, 92, 93, 94, 95]]])
+    >>> B = view_as_blocks(A, block_shape=(1, 2, 2))
+    >>> B.shape
+    (4, 2, 3, 1, 2, 2)
+    >>> B[2:, 0, 2]  # doctest: +NORMALIZE_WHITESPACE
+    array([[[[52, 53],
+             [58, 59]]],
+           [[[76, 77],
+             [82, 83]]]])
+    """
+    if not isinstance(block_shape, tuple):
+        raise TypeError('block needs to be a tuple')
+
+    block_shape = np.array(block_shape)
+    if (block_shape <= 0).any():
+        raise ValueError("'block_shape' elements must be strictly positive")
+
+    if block_shape.size != arr_in.ndim:
+        raise ValueError("'block_shape' must have the same length "
+                         "as 'arr_in.shape'")
+
+    arr_shape = np.array(arr_in.shape)
+    if (arr_shape % block_shape).sum() != 0:
+        raise ValueError("'block_shape' is not compatible with 'arr_in'")
+
+    # -- restride the array to build the block view
+
+    if not arr_in.flags.contiguous:
+        warn(RuntimeWarning("Cannot provide views on a non-contiguous input "
+                            "array without copying."))
+
+    arr_in = np.ascontiguousarray(arr_in)
+
+    new_shape = tuple(arr_shape // block_shape) + tuple(block_shape)
+    new_strides = tuple(arr_in.strides * block_shape) + arr_in.strides
+
+    arr_out = as_strided(arr_in, shape=new_shape, strides=new_strides)
+
+    return arr_out
+
+
+def view_as_windows(arr_in, window_shape, step=1):
+    """Rolling window view of the input n-dimensional array.
+
+    Windows are overlapping views of the input array, with adjacent windows
+    shifted by a single row or column (or an index of a higher dimension).
+
+    Parameters
+    ----------
+    arr_in : ndarray
+        N-d input array.
+    window_shape : integer or tuple of length arr_in.ndim
+        Defines the shape of the elementary n-dimensional orthotope
+        (better know as hyperrectangle [1]_) of the rolling window view.
+        If an integer is given, the shape will be a hypercube of
+        sidelength given by its value.
+    step : integer or tuple of length arr_in.ndim
+        Indicates step size at which extraction shall be performed.
+        If integer is given, then the step is uniform in all dimensions.
+
+    Returns
+    -------
+    arr_out : ndarray
+        (rolling) window view of the input array.   If `arr_in` is
+        non-contiguous, a copy is made.
+
+    Notes
+    -----
+    One should be very careful with rolling views when it comes to
+    memory usage.  Indeed, although a 'view' has the same memory
+    footprint as its base array, the actual array that emerges when this
+    'view' is used in a computation is generally a (much) larger array
+    than the original, especially for 2-dimensional arrays and above.
+
+    For example, let us consider a 3 dimensional array of size (100,
+    100, 100) of ``float64``. This array takes about 8*100**3 Bytes for
+    storage which is just 8 MB. If one decides to build a rolling view
+    on this array with a window of (3, 3, 3) the hypothetical size of
+    the rolling view (if one was to reshape the view for example) would
+    be 8*(100-3+1)**3*3**3 which is about 203 MB! The scaling becomes
+    even worse as the dimension of the input array becomes larger.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Hyperrectangle
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.util.shape import view_as_windows
+    >>> A = np.arange(4*4).reshape(4,4)
+    >>> A
+    array([[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15]])
+    >>> window_shape = (2, 2)
+    >>> B = view_as_windows(A, window_shape)
+    >>> B[0, 0]
+    array([[0, 1],
+           [4, 5]])
+    >>> B[0, 1]
+    array([[1, 2],
+           [5, 6]])
+
+    >>> A = np.arange(10)
+    >>> A
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    >>> window_shape = (3,)
+    >>> B = view_as_windows(A, window_shape)
+    >>> B.shape
+    (8, 3)
+    >>> B
+    array([[0, 1, 2],
+           [1, 2, 3],
+           [2, 3, 4],
+           [3, 4, 5],
+           [4, 5, 6],
+           [5, 6, 7],
+           [6, 7, 8],
+           [7, 8, 9]])
+
+    >>> A = np.arange(5*4).reshape(5, 4)
+    >>> A
+    array([[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15],
+           [16, 17, 18, 19]])
+    >>> window_shape = (4, 3)
+    >>> B = view_as_windows(A, window_shape)
+    >>> B.shape
+    (2, 2, 4, 3)
+    >>> B  # doctest: +NORMALIZE_WHITESPACE
+    array([[[[ 0,  1,  2],
+             [ 4,  5,  6],
+             [ 8,  9, 10],
+             [12, 13, 14]],
+            [[ 1,  2,  3],
+             [ 5,  6,  7],
+             [ 9, 10, 11],
+             [13, 14, 15]]],
+           [[[ 4,  5,  6],
+             [ 8,  9, 10],
+             [12, 13, 14],
+             [16, 17, 18]],
+            [[ 5,  6,  7],
+             [ 9, 10, 11],
+             [13, 14, 15],
+             [17, 18, 19]]]])
+    """
+
+    # -- basic checks on arguments
+    if not isinstance(arr_in, np.ndarray):
+        raise TypeError("`arr_in` must be a numpy ndarray")
+
+    ndim = arr_in.ndim
+
+    if isinstance(window_shape, numbers.Number):
+        window_shape = (window_shape,) * ndim
+    if not (len(window_shape) == ndim):
+        raise ValueError("`window_shape` is incompatible with `arr_in.shape`")
+
+    if isinstance(step, numbers.Number):
+        if step < 1:
+            raise ValueError("`step` must be >= 1")
+        step = (step,) * ndim
+    if len(step) != ndim:
+        raise ValueError("`step` is incompatible with `arr_in.shape`")
+
+    arr_shape = np.array(arr_in.shape)
+    window_shape = np.array(window_shape, dtype=arr_shape.dtype)
+
+    if ((arr_shape - window_shape) < 0).any():
+        raise ValueError("`window_shape` is too large")
+
+    if ((window_shape - 1) < 0).any():
+        raise ValueError("`window_shape` is too small")
+
+    # -- build rolling window view
+    if not arr_in.flags.contiguous:
+        warn(RuntimeWarning("Cannot provide views on a non-contiguous input "
+                            "array without copying."))
+
+    arr_in = np.ascontiguousarray(arr_in)
+
+    slices = tuple(slice(None, None, st) for st in step)
+    window_strides = np.array(arr_in.strides)
+
+    indexing_strides = arr_in[slices].strides
+
+    win_indices_shape = (((np.array(arr_in.shape) - np.array(window_shape))
+                          // np.array(step)) + 1)
+
+    new_shape = tuple(list(win_indices_shape) + list(window_shape))
+    strides = tuple(list(indexing_strides) + list(window_strides))
+
+    arr_out = as_strided(arr_in, shape=new_shape, strides=strides)
+    return arr_out

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -1,0 +1,123 @@
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QLabel
+
+from Orange.data import Table, Domain, ContinuousVariable
+from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.widget import OWWidget, Input, Output, Msg
+from Orange.widgets import gui, settings
+
+from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
+
+class OWBin(OWWidget):
+    # Widget's name as displayed in the canvas
+    name = "Bin Data"
+
+    # Short widget description
+    description = (
+        "Bins a hyperspectral dataset by continous variable such as coordinates.")
+
+    icon = "icons/bin.svg"
+
+    # Define inputs and outputs
+    class Inputs:
+        data = Input("Hyperspectral Data", Table, default=True)
+
+    class Outputs:
+        bin_data = Output("Binned Data", Table, default=True)
+
+    class Error(OWWidget.Error):
+        nan_in_image = Msg("Unknown values within images: {} unknowns")
+        invalid_axis = Msg("Invalid axis: {}")
+
+    autocommit = settings.Setting(True)
+
+    want_main_area = False
+    want_control_area = True
+    resizing_enabled = False
+
+    settingsHandler = DomainContextHandler()
+
+    attr_x = ContextSetting(None)
+    attr_y = ContextSetting(None)
+    bin_sqrt = settings.Setting(1)
+
+    def __init__(self):
+        super().__init__()
+
+        self.data = None
+
+        box = gui.widgetBox(self.controlArea, "Axes")
+
+        common_options = dict(
+            labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True,
+            valueType=str)
+        self.xy_model = DomainModel(DomainModel.METAS | DomainModel.CLASSES,
+                                    valid_types=ContinuousVariable)
+        self.cb_attr_x = gui.comboBox(
+            box, self, "attr_x", label="Axis x:", callback=self._update_attr,
+            model=self.xy_model, **common_options)
+        self.cb_attr_y = gui.comboBox(
+            box, self, "attr_y", label="Axis y:", callback=self._update_attr,
+            model=self.xy_model, **common_options)
+
+        self.contextAboutToBeOpened.connect(self._init_interface_data)
+
+        box = gui.widgetBox(self.controlArea, "Parameters")
+
+        gui.separator(box)
+        hbox = gui.hBox(box)
+        self.le1 = lineEditIntRange(box, self, "bin_sqrt", bottom=1, default=1,
+                                    callback=self._bin_changed)
+        hbox.layout().addWidget(QLabel("Bin size:", self))
+        hbox.layout().addWidget(self.le1)
+
+        gui.rubber(self.controlArea)
+
+        gui.auto_commit(self.controlArea, self, "autocommit", "Send Data")
+
+
+    def _sanitize_bin_value(self):
+        pass #TODO make sure bin value is compatible with dataset
+
+    def _bin_changed(self):
+        self._sanitize_bin_value()
+        self.commit()
+
+    def _init_attr_values(self, data):
+        domain = data.domain if data is not None else None
+        self.xy_model.set_domain(domain)
+        self.attr_x = self.xy_model[0] if self.xy_model else None
+        self.attr_y = self.xy_model[1] if len(self.xy_model) >= 2 \
+            else self.attr_x
+
+    def _init_interface_data(self, args):
+        data = args[0]
+        same_domain = (self.data and data and
+                       data.domain == self.data.domain)
+        if not same_domain:
+            self._init_attr_values(data)
+
+    def _update_attr(self):
+        self.commit()
+
+    @Inputs.data
+    def set_data(self, dataset):
+        self.closeContext()
+        self.openContext(dataset)
+        if dataset is not None:
+            self.data = dataset
+            self._sanitize_bin_value()
+        else:
+            self.data = None
+        self.Error.nan_in_image.clear()
+        self.Error.invalid_axis.clear()
+        self.commit()
+
+    def commit(self):
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from Orange.widgets.utils.widgetpreview import WidgetPreview
+    WidgetPreview(OWBin).run(Table("agilent/5_mosaic_agg1024.dmt"))

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -25,7 +25,7 @@ class OWBin(OWWidget):
 
     # Define inputs and outputs
     class Inputs:
-        data = Input("Hyperspectral Data", Table, default=True)
+        data = Input("Data", Table, default=True)
 
     class Outputs:
         bindata = Output("Binned Data", Table, default=True)

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -1,11 +1,10 @@
-import numpy as np
-
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QLabel
 
-from Orange.data import Table, Domain, ContinuousVariable
+from Orange.data import Table, ContinuousVariable
 from Orange.widgets.settings import DomainContextHandler, ContextSetting
 from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 from Orange.widgets import gui, settings
 
@@ -130,7 +129,7 @@ class OWBin(OWWidget):
         if self.data and len(self.data.domain.attributes) and self.attr_x and self.attr_y:
             try:
                 bin_data = bin_hypercube(self.data, self.attr_x, self.attr_y,
-                                                  bin_sqrt=self.bin_sqrt)
+                                         bin_sqrt=self.bin_sqrt)
             except NanInsideHypercube as e:
                 self.Error.nan_in_image(e.args[0])
             except InvalidAxisException as e:
@@ -142,5 +141,4 @@ class OWBin(OWWidget):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from Orange.widgets.utils.widgetpreview import WidgetPreview
     WidgetPreview(OWBin).run(Table("agilent/5_mosaic_agg1024.dmt"))

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -10,7 +10,7 @@ from Orange.widgets.widget import OWWidget, Input, Output, Msg
 from Orange.widgets import gui, settings
 
 from orangecontrib.spectroscopy.utils import NanInsideHypercube, InvalidAxisException
-from orangecontrib.spectroscopy.utils.binning import bin_hypercube
+from orangecontrib.spectroscopy.utils.binning import bin_hypercube, InvalidBlockShape
 from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
 
 class OWBin(OWWidget):
@@ -33,6 +33,7 @@ class OWBin(OWWidget):
     class Error(OWWidget.Error):
         nan_in_image = Msg("Unknown values within images: {} unknowns")
         invalid_axis = Msg("Invalid axis: {}")
+        invalid_block = Msg("Bin block size not compatible with dataset: {}")
 
     autocommit = settings.Setting(True)
 
@@ -116,6 +117,7 @@ class OWBin(OWWidget):
             self.data = None
         self.Error.nan_in_image.clear()
         self.Error.invalid_axis.clear()
+        self.Error.invalid_block.clear()
         self.commit()
 
     def commit(self):
@@ -123,6 +125,7 @@ class OWBin(OWWidget):
 
         self.Error.nan_in_image.clear()
         self.Error.invalid_axis.clear()
+        self.Error.invalid_block.clear()
 
         if self.data and len(self.data.domain.attributes) and self.attr_x and self.attr_y:
             try:
@@ -132,9 +135,8 @@ class OWBin(OWWidget):
                 self.Error.nan_in_image(e.args[0])
             except InvalidAxisException as e:
                 self.Error.invalid_axis(e.args[0])
-            except ValueError:
-                # TODO this should be better with warning, etc
-                self.bin_sqrt = 1
+            except InvalidBlockShape as e:
+                self.Error.invalid_block(e.args[0])
 
         self.Outputs.bindata.send(bin_data)
 

--- a/pylintrc
+++ b/pylintrc
@@ -10,6 +10,7 @@
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
+ignore-patterns=**/skimage/**/*.py
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
Simple block-view binning widget. This first version hard-codes assumptions that the hyperspectral data of interest is a hyperspectral cube from imaging data and that binning blocks are square.

In future should be n-dim or at least support 1-3 binning dimensions.

![owbin](https://user-images.githubusercontent.com/19228847/56838033-e1aac300-6839-11e9-8c6a-8344b5b5bae7.png)

Uses code in #331 

- [ ] Change widget name to "Binning"
- [ ] Add icon
- [ ] Documentation
- [ ] Replace nan hypercube error with nanmean and warning
- [ ] generalize block shape?