### PR TITLE
[ENH] FFT multirow processing

### DIFF
--- a/orangecontrib/spectroscopy/irfft.py
+++ b/orangecontrib/spectroscopy/irfft.py
@@ -272,8 +272,7 @@ class IRFFT():
         elif self.phase_corr == PhaseCorrection.STORED:
             if self.phase is None:
                 raise ValueError("No stored phase provided.")
-            else:
-                return
+            return
         elif self.phase_corr == PhaseCorrection.MERTZ:
             self.phase = np.arctan2(ifg_sub_fft.imag, ifg_sub_fft.real)
         elif self.phase_corr == PhaseCorrection.MERTZSIGNED:
@@ -284,7 +283,7 @@ class IRFFT():
 
 class MultiIRFFT(IRFFT):
 
-    def __call__(self, ifg, zpd, phase=None):
+    def __call__(self, ifg, zpd=None, phase=None):
         if ifg.ndim != 2:
             raise ValueError("ifg must be 2D array of row-wise interferograms")
         # TODO does stored phase work / make sense here?

--- a/orangecontrib/spectroscopy/irfft.py
+++ b/orangecontrib/spectroscopy/irfft.py
@@ -61,7 +61,7 @@ def apodize(ifg, zpd, apod_func):
     function
 
     Args:
-        ifg (np.array): 1D array with a single interferogram
+        ifg (np.array): interferogram array (1D or 2D row-wise)
         zpd (int): Index of the Zero Phase Difference (centerburst)
         apod_func (IntEnum): One of apodization function options:
                 <ApodFunc.BOXCAR: 0>            : Boxcar apodization
@@ -70,12 +70,12 @@ def apodize(ifg, zpd, apod_func):
                 <ApodFunc.BLACKMAN_NUTTALL: 3>  : Blackman-Nuttall (Eric Peach implementation)
 
     Returns:
-        ifg_apod (np.array): 1D array of apodized ifg
+        ifg_apod (np.array): apodized interferogram(s)
     """
 
     # Calculate negative and positive wing size
     # correcting zpd from 0-based index
-    ifg_N = ifg.shape[0]
+    ifg_N = ifg.shape[-1]
     wing_n = zpd + 1
     wing_p = ifg_N - (zpd + 1)
 
@@ -151,21 +151,22 @@ def _zero_fill_size(ifg_N, zff):
     return int(np.exp2(np.ceil(np.log2(Nzff))))
 
 def _zero_fill_pad(ifg, zerofill):
-    return np.hstack((ifg, np.zeros(zerofill, dtype=ifg.dtype)))
+    zeroshape = (ifg.shape[0], zerofill) if ifg.ndim == 2 else zerofill
+    return np.hstack((ifg, np.zeros(zeroshape, dtype=ifg.dtype)))
 
 def zero_fill(ifg, zff):
     """
-    Zero-fill interferogram.
+    Zero-fill interferogram to DFT-efficient power of two.
     Assymetric to prevent zpd from changing index.
 
     Args:
-        ifg (np.array): 1D array with a single interferogram
+        ifg (np.array): interferogram array (1D or 2D row-wise)
         zff (int): Zero-filling factor
 
     Returns:
