### PR TITLE
Compatibility with Orange Save widget tests

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -88,13 +88,6 @@ class SelectColumnReader(FileFormat, SpectralFileFormat):
                               unpack=True)
         return spectrum[0], np.atleast_2d(spectrum[1]), None
 
-    @staticmethod
-    def write_file(filename, data):
-        xs = getx(data)
-        xs = xs.reshape((-1, 1))
-        table = np.hstack((xs, data.X.T))
-        np.savetxt(filename, table, delimiter="\t", fmt="%g")
-
 
 class AsciiMapReader(FileFormat):
     """ Reader ascii map files.

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -117,12 +117,9 @@ class AsciiMapReader(FileFormat):
     @staticmethod
     def write_file(filename, data):
         wavelengths = getx(data)
-        try:
-            ndom = Domain([data.domain["map_x"], data.domain["map_y"]] +
-                          list(data.domain.attributes))
-        except KeyError:
-            raise RuntimeError('Data needs to include meta variables '
-                               '"map_x" and "map_y"')
+        map_x = data.domain["map_x"] if "map_x" in data.domain else ContinuousVariable("map_x")
+        map_y = data.domain["map_y"] if "map_y" in data.domain else ContinuousVariable("map_y")
+        ndom = Domain([map_x, map_y] + list(data.domain.attributes))
         data = data.transform(ndom)
         with open(filename, "wb") as f:
             header = ["", ""] + [("%g" % w) for w in wavelengths]

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -105,10 +105,12 @@ class TestAsciiMapReader(unittest.TestCase):
             np.testing.assert_equal(getx(d1), getx(d2))
             np.testing.assert_equal(d1.metas, d2.metas)
 
-    def test_write_exception(self):
+    def test_undefined_map_positions(self):
         d = Orange.data.Table("iris")
-        with self.assertRaises(RuntimeError):
-            d.save("test.xyz")
+        with named_file("", suffix=".xyz") as fn:
+            d.save(fn)
+            d2 = Orange.data.Table(fn)
+            np.testing.assert_equal(np.isnan(d2.metas), np.ones((150, 2)))
 
 
 class TestAgilentReader(unittest.TestCase):


### PR DESCRIPTION
Spectroscopy adds file formats, which are then also tested by Orange tests.

Fix some bugs:
- Remove a Writer that was not supported
- Make another writer not fail, because there is no error reporting mechanism in OWSave yet.