### PR TITLE
[FIX] NeaReaderGSF: Changed order of metas in NeaReaderGSF

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1130,12 +1130,13 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
         info = {}
         for row in parameters:
             info.update({row[0].strip(':'): row[1:]})
+        
+        info.update({'Reader': 'NeaReaderGSF'}) # key used in confirmation for complex fft calculation
 
         averaging = int(info['Averaging'][1])
         px_x = int(info['Pixel Area (X, Y, Z)'][1])
         px_y = int(info['Pixel Area (X, Y, Z)'][2])
         px_z = int(info['Pixel Area (X, Y, Z)'][3])
-        description = info['Description'][1]
 
         data_complete = []
         final_metas = []

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1110,9 +1110,9 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
 
         final_data, parameters, final_metas = self._format_file(data_gsf_a, data_gsf_p, info)
 
-        metas = [Orange.data.ContinuousVariable.make("run"),
+        metas = [Orange.data.ContinuousVariable.make("column"),
                  Orange.data.ContinuousVariable.make("row"),
-                 Orange.data.ContinuousVariable.make("column"),
+                 Orange.data.ContinuousVariable.make("run"),
                  Orange.data.StringVariable.make("channel")]
 
         domain = Orange.data.Domain([], None, metas=metas)
@@ -1148,8 +1148,8 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
                 for run in range(0, averaging):
                     data_complete += [amplitude[i:f]]
                     data_complete += [phase[i:f]]
-                    final_metas += [[run, x, y, self.channel_a]]
-                    final_metas += [[run, x, y, self.channel_p]]
+                    final_metas += [[x, y, run, self.channel_a]]
+                    final_metas += [[x, y, run, self.channel_p]]
                     i = f
                     f = i + px_z
 

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -251,7 +251,7 @@ class TestNeaGSF(unittest.TestCase):
         absolute_filename = FileFormat.locate(fn, dataset_dirs)
         data = NeaReaderGSF(absolute_filename).read()
         self.assertEqual(len(data), 2)
-        self.assertEqual("column", data.domain.metas[2].name)
+        self.assertEqual("run", data.domain.metas[2].name)
         self.assertEqual("O2A", data.metas[0][3])
         np.testing.assert_almost_equal(data.X[0, 0], 0.734363853931427)
         self.assertEqual("O2P", data.metas[1][3])


### PR DESCRIPTION
I realized that I made a mistake.
This change is necessary to view the X and Y axes in the hyperspectral data.
I took the opportunity to insert a key in the attributes, that key will be very important for the FFT - I will finish it soon.