-        np.array: 1D array of ifg + zero fill
+        np.array: ifg with appended zero fill
     """
-    ifg_N = ifg.shape[0]
+    ifg_N = ifg.shape[-1]
     # Calculate zero-fill to next power of two for DFT efficiency
     zero_fill = _zero_fill_size(ifg_N, zff) - ifg_N
     # Pad array
@@ -197,6 +198,8 @@ class IRFFT():
         self.peak_search = peak_search
 
     def __call__(self, ifg, zpd=None, phase=None):
+        if ifg.ndim != 1:
+            raise ValueError("ifg must be 1D array")
         # Stored phase
         self.phase = phase
         # Stored ZPD
@@ -277,3 +280,61 @@ class IRFFT():
             self.phase = np.arctan(ifg_sub_fft.imag/ifg_sub_fft.real)
         else:
             raise ValueError("Invalid PhaseCorrection: {}".format(self.phase_corr))
+
+
+class MultiIRFFT(IRFFT):
+
+    def __call__(self, ifg, zpd, phase=None):
+        if ifg.ndim != 2:
+            raise ValueError("ifg must be 2D array of row-wise interferograms")
+        # TODO does stored phase work / make sense here?
+        self.phase = phase
+        try:
+            self.zpd = int(zpd)
+        except TypeError:
+            raise TypeError("zpd must be specified as a single value valid for all interferograms")
+
+        # Subtract DC value from interferogram
+        ifg = ifg - ifg.mean(axis=1, keepdims=True)
+
+        # Calculate phase on interferogram of specified size 2*L
+        L = self.phase_ifg_size(ifg.shape[1])
+        if L == 0: # Use full ifg for phase #TODO multi is this code tested
+            ifg = apodize(ifg, self.zpd, self.apod_func)
+            ifg = zero_fill(ifg, self.zff)
+            # Rotate the Complete IFG so that the centerburst is at edges.
+            ifg = np.hstack((ifg[self.zpd:], ifg[0:self.zpd]))
+            Nzff = ifg.shape[0]
+            # Take FFT of Rotated Complete Graph
+            ifg = np.fft.rfft(ifg)
+            self.compute_phase(ifg)
+        else:
+            # Select phase interferogram as copy
+            # Note that L is now the zpd index
+            Ixs = ifg[:, self.zpd - L : self.zpd + L].copy()
+            ifg = apodize(ifg, self.zpd, self.apod_func)
+            ifg = zero_fill(ifg, self.zff)
+            ifg = np.hstack((ifg[:, self.zpd:], ifg[:, 0:self.zpd]))
+            Nzff = ifg.shape[1]
+
+            Ixs = apodize(Ixs, L, self.apod_func)
+            # Zero-fill Ixs to same size as ifg (instead of interpolating later)
+            Ixs = _zero_fill_pad(Ixs, Nzff - Ixs.shape[1])
+            Ixs = np.hstack((Ixs[:, L:], Ixs[:, 0:L]))
+
+            ifg = np.fft.rfft(ifg)
+            Ixs = np.fft.rfft(Ixs)
+            self.compute_phase(Ixs)
+
+        self.wavenumbers = np.fft.rfftfreq(Nzff, self.dx)
+
+        if self.phase_corr == PhaseCorrection.NONE:
+            self.spectrum = ifg.real
+            self.phase = ifg.imag
+        else:
+            try:
+                self.spectrum = np.cos(self.phase) * ifg.real + np.sin(self.phase) * ifg.imag
+            except ValueError as e:
+                raise ValueError("Incompatible phase: {}".format(e))
+
+        return self.spectrum, self.phase, self.wavenumbers

--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -6,7 +6,8 @@ import Orange
 from orangecontrib.spectroscopy.data import getx
 
 from orangecontrib.spectroscopy.irfft import (IRFFT, zero_fill, PhaseCorrection,
-                                              find_zpd, PeakSearch, ApodFunc
+                                              find_zpd, PeakSearch, ApodFunc,
+                                              MultiIRFFT,
                                              )
 
 dx = 1.0 / 15797.337544 / 2.0
@@ -97,3 +98,40 @@ class TestIRFFT(unittest.TestCase):
         # Compare to agilent absorbance
         # NB 4 mAbs error
         np.testing.assert_allclose(ab[limits[0]:limits[1]], dat, atol=0.004)
+
+    def test_multi(self):
+        dx_ag = (1 / 1.57980039e+04 / 2) * 4
+        fft = MultiIRFFT(dx=dx_ag,
+                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                    zff=1,
+                    phase_res=None,
+                    phase_corr=PhaseCorrection.MERTZ,
+                    peak_search=PeakSearch.MINIMUM)
+        zpd = 69    # from test_agilent_fft_sc(), TODO replace with value read from file
+        fft(self.ifg_seq_ref.X, zpd)
+
+    def test_multi_ab(self):
+        ifg_ref = self.ifg_seq_ref.X
+        ifg_sam = Orange.data.Table("agilent/4_noimage_agg256.seq").X
+        dat_T = Orange.data.Table("agilent/4_noimage_agg256.dat")
+        dat = dat_T.X
+        dx_ag = (1 / 1.57980039e+04 / 2) * 4
+        fft = MultiIRFFT(dx=dx_ag,
+                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                    zff=1,
+                    phase_res=None,
+                    phase_corr=PhaseCorrection.MERTZ,
+                    peak_search=PeakSearch.MINIMUM)
+        zpd = 69  # from test_agilent_fft_sc(), TODO replace with value read from file
+        fft(ifg_ref, zpd)
+        rsc = fft.spectrum
+        fft(ifg_sam, zpd)
+        ssc = fft.spectrum
+        dat_x = getx(dat_T)
+        limits = np.searchsorted(fft.wavenumbers, [dat_x[0] - 1, dat_x[-1]])
+        np.testing.assert_allclose(fft.wavenumbers[limits[0]:limits[1]], dat_x)
+        # Calculate absorbance from ssc and rsc
+        ab = np.log10(rsc / ssc)
+        # Compare to agilent absorbance
+        # NB 4 mAbs error
+        np.testing.assert_allclose(ab[:, limits[0]:limits[1]], dat, atol=0.004)

--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -102,11 +102,11 @@ class TestIRFFT(unittest.TestCase):
     def test_multi(self):
         dx_ag = (1 / 1.57980039e+04 / 2) * 4
         fft = MultiIRFFT(dx=dx_ag,
-                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
-                    zff=1,
-                    phase_res=None,
-                    phase_corr=PhaseCorrection.MERTZ,
-                    peak_search=PeakSearch.MINIMUM)
+                         apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                         zff=1,
+                         phase_res=None,
+                         phase_corr=PhaseCorrection.MERTZ,
+                         peak_search=PeakSearch.MINIMUM)
         zpd = 69    # from test_agilent_fft_sc(), TODO replace with value read from file
         fft(self.ifg_seq_ref.X, zpd)
 
@@ -117,11 +117,11 @@ class TestIRFFT(unittest.TestCase):
         dat = dat_T.X
         dx_ag = (1 / 1.57980039e+04 / 2) * 4
         fft = MultiIRFFT(dx=dx_ag,
-                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
-                    zff=1,
-                    phase_res=None,
-                    phase_corr=PhaseCorrection.MERTZ,
-                    peak_search=PeakSearch.MINIMUM)
+                         apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                         zff=1,
+                         phase_res=None,
+                         phase_corr=PhaseCorrection.MERTZ,
+                         peak_search=PeakSearch.MINIMUM)
         zpd = 69  # from test_agilent_fft_sc(), TODO replace with value read from file
         fft(ifg_ref, zpd)
         rsc = fft.spectrum

--- a/orangecontrib/spectroscopy/tests/test_owfft.py
+++ b/orangecontrib/spectroscopy/tests/test_owfft.py
@@ -2,7 +2,9 @@ import numpy as np
 
 import Orange
 from Orange.widgets.tests.base import WidgetTest
-from orangecontrib.spectroscopy.widgets.owfft import OWFFT
+from orangecontrib.spectroscopy.data import getx
+from orangecontrib.spectroscopy import irfft
+from orangecontrib.spectroscopy.widgets.owfft import OWFFT, CHUNK_SIZE
 
 
 class TestOWFFT(WidgetTest):
@@ -32,10 +34,14 @@ class TestOWFFT(WidgetTest):
         self.send_signal("Interferogram", self.ifg_single)
         self.assertEqual(self.widget.dx, 5)
 
+    def test_auto_dx(self):
+        self.send_signal("Interferogram", self.ifg_seq)
+        self.assertEqual(self.widget.dx, (1 / 1.57980039e+04 / 2) * 4)
+
     def test_keep_metas(self):
-        self.widget.autocommit = True
         input = self.ifg_seq
         self.send_signal(self.widget.Inputs.data, input)
+        self.commit_and_wait()
         spectra = self.get_output(self.widget.Outputs.spectra)
         phases = self.get_output(self.widget.Outputs.phases)
         np.testing.assert_equal(input.metas, spectra.metas)
@@ -44,10 +50,62 @@ class TestOWFFT(WidgetTest):
     def test_custom_zpd(self):
         """ Test setting custom zpd value"""
         custom_zpd = 1844
-        self.widget.autocommit = True
         self.send_signal(self.widget.Inputs.data, self.ifg_single)
         self.widget.peak_search_enable = False
         self.widget.zpd1 = custom_zpd
         self.widget.peak_search_changed()
+        self.commit_and_wait()
         phases = self.get_output(self.widget.Outputs.phases)
         self.assertEqual(phases[0, "zpd_fwd"], custom_zpd)
+
+    def test_chunk_one(self):
+        """ Test batching when len(data) < chunk_size """
+        self.assertLess(len(self.ifg_seq), CHUNK_SIZE)
+        self.send_signal(self.widget.Inputs.data, self.ifg_seq)
+        self.widget.peak_search_enable = False
+        self.widget.zpd1 = 69 # TODO replace with value read from file
+        self.widget.peak_search_changed()
+        self.commit_and_wait()
+
+    def test_chunk_many(self):
+        """ Test batching when len(data) >> chunk_size """
+        data = Orange.data.table.Table.concatenate(5 * (self.ifg_seq,))
+        self.assertGreater(len(data), CHUNK_SIZE)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.peak_search_enable = False
+        self.widget.zpd1 = 69 # TODO replace with value read from file
+        self.widget.peak_search_changed()
+        self.commit_and_wait()
+
+    def test_calculation(self):
+        """" Test calculation with custom settings and batching """
+        ifg_ref = Orange.data.Table("agilent/background_agg256.seq")
+        abs = Orange.data.Table("agilent/4_noimage_agg256.dat")
+
+        self.widget.apod_func = irfft.ApodFunc.BLACKMAN_HARRIS_4
+        self.widget.zff = 0  # 2**0 = 1
+        self.widget.phase_res_limit = False
+        self.widget.phase_corr = irfft.PhaseCorrection.MERTZ
+        self.widget.setting_changed()
+        self.widget.peak_search_enable = False
+        self.widget.zpd1 = 69 # TODO replace with value read from file
+        self.widget.peak_search_changed()
+
+        self.send_signal(self.widget.Inputs.data, ifg_ref)
+        self.commit_and_wait()
+        rsc = self.get_output(self.widget.Outputs.spectra)
+
+        self.send_signal(self.widget.Inputs.data, self.ifg_seq)
+        self.commit_and_wait()
+        ssc = self.get_output(self.widget.Outputs.spectra)
+
+        # Calculate absorbance from ssc and rsc
+        calc_abs = np.log10(rsc.X / ssc.X)
+        # Match energy region
+        abs_x = getx(abs)
+        calc_x = getx(ssc)
+        limits = np.searchsorted(calc_x, [abs_x[0] - 1, abs_x[-1]])
+        np.testing.assert_allclose(calc_x[limits[0]:limits[1]], abs_x)
+        # Compare to agilent absorbance
+        # NB 4 mAbs error
+        np.testing.assert_allclose(calc_abs[:, limits[0]:limits[1]], abs.X, atol=0.004)

