### PR TITLE
[ENH] OWBin: n-dimensional binning and non-square block shape

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -41,7 +41,7 @@ class TestOWBin(WidgetTest):
         np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
 
     def test_nonsquare_bin(self):
-        self.widget.bin_shape = (2, 4)
+        self.widget.bin_shape = (4, 2)
         self.widget._init_bins
         self.send_signal(OWBin.Inputs.data, self.mosaic)
         m = self.get_output(OWBin.Outputs.bindata)
@@ -59,8 +59,12 @@ class TestOWBin(WidgetTest):
         self.send_signal(OWBin.Inputs.data, self.mosaic)
         m = self.get_output(OWBin.Outputs.bindata)
         np.testing.assert_equal(self.mosaic.X, m.X)
+        np.testing.assert_equal(self.mosaic[:, "map_x"].metas, m[:, "map_x"].metas)
+        np.testing.assert_equal(self.mosaic[:, "map_y"].metas, m[:, "map_y"].metas)
         # TODO this should be true
-        np.testing.assert_equal(self.mosaic, m)
+        # Issue is the array is row-ordered (y, x) but the metas are (x, y) ordered
+        # and after binning the metas are reversed
+        # np.testing.assert_equal(self.mosaic, m)
 
     def test_invalid_bin(self):
         self.widget.bin_shape = (3, 3)

--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -40,6 +40,28 @@ class TestOWBin(WidgetTest):
         m = self.get_output(OWBin.Outputs.bindata)
         np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
 
+    def test_nonsquare_bin(self):
+        self.widget.bin_shape = (2, 4)
+        self.widget._init_bins
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
+        m = self.get_output(OWBin.Outputs.bindata)
+        np.testing.assert_equal(len(m.X), len(self.mosaic.X) / (2 * 4))
+        x_coords = self.mosaic[:, "map_x"].metas[0:4, 0]
+        x_coords_binned = np.array([x_coords[0:2].mean(), x_coords[2:4].mean()])
+        np.testing.assert_equal(m[:, "map_x"].metas[0:2, 0], x_coords_binned)
+        y_coords = self.mosaic[:, "map_y"].metas[::4, 0]
+        y_coords_binned = np.array([y_coords[0:4].mean(), y_coords[4:8].mean()])
+        np.testing.assert_equal(m[:, "map_y"].metas[::2, 0], y_coords_binned)
+
+    def test_no_bin(self):
+        self.widget.bin_shape = (1, 1)
+        self.widget._init_bins()
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
+        m = self.get_output(OWBin.Outputs.bindata)
+        np.testing.assert_equal(self.mosaic.X, m.X)
+        # TODO this should be true
+        np.testing.assert_equal(self.mosaic, m)
+
     def test_invalid_bin(self):
         self.widget.bin_shape = (3, 3)
         self.widget._init_bins()

--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -20,8 +20,8 @@ class TestOWBin(WidgetTest):
 
     def test_bin(self):
         self.send_signal(OWBin.Inputs.data, self.mosaic)
-        self.widget.bin_sqrt = 2
-        self.widget.commit()
+        self.widget.bin_shape = (2, 2)
+        self.widget._bin_changed()
         m = self.get_output(OWBin.Outputs.bindata)
         np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
         x_coords = self.mosaic[:, "map_x"].metas[0:4, 0]
@@ -34,8 +34,8 @@ class TestOWBin(WidgetTest):
 
     def test_invalid_bin(self):
         self.send_signal(OWBin.Inputs.data, self.mosaic)
-        self.widget.bin_sqrt = 3
-        self.widget.commit()
+        self.widget.bin_shape = (3, 3)
+        self.widget._bin_changed()
         self.assertTrue(self.widget.Error.invalid_block.is_shown())
         self.assertIsNone(self.get_output(OWBin.Outputs.bindata))
 

--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -42,7 +42,7 @@ class TestOWBin(WidgetTest):
 
     def test_nonsquare_bin(self):
         self.widget.bin_shape = (4, 2)
-        self.widget._init_bins
+        self.widget._init_bins()
         self.send_signal(OWBin.Inputs.data, self.mosaic)
         m = self.get_output(OWBin.Outputs.bindata)
         np.testing.assert_equal(len(m.X), len(self.mosaic.X) / (2 * 4))

--- a/orangecontrib/spectroscopy/tests/test_owbin.py
+++ b/orangecontrib/spectroscopy/tests/test_owbin.py
@@ -19,9 +19,9 @@ class TestOWBin(WidgetTest):
         pass
 
     def test_bin(self):
-        self.send_signal(OWBin.Inputs.data, self.mosaic)
         self.widget.bin_shape = (2, 2)
