### PR TITLE
Added SNV normalization

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -312,6 +312,9 @@ class _NormalizeCommon(CommonDomain):
                                   limits=[[self.lower, self.upper]])(data)
             data.X /= norm_data.X
             replace_infs(data.X)
+        elif self.method == Normalize.SNV:
+            data.X = (data.X - np.nanmean(data.X, axis=1, keepdims=True)) / np.nanstd(data.X, axis=1, keepdims=True)
+            replace_infs(data.X)
         elif self.method == Normalize.Attribute:
             if self.attr in data.domain and isinstance(data.domain[self.attr], Orange.data.ContinuousVariable):
                 ndom = Orange.data.Domain([data.domain[self.attr]])
@@ -331,7 +334,7 @@ class _NormalizeCommon(CommonDomain):
 
 class Normalize(Preprocess):
     # Normalization methods
-    Vector, Area, Attribute, MinMax = 0, 1, 2, 3
+    Vector, Area, Attribute, MinMax, SNV = 0, 1, 2, 3, 4
 
     def __init__(self, method=Vector, lower=float, upper=float, int_method=0, attr=None):
         self.method = method

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -357,6 +357,16 @@ class TestNormalize(unittest.TestCase):
         p = Normalize(method=Normalize.MinMax, lower=0, upper=2)(data)
         np.testing.assert_equal(p.X, q)
 
+    def test_SNV_norm(self):
+        data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
+        p = Normalize(method=Normalize.SNV)(data)
+        q = (data.X - 2) / 0.6324555320336759
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.SNV, lower=0, upper=4)(data)
+        np.testing.assert_equal(p.X, q)
+        p = Normalize(method=Normalize.SNV, lower=0, upper=2)(data)
+        np.testing.assert_equal(p.X, q)
+
 
 class TestNormalizeReference(unittest.TestCase):
 

--- a/orangecontrib/spectroscopy/widgets/preprocessors/normalize.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/normalize.py
@@ -27,6 +27,7 @@ class NormalizeEditor(BaseEditorOrange):
         ("Min-Max Normalization", Normalize.MinMax),
         ("Area Normalization", Normalize.Area),
         ("Attribute Normalization", Normalize.Attribute),
+        ("Standard Normal Variate (SNV)", Normalize.SNV),
         ("Normalize by Reference", NORMALIZE_BY_REFERENCE)]
 
     def __init__(self, parent=None, **kwargs):


### PR DESCRIPTION
At the request of users from Spain.

Standard Normal Variate is calculated by mean centering the spectra and subsequently dividing each with its standard deviation.