--- a/orangecontrib/spectroscopy/tests/test_owfft.py
+++ b/orangecontrib/spectroscopy/tests/test_owfft.py
@@ -40,3 +40,14 @@ class TestOWFFT(WidgetTest):
         phases = self.get_output(self.widget.Outputs.phases)
         np.testing.assert_equal(input.metas, spectra.metas)
         np.testing.assert_equal(input.metas, phases.metas[:, :input.metas.shape[1]])
+
+    def test_custom_zpd(self):
+        """ Test setting custom zpd value"""
+        custom_zpd = 1844
+        self.widget.autocommit = True
+        self.send_signal(self.widget.Inputs.data, self.ifg_single)
+        self.widget.peak_search_enable = False
+        self.widget.zpd1 = custom_zpd
+        self.widget.peak_search_changed()
+        phases = self.get_output(self.widget.Outputs.phases)
+        self.assertEqual(phases[0, "zpd_fwd"], custom_zpd)

--- a/orangecontrib/spectroscopy/tests/time_irfft.py
+++ b/orangecontrib/spectroscopy/tests/time_irfft.py
@@ -46,27 +46,50 @@ def test_time_multi_fft(fns):
 
         print(data.X.shape)
 
-        min_multi = float('inf')
-        for n in range(3):
-            t = time.time()
-            r = fft(data.X)
-            dt = time.time() - t
-            print("multi", dt)
-            min_multi = min(min_multi, dt)
-        print("multi (min)", min_multi)
-
         min_row = float('inf')
         for n in range(3):
             t = time.time()
             for row in data:
