### PR TITLE
Normalize, MinMax: no shifting, only division by range

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -327,7 +327,7 @@ class _NormalizeCommon(CommonDomain):
         elif self.method == Normalize.MinMax:
             min = np.nanmin(data.X, axis=1, keepdims=True)
             max = np.nanmax(data.X, axis=1, keepdims=True)
-            data.X = (data.X - min) / (max - min)
+            data.X = (data.X) / (max - min)
             replace_infs(data.X)
         return data.X
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -350,7 +350,7 @@ class TestNormalize(unittest.TestCase):
     def test_minmax_norm(self):
         data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
         p = Normalize(method=Normalize.MinMax)(data)
-        q = (data.X - 1) / (3 - 1)
+        q = (data.X) / (3 - 1)
         np.testing.assert_equal(p.X, q)
         p = Normalize(method=Normalize.MinMax, lower=0, upper=4)(data)
         np.testing.assert_equal(p.X, q)


### PR DESCRIPTION
That makes the range=1 and also works for derivatives, when can be negative. This should be similar behaviour as in Unscrambler.

Thanks @clsandt.