### PR TITLE
[FIX] Fix handling rows with all-NaN values

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -577,8 +577,17 @@ class _ExtractEXAFSCommon(CommonDomain):
         X, nans = nan_extend_edges_and_interpolate(xs[xsind], X)
         # TODO notify the user if some unknown values were interpolated
 
+        # Replace remaining NaNs (where whole rows were NaN) with
+        # with some values so that the function does not crash.
+        # Results are going to be discarded later.
+        nan_rows = np.isnan(X).all(axis=1)
+        X[nan_rows] = 1.
+
         # do the transformation
         X = self.transformed(X, xs[xsind], I_jumps)
+
+        # discard nan rows
+        X[nan_rows] = np.nan
 
         # k scores are always ordered, so do not restore order
         return X

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -114,6 +114,11 @@ class CommonDomainOrderUnknowns(CommonDomainOrder):
         # interpolates unknowns
         X, nans = nan_extend_edges_and_interpolate(xs[xsind], X)
 
+        # Replace remaining NaNs (where whole rows were NaN) with
+        # with some values so that the function does not crash.
+        # Results are going to be discarded later.
+        X[np.isnan(X)] = 1.
+
         # do the transformation
         X = self.transformed(X, xs[xsind])
 


### PR DESCRIPTION
CommonDomainOrderUnknowns: do not pass NaN rows further

Fixes error with EMSC on my machine on all_nans test:
  File "/Users/marko/anaconda3/lib/python3.6/site-packages/numpy/linalg/linalg.py", line 2156, in lstsq
    x, resids, rank, s = gufunc(a, b, rcond, signature=signature, extobj=extobj)
ValueError: On entry to DGELSD parameter number 6 had an illegal value

Fixes error with EXAFS on built packages on all_nans test:
ValueError: array must not contain infs or NaNs