-                r = fft(row)
+                # Array is at RowInstance.x
+                r = fft(row.x)
             dt = time.time() - t
             print("row by row", dt)
             min_row = min(min_row, dt)
         print("row by row (min)", min_row)
 
+        min_batch = float('inf')
+        chunk_size = 100
+        chunks = max(1, len(data) // chunk_size)
+        print(f"{chunks} chunks")
+        for n in range(3):
+            t = time.time()
+            for chunk in np.array_split(data.X, chunks, axis=0):
+                r = fft(chunk)
+            dt = time.time() - t
+            print("100 batch", dt)
+            min_batch = min(min_batch, dt)
+        print("100 batch (min)", min_batch)
+
+        min_multi = float('inf')
+        for n in range(3):
+            t = time.time()
+            try:
+                r = fft(data.X)
+            except MemoryError as e:
+                print(e)
+                break
+            dt = time.time() - t
+            print("multi", dt)
+            min_multi = min(min_multi, dt)
+        print("multi (min)", min_multi)
+
         try:
-            print(f"Speedup: {min_row / min_multi}")
+            print(f"Multirow Speedup: {min_row / min_multi}")
+        except ZeroDivisionError:
+            print("Speedup: infinity!")
+
+        try:
+            print(f"100 Batch Speedup: {min_row / min_batch}")
         except ZeroDivisionError:
             print("Speedup: infinity!")
 

--- a/orangecontrib/spectroscopy/tests/time_irfft.py
+++ b/orangecontrib/spectroscopy/tests/time_irfft.py
@@ -1,0 +1,73 @@
+import time
+
+import numpy as np
+from Orange.data import Table
+
+from orangecontrib.spectroscopy.data import getx, agilentMosaicIFGReader
+
+from orangecontrib.spectroscopy.irfft import (IRFFT, zero_fill, PhaseCorrection,
+                                              find_zpd, PeakSearch, ApodFunc
+                                             )
+from orangecontrib.spectroscopy.tests.test_readers import initialize_reader
+
+def test_time_multi_fft():
+    fns = ["agilent/4_noimage_agg256.seq",
+           "C:\\Users\\reads\\tmp\\aff-testdata\\2017-11-10 4X-25X\\2017-11-10 4X-25X.dmt",
+           "/data/staff/reads/aff-testdata/2017-11-10 4X-25X/2017-11-10 4x-25x.dmt",
+           "/data/staff/reads/USAF 25X Mosaic/usaf 25x mosaic.dmt"
+           ]
+    for fn in fns:
+        print(fn)
+        if fn[-3:] == 'dmt':
+            # This reader will only be selected manually due to shared .dmt extension
+            try:
+                reader = initialize_reader(agilentMosaicIFGReader, fn)
+            except (IOError, OSError):
+                print("Skipping, not present")
+                continue
+            else:
+                data = reader.read()
+        else:
+            try:
+                data = Table(fn)
+            except (IOError, OSError):
+                print("Skipping, not present")
+                continue
+        dx_ag = (1 / 1.57980039e+04 / 2) * 4
+        fft = IRFFT(dx=dx_ag,
+                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                    zff=1,
+                    phase_res=None,
+                    phase_corr=PhaseCorrection.MERTZ,
+                    peak_search=PeakSearch.MINIMUM)
+
+        print(data.X.shape)
+
+        min_multi = float('inf')
+        for n in range(3):
+            t = time.time()
+            r = fft(data.X)
+            dt = time.time() - t
+            print("multi", dt)
+            min_multi = min(min_multi, dt)
+        print("multi (min)", min_multi)
+
+        min_row = float('inf')
+        for n in range(3):
+            t = time.time()
+            for row in data:
+                r = fft(row)
+            dt = time.time() - t
+            print("row by row", dt)
+            min_row = min(min_row, dt)
+        print("row by row (min)", min_row)
+
+        try:
+            print(f"Speedup: {min_row / min_multi}")
+        except ZeroDivisionError:
+            print("Speedup: infinity!")
+
+
+
+if __name__ == "__main__":
+    test_time_multi_fft()

--- a/orangecontrib/spectroscopy/tests/time_irfft.py
+++ b/orangecontrib/spectroscopy/tests/time_irfft.py
@@ -1,4 +1,4 @@
-import time
+import time, sys
 
 import numpy as np
 from Orange.data import Table
@@ -7,15 +7,18 @@ from orangecontrib.spectroscopy.data import getx, agilentMosaicIFGReader
 
 from orangecontrib.spectroscopy.irfft import (IRFFT, zero_fill, PhaseCorrection,
                                               find_zpd, PeakSearch, ApodFunc
-                                             )
+                                              )
 from orangecontrib.spectroscopy.tests.test_readers import initialize_reader
 