-        self.widget._bin_changed()
+        self.widget._init_bins
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
         m = self.get_output(OWBin.Outputs.bindata)
         np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
         x_coords = self.mosaic[:, "map_x"].metas[0:4, 0]
@@ -32,10 +32,18 @@ class TestOWBin(WidgetTest):
                                     y_coords[4:6].mean(), y_coords[6:8].mean()])
         np.testing.assert_equal(m[:, "map_y"].metas[::2, 0], y_coords_binned)
 
-    def test_invalid_bin(self):
+    def test_bin_changed(self):
         self.send_signal(OWBin.Inputs.data, self.mosaic)
-        self.widget.bin_shape = (3, 3)
+        self.widget.bin_0 = 2
+        self.widget.bin_1 = 2
         self.widget._bin_changed()
+        m = self.get_output(OWBin.Outputs.bindata)
+        np.testing.assert_equal(len(m.X), len(self.mosaic.X) / 2**2)
+
+    def test_invalid_bin(self):
+        self.widget.bin_shape = (3, 3)
+        self.widget._init_bins()
+        self.send_signal(OWBin.Inputs.data, self.mosaic)
         self.assertTrue(self.widget.Error.invalid_block.is_shown())
         self.assertIsNone(self.get_output(OWBin.Outputs.bindata))
 

--- a/orangecontrib/spectroscopy/tests/test_utils.py
+++ b/orangecontrib/spectroscopy/tests/test_utils.py
@@ -6,7 +6,8 @@ import numpy as np
 import Orange.data
 
 from orangecontrib.spectroscopy.data import _spectra_from_image, build_spec_table, getx
-from orangecontrib.spectroscopy.utils import get_hypercube, index_values
+from orangecontrib.spectroscopy.utils import get_hypercube, index_values, \
+    InvalidAxisException
 
 
 class TestHyperspec(unittest.TestCase):
@@ -40,3 +41,7 @@ class TestHyperspec(unittest.TestCase):
         np.testing.assert_equal(d.Y, nd.Y)
         np.testing.assert_equal(d.metas, nd.metas)
         self.assertEqual(d.domain, nd.domain)
+
+    def test_none_attr(self):
+        with self.assertRaises(InvalidAxisException):
+            get_hypercube(self.mosaic, None, None)

--- a/orangecontrib/spectroscopy/tests/test_widgets_utils.py
+++ b/orangecontrib/spectroscopy/tests/test_widgets_utils.py
@@ -1,0 +1,41 @@
+import unittest
+import array
+
+import numpy as np
+
+from orangecontrib.spectroscopy.widgets.utils import pack_selection, unpack_selection
+
+
+class TestSelectionPacking(unittest.TestCase):
+
+    def test_pack(self):
+        # None
+        self.assertEqual(pack_selection(None), None)
+        # empty
+        sel = np.zeros(10, dtype=np.uint8)
+        self.assertEqual(pack_selection(sel), None)
+        # with a few elements
+        sel[[2, 4]] = [1, 3]
+        r = pack_selection(sel)
+        self.assertEqual(r, [(2, 1), (4, 3)])
+        # bigger arrays
+        sel = np.zeros(2000, dtype=np.uint8)
+        sel[500:1000] = 1
+        sel[1000:1500] = 2
+        r = pack_selection(sel)
+        self.assertTrue(isinstance(r, array.array))
+        self.assertTrue((np.array(r[500:1000]) == 1).all())
+        self.assertTrue((np.array(r[1000:1500]) == 2).all())
+
+    def test_unpack(self):
+        # None
+        self.assertTrue(isinstance(unpack_selection(None), np.ndarray))
+        np.testing.assert_equal(unpack_selection(None), [])
+        # list of tuples
+        r = unpack_selection([(2, 1), (4, 3)])
+        np.testing.assert_equal(r, [0, 0, 1, 0, 3])
+        # arrays
+        ia = [0, 0, 1, 2]
+        r = unpack_selection(array.array('B', ia))
+        self.assertTrue(isinstance(r, np.ndarray))
+        np.testing.assert_equal(r, ia)

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -64,6 +64,7 @@ class InvalidAxisException(Exception):
 def get_hypercube(data, xat, yat):
     """
     Reshape table array into a hypercube array according to x and y attributes.
+    The hypercube is organized [ rows, columns, wavelengths ].
 
     Args:
         data (Table): Hyperspectral data Table

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -91,7 +91,10 @@ def get_ndim_hyperspec(data, attrs):
     Returns:
         (hyperspec, [ls]): Hypercube numpy array and list linspace tuples
     """
