### PR TITLE
[FIX] build_spec_table: respect additional_table.attributes

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1005,7 +1005,8 @@ def build_spec_table(domvals, data, additional_table=None):
                         class_vars=additional_table.domain.class_vars,
                         metas=additional_table.domain.metas)
         ret_data = Table.from_numpy(domain, X=data, Y=additional_table.Y,
-                                    metas=additional_table.metas)
+                                    metas=additional_table.metas,
+                                    attributes=additional_table.attributes)
         return ret_data
 
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1130,11 +1130,15 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
 
         info = {}
         for row in parameters:
-            info.update({row[0].strip(':'): row[1:]})
+            key = row[0].strip(':')
+            value = [v for v in row[1:] if len(v)]
+            if len(value) == 1:
+                value = value[0]
+            info.update({key: value})
         
         info.update({'Reader': 'NeaReaderGSF'}) # key used in confirmation for complex fft calculation
 
-        averaging = int(info['Averaging'][1])
+        averaging = int(info['Averaging'])
         px_x = int(info['Pixel Area (X, Y, Z)'][1])
         px_y = int(info['Pixel Area (X, Y, Z)'][2])
         px_z = int(info['Pixel Area (X, Y, Z)'][3])

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -256,6 +256,9 @@ class TestNeaGSF(unittest.TestCase):
         np.testing.assert_almost_equal(data.X[0, 0], 0.734363853931427)
         self.assertEqual("O2P", data.metas[1][3])
         np.testing.assert_almost_equal(data.X[1, 43], 0.17290098965168)
+        n_ifg = int(data.attributes['Pixel Area (X, Y, Z)'][3])
+        self.assertEqual(n_ifg, 1024)
+        self.assertEqual(n_ifg, len(data.domain.attributes))
 
 
 class TestSpa(unittest.TestCase):

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -6,6 +6,7 @@ import Orange
 from Orange.data import dataset_dirs
 from Orange.data.io import FileFormat
 from Orange.tests import named_file
+from Orange.widgets.data.owfile import OWFile
 from orangecontrib.spectroscopy.data import getx, build_spec_table, SelectColumnReader, NeaReader
 from orangecontrib.spectroscopy.preprocess import features_with_interpolation
 from orangecontrib.spectroscopy.data import SPAReader, agilentMosaicIFGReader
@@ -24,6 +25,15 @@ def initialize_reader(reader, fn):
     """
     absolute_filename = FileFormat.locate(fn, Orange.data.table.dataset_dirs)
     return reader(absolute_filename)
+
+# pylint: disable=protected-access
+def check_attributes(table):
+    """
+    Checks output attributes conform to OWFile expectations
+    Keys "Name" and "Description" must be strings, etc
+    This should be added to tests for all readers that implement attributes
+    """
+    OWFile._describe(table)
 
 
 class TestReaders(unittest.TestCase):
@@ -259,6 +269,7 @@ class TestNeaGSF(unittest.TestCase):
         n_ifg = int(data.attributes['Pixel Area (X, Y, Z)'][3])
         self.assertEqual(n_ifg, 1024)
         self.assertEqual(n_ifg, len(data.domain.attributes))
+        check_attributes(data)
 
 
 class TestSpa(unittest.TestCase):


### PR DESCRIPTION
`NeaReaderGSF` added attributes to _additional_table_, but `build_spec_table` didn't include them in the final table output.

Includes test :)