-def test_time_multi_fft():
-    fns = ["agilent/4_noimage_agg256.seq",
-           "C:\\Users\\reads\\tmp\\aff-testdata\\2017-11-10 4X-25X\\2017-11-10 4X-25X.dmt",
-           "/data/staff/reads/aff-testdata/2017-11-10 4X-25X/2017-11-10 4x-25x.dmt",
-           "/data/staff/reads/USAF 25X Mosaic/usaf 25x mosaic.dmt"
-           ]
+FILENAMES = ["agilent/4_noimage_agg256.seq",
+             "C:\\Users\\reads\\tmp\\aff-testdata\\2017-11-10 4X-25X\\2017-11-10 4X-25X.dmt",
+             "/data/staff/reads/aff-testdata/2017-11-10 4X-25X/2017-11-10 4x-25x.dmt",
+             "/data/staff/reads/USAF 25X Mosaic/usaf 25x mosaic.dmt"
+             ]
+FILENAMES_FAST = FILENAMES[0:1]
+
+
+def test_time_multi_fft(fns):
     for fn in fns:
         print(fn)
         if fn[-3:] == 'dmt':
@@ -68,6 +71,11 @@ def test_time_multi_fft():
             print("Speedup: infinity!")
 
 
-
 if __name__ == "__main__":
