### PR TITLE
[ENH] HyperSpectra: display visible image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: ORANGE="release" RUN_PYLINT=true
 
     - python: '3.6'
-      env: ORANGE="3.24.0" PIP_INSTALL="orange-canvas-core==0.1.10 orange-widget-base==4.3.0 scikit-learn~=0.22.0"
+      env: ORANGE="3.25.0" PIP_INSTALL="orange-canvas-core==0.1.9 orange-widget-base==4.5.0 scikit-learn~=0.22.0"
 
     - python: '3.6'
       env: ORANGE="release"  UPLOAD_COVERAGE=true PIP_INSTALL=""

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - recommonmark
   run:
     - python
-    - orange3 >=3.24
+    - orange3 >=3.25
     - scipy >=0.14.0
     - spectral >=0.18
     - serverfiles >=0.2

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -775,14 +775,17 @@ class OPUSReader(FileFormat):
 
         visible_images = []
         for img in opusFC.getVisImages(self.filename):
-            visible_images.append({
-                'name': img['Title'],
-                'image_bytes': img['image'],
-                'pos_x': img['Pos. X'] * img['PixelSizeX'],
-                'pos_y': img['Pos. Y'] * img['PixelSizeY'],
-                'pixel_size_x': img['PixelSizeX'],
-                'pixel_size_y': img['PixelSizeY'],
-            })
+            try:
+                visible_images.append({
+                    'name': img['Title'],
+                    'image_bytes': img['image'],
+                    'pos_x': img['Pos. X'] * img['PixelSizeX'],
+                    'pos_y': img['Pos. Y'] * img['PixelSizeY'],
+                    'pixel_size_x': img['PixelSizeX'],
+                    'pixel_size_y': img['PixelSizeY'],
+                })
+            except KeyError:
+                pass
 
         domain = Orange.data.Domain(attrs, clses, metas)
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -773,6 +773,17 @@ class OPUSReader(FileFormat):
                 else:
                     meta_data = params
 
+        visible_images = []
+        for img in opusFC.getVisImages(self.filename):
+            visible_images.append({
+                'name': img['Title'],
+                'image_bytes': img['image'],
+                'pos_x': img['Pos. X'] * img['PixelSizeX'],
+                'pos_y': img['Pos. Y'] * img['PixelSizeY'],
+                'pixel_size_x': img['PixelSizeX'],
+                'pixel_size_y': img['PixelSizeY'],
+            })
+
         domain = Orange.data.Domain(attrs, clses, metas)
 
         meta_data = np.atleast_2d(meta_data)
@@ -780,6 +791,9 @@ class OPUSReader(FileFormat):
         table = Orange.data.Table.from_numpy(domain,
                                              y_data.astype(float, order='C'),
                                              metas=meta_data)
+
+        if visible_images:
+            table.attributes['visible_images'] = visible_images
 
         return table
 

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -384,3 +384,15 @@ class TestVisibleImage(WidgetTest):
         wait_for_image(w)
 
         self.assertTrue(w.visbox.isEnabled())
