### PR TITLE
[FIX] GSF file reader data indexing

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -212,6 +212,10 @@ class TestGSF(unittest.TestCase):
     def test_open_2d(self):
         data = Orange.data.Table("whitelight.gsf")
         self.assertEqual(data.X.shape, (20000, 1))
+        # check some pixel vaules
+        self.assertAlmostEqual(data.X[235,0], 1.2788502, 7)
+        self.assertAlmostEqual(data.X[1235,0], 1.2770579, 7)
+        self.assertAlmostEqual(data.X[11235,0], 1.2476133, 7)
 
 
 class TestNea(unittest.TestCase):

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -214,8 +214,13 @@ class TestGSF(unittest.TestCase):
         self.assertEqual(data.X.shape, (20000, 1))
         # check some pixel vaules
         self.assertAlmostEqual(data.X[235,0], 1.2788502, 7)
+        np.testing.assert_array_equal(data.metas[235], [35, 98])
+
         self.assertAlmostEqual(data.X[1235,0], 1.2770579, 7)
+        np.testing.assert_array_equal(data.metas[1235], [35, 93])
+
         self.assertAlmostEqual(data.X[11235,0], 1.2476133, 7)
+        np.testing.assert_array_equal(data.metas[11235], [35, 43])
 
 
 class TestNea(unittest.TestCase):


### PR DESCRIPTION
- simplified the code so that it uses the same functions as other readers
- fixed the data indexing to be consistent with Gwyddion and NeaSpec orientation
- added tests for checking pixel values