-    test_time_multi_fft()
+    try:
+        fast = sys.argv[1]
+    except IndexError:
+        fast = False
+    finally:
+        fns = FILENAMES_FAST if fast == "--fast" else FILENAMES
+    test_time_multi_fft(fns)

--- a/orangecontrib/spectroscopy/tests/time_irfft.py
+++ b/orangecontrib/spectroscopy/tests/time_irfft.py
@@ -5,7 +5,7 @@ from Orange.data import Table
 
 from orangecontrib.spectroscopy.data import getx, agilentMosaicIFGReader
 
-from orangecontrib.spectroscopy.irfft import (IRFFT, zero_fill, PhaseCorrection,
+from orangecontrib.spectroscopy.irfft import (IRFFT, MultiIRFFT, zero_fill, PhaseCorrection,
                                               find_zpd, PeakSearch, ApodFunc
                                               )
 from orangecontrib.spectroscopy.tests.test_readers import initialize_reader
@@ -43,6 +43,12 @@ def test_time_multi_fft(fns):
                     phase_res=None,
                     phase_corr=PhaseCorrection.MERTZ,
                     peak_search=PeakSearch.MINIMUM)
+        mfft = MultiIRFFT(dx=dx_ag,
+                    apod_func=ApodFunc.BLACKMAN_HARRIS_4,
+                    zff=1,
+                    phase_res=None,
+                    phase_corr=PhaseCorrection.MERTZ,
+                    peak_search=PeakSearch.MINIMUM)
 
         print(data.X.shape)
 
@@ -64,7 +70,7 @@ def test_time_multi_fft(fns):
         for n in range(3):
             t = time.time()
             for chunk in np.array_split(data.X, chunks, axis=0):
-                r = fft(chunk)
+                r = mfft(chunk, zpd=fft.zpd) # use last zpd from fft
             dt = time.time() - t
             print("100 batch", dt)
             min_batch = min(min_batch, dt)
@@ -74,7 +80,7 @@ def test_time_multi_fft(fns):
         for n in range(3):
             t = time.time()
             try:
-                r = fft(data.X)
+                r = mfft(data.X, zpd=fft.zpd) # use last zpd from fft
             except MemoryError as e:
                 print(e)
                 break

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -163,13 +163,15 @@ class OWFFT(OWWidget):
             callback=self.peak_search_changed,
             enabled=self.peak_search_enable,
             )
-        le1 = gui.lineEdit(self.dataBox, self, "zpd1",
+        le1 = gui.lineEdit(
+            self.dataBox, self, "zpd1",
             callback=self.peak_search_changed,
             valueType=int,
             controlWidth=50,
             disabled=self.peak_search_enable,
             )
-        le2 = gui.lineEdit(self.dataBox, self, "zpd2",
+        le2 = gui.lineEdit(
+            self.dataBox, self, "zpd2",
             callback=self.peak_search_changed,
             valueType=int,
             controlWidth=50,


### PR DESCRIPTION
Enhancements to the FFT processing as mentioned in https://github.com/Quasars/orange-spectroscopy/issues/360.
Currently showing speedups of 1-10x depending on datasize. Chunking into batches 100 as suggested by @markotoplak keeps the speed improvements but completely mitigates memory issues.

This code is only used for datasets with fixed, constant zpd values. The code I wrote to support variable zpd values from a peak search was too complex and fragile. Since this speedup is mostly useful for large imaging-array detector datasets, I think this is an acceptable tradeoff.

- [x] process multiple rows at a time
- [x] tests for multirow results and zpds

Not in scope: Fix the poor API boundary between irfft and owfft and add a preprocessor layer for use in scripts. That will be next.