### PR TITLE
[ENH] Hypercube: separate nan handling

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -46,3 +46,11 @@ class TestOWBin(WidgetTest):
         self.assertTrue(self.widget.Error.invalid_axis.is_shown())
         self.send_signal(OWBin.Inputs.data, None)
         self.assertFalse(self.widget.Error.invalid_axis.is_shown())
+
+    def test_nan_in_image(self):
+        data = self.mosaic.copy()
+        data.X[1, 2] = np.nan
+        self.send_signal(OWBin.Inputs.data, data)
+        self.assertTrue(self.widget.Warning.nan_in_image.is_shown())
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
+        self.assertFalse(self.widget.Warning.nan_in_image.is_shown())

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -94,7 +94,4 @@ def get_hypercube(data, xat, yat):
     yindex = index_values(coory, lsy)
     hypercube[yindex, xindex] = data.X
 
-    if np.any(np.isnan(hypercube)):
-        raise NanInsideHypercube(np.sum(np.isnan(hypercube)))
-
     return hypercube, lsx, lsy

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -32,9 +32,6 @@ def get_coords(data, xat, yat):
     yindex = index_values(coory, lsy)
     coords[yindex, xindex] = datam.X
 
-    if np.any(np.isnan(coords)):
-        raise NanInsideHypercube(np.sum(np.isnan(coords)))
-
     return coords
 
 def bin_mean(data, bin_sqrt, n_attrs):
@@ -43,7 +40,7 @@ def bin_mean(data, bin_sqrt, n_attrs):
     except ValueError as e:
         raise InvalidBlockShape(str(e))
     flatten_view = view.reshape(view.shape[0], view.shape[1], -1, n_attrs)
-    mean_view = np.mean(flatten_view, axis=2)
+    mean_view = np.nanmean(flatten_view, axis=2)
     return mean_view
 
 def bin_hypercube(in_data, xat, yat, bin_sqrt):

--- a/orangecontrib/spectroscopy/widgets/owstackalign.py
+++ b/orangecontrib/spectroscopy/widgets/owstackalign.py
@@ -77,6 +77,8 @@ def alignstack(raw, shiftfn, ref_frame_num=0, filterfn=lambda x: x):
 
 def process_stack(data, xat, yat, upsample_factor=100, use_sobel=False, ref_frame_num=0):
     hypercube, lsx, lsy = get_hypercube(data, xat, yat)
+    if np.any(np.isnan(hypercube)):
+        raise NanInsideHypercube(np.sum(np.isnan(hypercube)))
 
     calculate_shift = RegisterTranslation(upsample_factor=upsample_factor)
     filterfn = sobel if use_sobel else lambda x: x


### PR DESCRIPTION
This PR 

- moves the NanInsideHypercube exception back out of the get_hypercube utility function
- changes the behaviour of the OWBin widget to produce nanmean binned data and warn the user instead of erroring