### PR TITLE
Remove pylintrc ignore that was crashing pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -10,7 +10,6 @@
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
-ignore-patterns=**/skimage/**/*.py
 
 # Pickle collected data for later comparisons.
 persistent=yes


### PR DESCRIPTION
Pylint currently crashes on my machine and also on travis. This makes the crash go away.