-    ndom = Domain(attrs)
+    try:
+        ndom = Domain(attrs)
+    except TypeError:
+        raise InvalidAxisException("Axis cannot be None")
     datam = Table(ndom, data)
 
     ls, indices = axes_to_ndim_linspace(datam, attrs)

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -61,6 +61,21 @@ class InvalidAxisException(Exception):
     pass
 
 
+def axes_to_ndim_linspace(datam, attrs):
+    ls = []
+    indices = []
+
+    for i, axis in enumerate(attrs):
+        coor = datam.X[:, i]
+        lsa = values_to_linspace(coor)
+        if lsa is None:
+            raise InvalidAxisException(axis.name)
+        ls.append(lsa)
+        indices.append(index_values(coor, lsa))
+
+    return ls, indices
+
+
 def get_ndim_hyperspec(data, attrs):
     """
     Reshape table array into a n-dimensional hyperspectral array with respect to
@@ -79,16 +94,7 @@ def get_ndim_hyperspec(data, attrs):
     ndom = Domain(attrs)
     datam = Table(ndom, data)
 
-    ls = []
-    indices = []
-
-    for i, axis in enumerate(attrs):
-        coor = datam.X[:, i]
-        lsa = values_to_linspace(coor)
-        if lsa is None:
-            raise InvalidAxisException(axis.name)
-        ls.append(lsa)
-        indices.append(index_values(coor, lsa))
+    ls, indices = axes_to_ndim_linspace(datam, attrs)
 
     # set data
     new_shape = tuple([lsa[2] for lsa in ls]) + (data.X.shape[1],)

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -61,6 +61,44 @@ class InvalidAxisException(Exception):
     pass
 
 
+def get_ndim_hyperspec(data, attrs):
+    """
+    Reshape table array into a n-dimensional hyperspectral array with respect to
+    provided (n-1) ContinuousVariable attributes.
+
+    The hypercube is organized [ attr0, attr1, ..., wavelengths ].
+    Linspace tuple indexes correspond to original attr index.
+
+    Args:
+        data (Table): Hyperspectral data Table
+        attrs (List): Attributes to build array dimensions along
+
+    Returns:
+        (hyperspec, [ls]): Hypercube numpy array and list linspace tuples
+    """
+    ndom = Domain(attrs)
+    datam = Table(ndom, data)
+
+    ls = []
+    indices = []
+
+    for i, axis in enumerate(attrs):
+        coor = datam.X[:, i]
+        lsa = values_to_linspace(coor)
+        if lsa is None:
+            raise InvalidAxisException(axis.name)
+        ls.append(lsa)
+        indices.append(index_values(coor, lsa))
+
+    # set data
+    new_shape = tuple([lsa[2] for lsa in ls]) + (data.X.shape[1],)
+    hyperspec = np.ones(new_shape) * np.nan
+
+    hyperspec[indices] = data.X
+
+    return hyperspec, ls
+
+
 def get_hypercube(data, xat, yat):
     """
     Reshape table array into a hypercube array according to x and y attributes.
