### PR TITLE
[ENH] Responsive Hyperspectra widget

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1201,7 +1201,6 @@ class PreviewRunner(QObject, ConcurrentMixin):
         else:
             raise ex
 
-
     def on_done(self, result):
         orig_data, after_data = result
         final_preview = self.preview_pos is None


### PR DESCRIPTION
Computing integrals does not block the widget anymore.

Also, while working on this, I noticed that the image was needlessly recomputed when a new spectra was chosen for integral preview.