+
+    def test_first_visible_image_selected_in_combobox_by_default(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        self.assertEqual(len(w.vis_img_name_model),
+                         len(data.attributes["visible_images"]))
+        self.assertEqual(w.cur_visible_image_idx, 0)
+        self.assertEqual(w.vis_img_combo.currentIndex(), 0)
+        self.assertEqual(w.vis_img_combo.currentText(), "Image 01")

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -394,6 +394,18 @@ class TestVisibleImage(WidgetTest):
 
         self.assertTrue(w.visbox.isEnabled())
 
+    def test_controls_enabled_by_show_chkbox(self):
+        w = self.widget
+        self.send_signal("Data", self.data_with_visible_images)
+        wait_for_image(w)
+
+        self.assertTrue(w.show_vis_img.isEnabled())
+        self.assertFalse(w.show_vis_img.isChecked())
+        self.assertFalse(w.vis_img_combo.isEnabled())
+
+        w.show_vis_img.setChecked(True)
+        self.assertTrue(w.vis_img_combo.isEnabled())
+
     def test_first_visible_image_selected_in_combobox_by_default(self):
         w = self.widget
         vis_img = w.imageplot.vis_img

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -402,9 +402,11 @@ class TestVisibleImage(WidgetTest):
         self.assertTrue(w.show_vis_img.isEnabled())
         self.assertFalse(w.show_vis_img.isChecked())
         self.assertFalse(w.vis_img_combo.isEnabled())
+        self.assertFalse(w.vis_img_opacity_slider.isEnabled())
 
         w.show_vis_img.setChecked(True)
         self.assertTrue(w.vis_img_combo.isEnabled())
+        self.assertTrue(w.vis_img_opacity_slider.isEnabled())
 
     def test_first_visible_image_selected_in_combobox_by_default(self):
         w = self.widget
@@ -469,3 +471,14 @@ class TestVisibleImage(WidgetTest):
             self.assert_same_visible_image(data.attributes["visible_images"][1],
                                            w.imageplot.vis_img,
                                            mock_rect)
+
+    def test_visible_image_opacity(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        with patch.object(w.imageplot.vis_img, 'setOpacity') as m:
+            w.vis_img_opacity_slider.setValue(20)
+            self.assertEqual(w.visible_image_opacity, 20)
+            m.assert_called_once_with(w.visible_image_opacity / 255)

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -423,3 +423,49 @@ class TestVisibleImage(WidgetTest):
             self.assert_same_visible_image(data.attributes["visible_images"][0],
                                            w.imageplot.vis_img,
                                            mock_rect)
+
+    def test_visible_image_displayed(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        self.assertNotIn(w.imageplot.vis_img, w.imageplot.plot.items)
+
+        w.show_vis_img.setChecked(True)
+        self.assertIn(w.imageplot.vis_img, w.imageplot.plot.items)
+        w.show_vis_img.setChecked(False)
+        self.assertNotIn(w.imageplot.vis_img, w.imageplot.plot.items)
+
+    def test_hide_visible_image_after_no_image_loaded(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        w.show_vis_img.setChecked(True)
+        data = Orange.data.Table("agilent/4_noimage_agg256.dat")
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        self.assertFalse(w.visbox.isEnabled())
+        self.assertFalse(w.is_show_visible_image)
+        self.assertNotIn(w.imageplot.vis_img, w.imageplot.plot.items)
+
+    def test_select_another_visible_image(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        w.show_vis_img.setChecked(True)
+        vis_img = w.imageplot.vis_img
+        with patch.object(vis_img, 'setRect', wraps=vis_img.setRect) as mock_rect:
+            w.vis_img_combo.setCurrentIndex(1)
+            # since activated signal emitted only by visual interaction
+            # we need to trigger it by hand here.
+            w.vis_img_combo.activated.emit(1)
+
+            self.assert_same_visible_image(data.attributes["visible_images"][1],
+                                           w.imageplot.vis_img,
+                                           mock_rect)

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -373,7 +373,8 @@ class TestVisibleImage(WidgetTest):
         self.widget = self.create_widget(OWHyper)  # type: OWHyper
 
     def assert_same_visible_image(self, img_info, vis_img, mock_rect):
-        img = np.array(Image.open(io.BytesIO(img_info["image_bytes"])))[::-1]
+        img = Image.open(io.BytesIO(img_info["image_bytes"])).convert('RGBA')
+        img = np.array(img)[::-1]
         rect = QRectF(img_info['pos_x'], img_info['pos_y'],
                       img.shape[1] * img_info['pixel_size_x'],
                       img.shape[0] * img_info['pixel_size_y'])

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -1,5 +1,7 @@
 import unittest
 from unittest.mock import patch
+from io import BytesIO
+from PIL import Image
 
 import numpy as np
 import Orange
@@ -68,6 +70,39 @@ class TestDat(unittest.TestCase):
             d1.save(fn)
             d2 = Orange.data.Table(fn)
             np.testing.assert_equal(d1.X, d2.X)
+
+
+@unittest.skipIf(opusFC is None, "opusFC module not installed")
+class TestOpusReader(unittest.TestCase):
+
+    def test_no_visible_image_read(self):
+        d = Orange.data.Table("opus/no_visible_images.0")
+
+        # visible_images is not a permanent key
+        self.assertNotIn("visible_images", d.attributes)
+
+    def test_one_visible_image_read(self):
+        d = Orange.data.Table("opus/one_visible_image.0")
+
+        self.assertIn("visible_images", d.attributes)
+        self.assertEqual(len(d.attributes["visible_images"]), 1)
+
+        img_info = d.attributes["visible_images"][0]
+        # decompress bytes only in widgets to reduce memory footprint
+        self.assertEqual(type(img_info["image_bytes"]), bytes)
+        self.assertEqual(img_info["name"], "Image 01")
+        self.assertAlmostEqual(img_info["pixel_size_x"], 0.90088498)
+        self.assertAlmostEqual(img_info["pixel_size_y"], 0.89284902)
+        self.assertAlmostEqual(img_info["pos_x"],
+                               43552.0 * img_info["pixel_size_x"])
+        self.assertAlmostEqual(img_info["pos_y"],
+                               20727.0 * img_info["pixel_size_y"])
+
+        # test image
+        with BytesIO(img_info["image_bytes"]) as f:
+            img = Image.open(f)
+            img = np.array(img)
+            self.assertEqual(img.shape, (538, 666, 3))
 
 
 class TestHermesHDF5Reader(unittest.TestCase):

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -72,15 +72,30 @@ class TestDat(unittest.TestCase):
             np.testing.assert_equal(d1.X, d2.X)
 
 
+try:
+    no_visible_image = FileFormat.locate("opus/no_visible_images.0",
+                                         Orange.data.table.dataset_dirs)
+except OSError:
+    no_visible_image = False
+
+try:
+    one_visible_image = FileFormat.locate("opus/one_visible_image.0",
+                                          Orange.data.table.dataset_dirs)
+except OSError:
+    one_visible_image = False
+
+
 @unittest.skipIf(opusFC is None, "opusFC module not installed")
 class TestOpusReader(unittest.TestCase):
 
+    @unittest.skipIf(no_visible_image is False, "Missing opus/no_visible_images.0")
     def test_no_visible_image_read(self):
         d = Orange.data.Table("opus/no_visible_images.0")
 
         # visible_images is not a permanent key
         self.assertNotIn("visible_images", d.attributes)
 
+    @unittest.skipIf(one_visible_image is False, "Missing opus/one_visible_image.0")
     def test_one_visible_image_read(self):
         d = Orange.data.Table("opus/one_visible_image.0")
 

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -23,7 +23,7 @@ from Orange.widgets.widget import OWWidget, Msg, OWComponent, Input, Output
 from Orange.widgets import gui
 from Orange.widgets.settings import \
     Setting, ContextSetting, DomainContextHandler, SettingProvider
-from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.utils.itemmodels import DomainModel, PyListModel
 from Orange.widgets.utils import saveplot
 from Orange.data import DiscreteVariable, ContinuousVariable
 from Orange.widgets.utils.concurrent import TaskState, ConcurrentMixin
@@ -843,6 +843,8 @@ class OWHyper(OWWidget):
     value_type = Setting(0)
     attr_value = ContextSetting(None)
 
+    cur_visible_image_idx = Setting(-1)
+
     lowlim = Setting(None)
     highlim = Setting(None)
     choose = Setting(None)
@@ -950,6 +952,11 @@ class OWHyper(OWWidget):
     def setup_visible_image_controls(self):
         self.visbox = gui.widgetBox(self.controlArea, True)
 
+        self.vis_img_name_model = PyListModel()
+        self.vis_img_combo = gui.comboBox(
+            self.visbox, self, 'cur_visible_image_idx',
+            model=self.vis_img_name_model)
+
     def init_interface_data(self, data):
         same_domain = (self.data and data and
                        data.domain == self.data.domain)
@@ -982,10 +989,16 @@ class OWHyper(OWWidget):
         self.attr_value = self.feature_value_model[0] if self.feature_value_model else None
 
     def init_visible_image(self, data):
+        self.vis_img_name_model.clear()
         if data is not None and 'visible_images' in data.attributes:
             self.visbox.setEnabled(True)
+
+            for img in data.attributes['visible_images']:
+                self.vis_img_name_model.append(img['name'])
+            self.cur_visible_image_idx = 0
         else:
             self.visbox.setEnabled(False)
+            self.cur_visible_image_idx = -1
 
     def redraw_integral_info(self):
         di = {}

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -851,6 +851,7 @@ class OWHyper(OWWidget):
     value_type = Setting(0)
     attr_value = ContextSetting(None)
 
+    is_show_visible_image = Setting(False)
     cur_visible_image_idx = Setting(-1)
 
     lowlim = Setting(None)
@@ -960,11 +961,24 @@ class OWHyper(OWWidget):
     def setup_visible_image_controls(self):
         self.visbox = gui.widgetBox(self.controlArea, True)
 
+        self.show_vis_img = gui.checkBox(
+            self.visbox, self, 'is_show_visible_image',
+            label='Show visible image')
+
         self.vis_img_name_model = PyListModel()
         self.vis_img_combo = gui.comboBox(
             self.visbox, self, 'cur_visible_image_idx',
             model=self.vis_img_name_model,
             callback=self.update_visible_image)
+
+        enable_widgets_by_show_chkbox = [
+            self.vis_img_combo
+        ]
+        for w in enable_widgets_by_show_chkbox:
+            self.show_vis_img.stateChanged.connect(w.setEnabled)
+
+        # emit signals to init connected entities
+        self.show_vis_img.stateChanged.emit(self.is_show_visible_image)
 
     def init_interface_data(self, data):
         same_domain = (self.data and data and

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1226,7 +1226,7 @@ class OWHyper(OWWidget):
         img_info = self.visible_image
         if self.show_visible_image and img_info is not None:
             self.visible_image_name = img_info["name"]  # save visual image name
-            img = Image.open(io.BytesIO(img_info['image_bytes']))
+            img = Image.open(io.BytesIO(img_info['image_bytes'])).convert('RGBA')
             # image must be vertically flipped
             # https://github.com/pyqtgraph/pyqtgraph/issues/315#issuecomment-214042453
             # Behavior may change at pyqtgraph 1.0 version

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -727,6 +727,10 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
     def hide_visible_image(self):
         self.plot.removeItem(self.vis_img)
 
+    def set_visible_image_opacity(self, opacity: int):
+        """Opacity is an alpha channel intensity integer from 0 to 255"""
+        self.vis_img.setOpacity(opacity / 255)
+
     @staticmethod
     def compute_image(data: Orange.data.Table, attr_x, attr_y,
                       image_values, image_values_fixed_levels, state: TaskState):
@@ -860,6 +864,7 @@ class OWHyper(OWWidget):
 
     is_show_visible_image = Setting(False)
     cur_visible_image_idx = Setting(-1)
+    visible_image_opacity = Setting(120)
 
     lowlim = Setting(None)
     highlim = Setting(None)
@@ -979,14 +984,25 @@ class OWHyper(OWWidget):
             model=self.vis_img_name_model,
             callback=self.update_visible_image)
 
+        self.vis_img_opacity_slider = gui.hSlider(
+            self.visbox, self, 'visible_image_opacity', label='Opacity:',
+            minValue=0, maxValue=255, step=10, createLabel=False,
+            callback=lambda: self.imageplot.set_visible_image_opacity(
+                self.visible_image_opacity)
+        )
+
         enable_widgets_by_show_chkbox = [
-            self.vis_img_combo
+            self.vis_img_combo,
+            self.vis_img_opacity_slider
         ]
         for w in enable_widgets_by_show_chkbox:
             self.show_vis_img.stateChanged.connect(w.setEnabled)
 
         # emit signals to init connected entities
         self.show_vis_img.stateChanged.emit(self.is_show_visible_image)
+        self.vis_img_opacity_slider.valueChanged.emit(
+            self.visible_image_opacity
+        )
 
     def init_interface_data(self, data):
         same_domain = (self.data and data and

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -916,6 +916,8 @@ class OWHyper(OWWidget):
         self.imageplot = ImagePlot(self)
         self.imageplot.selection_changed.connect(self.output_image_selection)
 
+        self.setup_visible_image_controls()
+
         self.curveplot = CurvePlotHyper(self, select=SELECTONE)
         self.curveplot.selection_changed.connect(self.redraw_integral_info)
         self.curveplot.plot.vb.x_padding = 0.005  # pad view so that lines are not hidden
@@ -945,11 +947,15 @@ class OWHyper(OWWidget):
         # prepare interface according to the new context
         self.contextAboutToBeOpened.connect(lambda x: self.init_interface_data(x[0]))
 
+    def setup_visible_image_controls(self):
+        self.visbox = gui.widgetBox(self.controlArea, True)
+
     def init_interface_data(self, data):
         same_domain = (self.data and data and
                        data.domain == self.data.domain)
         if not same_domain:
             self.init_attr_values(data)
+        self.init_visible_image(data)
 
     def output_image_selection(self):
         if not self.data:
@@ -974,6 +980,12 @@ class OWHyper(OWWidget):
         domain = data.domain if data is not None else None
         self.feature_value_model.set_domain(domain)
         self.attr_value = self.feature_value_model[0] if self.feature_value_model else None
+
+    def init_visible_image(self, data):
+        if data is not None and 'visible_images' in data.attributes:
+            self.visbox.setEnabled(True)
+        else:
+            self.visbox.setEnabled(False)
 
     def redraw_integral_info(self):
         di = {}

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -720,6 +720,13 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         self.vis_img.setImage(img)
         self.vis_img.setRect(rect)
 
+    def show_visible_image(self):
+        if self.vis_img not in self.plot.items:
+            self.plot.addItem(self.vis_img)
+
+    def hide_visible_image(self):
+        self.plot.removeItem(self.vis_img)
+
     @staticmethod
     def compute_image(data: Orange.data.Table, attr_x, attr_y,
                       image_values, image_values_fixed_levels, state: TaskState):
@@ -963,7 +970,8 @@ class OWHyper(OWWidget):
 
         self.show_vis_img = gui.checkBox(
             self.visbox, self, 'is_show_visible_image',
-            label='Show visible image')
+            label='Show visible image',
+            callback=self.toggle_visible_image)
 
         self.vis_img_name_model = PyListModel()
         self.vis_img_combo = gui.comboBox(
@@ -1021,6 +1029,7 @@ class OWHyper(OWWidget):
             self.cur_visible_image_idx = 0
         else:
             self.visbox.setEnabled(False)
+            self.show_vis_img.setChecked(False)
             self.cur_visible_image_idx = -1
 
     def redraw_integral_info(self):
@@ -1154,6 +1163,12 @@ class OWHyper(OWWidget):
         self.curveplot.shutdown()
         self.imageplot.shutdown()
         super().onDeleteWidget()
+
+    def toggle_visible_image(self):
+        if self.is_show_visible_image:
+            self.imageplot.show_visible_image()
+        else:
+            self.imageplot.hide_visible_image()
 
     def update_visible_image(self):
         idx = self.cur_visible_image_idx

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         package_data=PACKAGE_DATA,
         data_files=DATA_FILES,
         install_requires=[
-            'Orange3>=3.24.0',
+            'Orange3>=3.25.0',
             'scipy>=0.14.0',
             'spectral>=0.18',
             'serverfiles>=0.2',

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ if __name__ == '__main__':
             'h5py',
             'extranormal3',
             'renishawWiRE>=0.1.8',
+            'pillow',
         ],
         entry_points=ENTRY_POINTS,
         keywords=KEYWORDS,


### PR DESCRIPTION
Hi!

Sorry, I didn't start discussion in issues, since we discussed it at meetings.

Here is the following changes:

- Save all visible (microscopic) images (bytes, title, position and pixel size) from opus file into `data.attributes: dict[List[dict]]`;
- Bytes unpacked into `np.ndarray` with pillow package just before displaying it in `imageplot` (to save memory);
- Visible image can be selected from combo box;
- User can change opacity of visible image;
- User can select composition mode (Normal, Overlay, Multiply, Difference);

I don't have a good lightweight file to put in tests for Opus. The one I have weights 150 MBs

Closes #118