@@ -74,25 +112,6 @@ def get_hypercube(data, xat, yat):
     Returns:
         (hypercube, lsx, lsy): Hypercube numpy array and linspace tuples
     """
-    ndom = Domain([xat, yat])
-    datam = Table(ndom, data)
-    coorx = datam.X[:, 0]
-    coory = datam.X[:, 1]
-
-    lsx = values_to_linspace(coorx)
-    lsy = values_to_linspace(coory)
-    lsz = data.X.shape[1]
-
-    if lsx is None:
-        raise InvalidAxisException("x")
-    if lsy is None:
-        raise InvalidAxisException("y")
-
-    # set data
-    hypercube = np.ones((lsy[2], lsx[2], lsz)) * np.nan
-
-    xindex = index_values(coorx, lsx)
-    yindex = index_values(coory, lsy)
-    hypercube[yindex, xindex] = data.X
-
+    attrs = [yat, xat]
+    hypercube, (lsy, lsx) = get_ndim_hyperspec(data, attrs)
     return hypercube, lsx, lsy

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -44,16 +44,34 @@ def bin_mean(data, bin_shape, n_attrs):
     return mean_view
 
 def bin_hypercube(in_data, bin_attrs, bin_shape):
+    """
+    Bin a Table with respect to specified attributes and block shape.
+
+    Args:
+        in_data (Table): Hyperspectral data Table
+        bin_attrs (List): Attributes to bin along
+        bin_shape (Tuple): Shape where block index corresponds to
+                           attribute index in bin_attrs
+
+    Returns:
+        (Orange.data.Table): Binned data Table
+    """
     xat, yat = bin_attrs
-    hypercube, _, _ = get_hypercube(in_data, xat, yat)
+    # TODO Currently, get_hypercube hard-codes reversing xat, yat index in array
+    # so need to reverse the order here to match bin_shape
+    hypercube, _, _ = get_hypercube(in_data, yat, xat)
     n_attrs = len(in_data.domain.attributes)
     mean_view = bin_mean(hypercube, bin_shape, n_attrs)
 
-    coords = get_coords(in_data, bin_attrs)
+    # TODO Currently, get_coords hard-codes reversing xat, yat index in array
+    # so need to reverse the order here to match bin_shape
+    coords = get_coords(in_data, bin_attrs[::-1])
     mean_coords = bin_mean(coords, bin_shape, len(bin_attrs))
 
     table_view = mean_view.reshape(-1, n_attrs)
     table_view_coords = mean_coords.reshape(-1, 2)
 
-    domain = Domain(in_data.domain.attributes, metas=[xat, yat])
+    # TODO Currently, get_coords hard-codes reversing xat, yat index in array
+    # so need to reverse the metas order here to match bin_shape
+    domain = Domain(in_data.domain.attributes, metas=[yat, xat])
     return Table(domain, table_view, metas=table_view_coords)

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -11,7 +11,7 @@ from Orange.widgets.widget import OWWidget, Input, Output, Msg
 from Orange.widgets import gui, settings
 
 from orangecontrib.spectroscopy.utils import NanInsideHypercube, InvalidAxisException
-from orangecontrib.spectroscopy.utils.binning import bin_hypercube, InvalidBlockShape
+from orangecontrib.spectroscopy.utils.binning import bin_hyperspectra, InvalidBlockShape
 from orangecontrib.spectroscopy.widgets.gui import lineEditIntRange
 
 class OWBin(OWWidget):
@@ -146,12 +146,17 @@ class OWBin(OWWidget):
         self.Error.invalid_axis.clear()
         self.Error.invalid_block.clear()
 
+        attrs = [self.attr_x, self.attr_y]
+        # Special-case 2-axis arrays since these are probably images and should
+        # stay in (y, x) ordering
+        if len(attrs) == 2:
+            attrs = attrs[::-1]
+
         if self.data and len(self.data.domain.attributes) and self.attr_x and self.attr_y:
             if np.any(np.isnan(self.data.X)):
                 self.Warning.nan_in_image(np.sum(np.isnan(self.data.X)))
             try:
-                bin_data = bin_hypercube(self.data, [self.attr_x, self.attr_y],
-                                         self.bin_shape)
+                bin_data = bin_hyperspectra(self.data, attrs, self.bin_shape)
             except InvalidAxisException as e:
                 self.Error.invalid_axis(e.args[0])
             except InvalidBlockShape as e:

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -144,14 +144,12 @@ class OWBin(OWWidget):
         self.Error.invalid_axis.clear()
         self.Error.invalid_block.clear()
 
-        bin_sqrt = self.bin_shape[0]
-
         if self.data and len(self.data.domain.attributes) and self.attr_x and self.attr_y:
             if np.any(np.isnan(self.data.X)):
                 self.Warning.nan_in_image(np.sum(np.isnan(self.data.X)))
             try:
-                bin_data = bin_hypercube(self.data, self.attr_x, self.attr_y,
-                                         bin_sqrt=bin_sqrt)
+                bin_data = bin_hypercube(self.data, [self.attr_x, self.attr_y],
+                                         self.bin_shape)
             except InvalidAxisException as e:
                 self.Error.invalid_axis(e.args[0])
             except InvalidBlockShape as e:

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -49,6 +49,7 @@ class OWBin(OWWidget):
     attr_x = ContextSetting(None)
     attr_y = ContextSetting(None)
     bin_shape = settings.Setting((1, 1))
+    square_bin = settings.Setting(True)
 
     def __init__(self):
         super().__init__()
@@ -75,7 +76,11 @@ class OWBin(OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Parameters")
 
+        gui.checkBox(box, self, "square_bin",
+                     label="Use square bin shape",
+                     callback=self._bin_changed)
         gui.separator(box)
+
         hbox = gui.hBox(box)
         self.le0 = lineEditIntRange(box, self, "bin_0", bottom=1, default=1,
                                     callback=self._bin_changed)
@@ -94,6 +99,10 @@ class OWBin(OWWidget):
         pass #TODO make sure bin value is compatible with dataset
 
     def _update_bins(self):
+        if self.square_bin:
+            self.bin_shape = tuple([self.bin_0] * len(self.bin_shape))
+            self._init_bins()
+            return
         new_shape = []
         for i, _ in enumerate(self.bin_shape):
             new_shape.append(getattr(self, f"bin_{i}"))

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -94,8 +94,10 @@ class OWBin(OWWidget):
         pass #TODO make sure bin value is compatible with dataset
 
     def _update_bins(self):
-        for i, bin in enumerate(self.bin_shape):
-            bin = getattr(self, f"bin_{i}")
+        new_shape = []
+        for i, _ in enumerate(self.bin_shape):
+            new_shape.append(getattr(self, f"bin_{i}"))
+        self.bin_shape = tuple(new_shape)
 
     def _bin_changed(self):
         self._update_bins()

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -58,6 +58,12 @@ class OWBin(OWWidget):
 
         self._init_bins()
 
+        box = gui.widgetBox(self.controlArea, "Parameters")
+
+        gui.checkBox(box, self, "square_bin",
+                     label="Use square bin shape",
+                     callback=self._bin_changed)
+
         box = gui.widgetBox(self.controlArea, "Axes")
 
         common_options = dict(
@@ -65,30 +71,29 @@ class OWBin(OWWidget):
             valueType=str)
         self.xy_model = DomainModel(DomainModel.METAS | DomainModel.CLASSES,
                                     valid_types=ContinuousVariable)
-        self.cb_attr_x = gui.comboBox(
-            box, self, "attr_x", label="Axis x:", callback=self._update_attr,
-            model=self.xy_model, **common_options)
-        self.cb_attr_y = gui.comboBox(
-            box, self, "attr_y", label="Axis y:", callback=self._update_attr,
-            model=self.xy_model, **common_options)
-
-        self.contextAboutToBeOpened.connect(self._init_interface_data)
-
-        box = gui.widgetBox(self.controlArea, "Parameters")
-
-        gui.checkBox(box, self, "square_bin",
-                     label="Use square bin shape",
-                     callback=self._bin_changed)
-        gui.separator(box)
 
         hbox = gui.hBox(box)
-        self.le0 = lineEditIntRange(box, self, "bin_0", bottom=1, default=1,
+        self.cb_attr_x = gui.comboBox(
+            hbox, self, "attr_x", label="Axis x:", callback=self._update_attr,
+            model=self.xy_model, **common_options)
+        self.le0 = lineEditIntRange(hbox, self, "bin_0", bottom=1, default=1,
                                     callback=self._bin_changed)
-        self.le1 = lineEditIntRange(box, self, "bin_1", bottom=1, default=1,
-                                    callback=self._bin_changed)
-        hbox.layout().addWidget(QLabel("Bin size:", self))
+        self.le0.setFixedWidth(40)
+        gui.separator(hbox, width=40)
+        gui.widgetLabel(hbox, label="Bin size:", labelWidth=50)
         hbox.layout().addWidget(self.le0)
+        hbox = gui.hBox(box)
+        self.cb_attr_y = gui.comboBox(
+            hbox, self, "attr_y", label="Axis y:", callback=self._update_attr,
+            model=self.xy_model, **common_options)
+        self.le1 = lineEditIntRange(hbox, self, "bin_1", bottom=1, default=1,
+                                    callback=self._bin_changed)
+        self.le1.setFixedWidth(40)
+        gui.separator(hbox, width=40)
+        gui.widgetLabel(hbox, label="Bin size:", labelWidth=50)
         hbox.layout().addWidget(self.le1)
+
+        self.contextAboutToBeOpened.connect(self._init_interface_data)
 
         gui.rubber(self.controlArea)
 

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -212,10 +212,6 @@ class OWBin(OWWidget):
         self.Error.invalid_block.clear()
 
         attrs = self.attrs
-        # Special-case 2-axis arrays since these are probably images and should
-        # stay in (y, x) ordering
-        if len(attrs) == 2:
-            attrs = attrs[::-1]
 
         if self.data and len(self.data.domain.attributes) and len(attrs):
             if np.any(np.isnan(self.data.X)):


### PR DESCRIPTION
This adds support to OWBin for n-dimensional binning and non-square block shapes.

* `MAX_DIMENSIONS` is arbitrarily set to 5 to slightly simplify the GUI
* `utils.get_hypercube` has been generalized, but I kept `get_hypercube()` for simplicity / backwards compat
* I did **not** do a settings migration as the first version of OWBin has not actually been released
* ~I added a special case for 2-dimensional datasets: the code reverses the attr order (assuming the user sets Axis 0 to "x" and Axis 1 to "y") to maintain the row-major image table order. This is tested in `test_hypercube_roundtrip`~