### PR TITLE
[FIX] HyperSpectra: fix coloring by categoric variables with missing values

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -7,7 +7,7 @@ import numpy as np
 from AnyQt.QtCore import QPointF, Qt
 from AnyQt.QtTest import QSignalSpy
 import Orange
-from Orange.data import DiscreteVariable
+from Orange.data import DiscreteVariable, Domain, Table
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.spectroscopy.widgets import owhyper
@@ -253,6 +253,19 @@ class TestOWHyper(WidgetTest):
             self.widget.attr_value = "petal width"
             self.widget.imageplot.update_color_schema()
             np.testing.assert_equal(len(p.call_args[0][0]), 256)  # 256 for a continuous variable
+
+    def test_color_variable_levels(self):
+        class_values = ["a"], ["a", "b", "c"]
+        correct_levels = [0, 0], [0, 2]
+        for values, correct in zip(class_values, correct_levels):
+            domain = Domain([], DiscreteVariable("c", values=values))
+            data = Table.from_numpy(domain, X=[[]], Y=[[0]])
+            self.send_signal("Data", data)
+            self.widget.controls.value_type.buttons[1].click()
+            self.widget.attr_value = data.domain.class_var
+            self.widget.update_feature_value()
+            wait_for_image(self.widget)
+            np.testing.assert_equal(self.widget.imageplot.img.levels, correct)
 
     def test_single_update_view(self):
         with patch("orangecontrib.spectroscopy.widgets.owhyper.ImagePlot.update_view") as p:

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -272,6 +272,14 @@ class TestOWHyper(WidgetTest):
             self.send_signal("Data", self.iris)
             self.assertEqual(p.call_count, 1)
 
+    def test_correct_legend(self):
+        self.send_signal("Data", self.iris)
+        wait_for_image(self.widget)
+        self.assertTrue(self.widget.imageplot.legend.isVisible())
+        self.widget.controls.value_type.buttons[1].click()
+        wait_for_image(self.widget)
+        self.assertFalse(self.widget.imageplot.legend.isVisible())
+
     def test_migrate_selection(self):
         c = QPointF()  # some we set an attribute to
         setattr(c, "selection", [False, True, True, False])

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -308,7 +308,10 @@ class ImageColorSettingMixin:
         return box
 
     def update_legend_visible(self):
-        self.legend.setVisible(self.show_legend)
+        if self.fixed_levels is not None:
+            self.legend.setVisible(False)
+        else:
+            self.legend.setVisible(self.show_legend)
 
     def update_levels(self):
         if not self.data:
@@ -776,6 +779,7 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         self.img.setImage(imdata, autoLevels=False)
         self.update_levels()
         self.update_color_schema()
+        self.update_legend_visible()
 
         # shift centres of the pixels so that the axes are useful
         shiftx = _shift(lsx)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -290,11 +290,11 @@ class ImageColorSettingMixin:
         self._level_high_le.validator().setDefault(1)
         form.addRow("High limit:", self._level_high_le)
 
-        lowslider = gui.hSlider(
+        self._threshold_low_slider = lowslider = gui.hSlider(
             box, self, "threshold_low", minValue=0.0, maxValue=1.0,
             step=0.05, ticks=True, intOnly=False,
             createLabel=False, callback=self.update_levels)
-        highslider = gui.hSlider(
+        self._threshold_high_slider = highslider = gui.hSlider(
             box, self, "threshold_high", minValue=0.0, maxValue=1.0,
             step=0.05, ticks=True, intOnly=False,
             createLabel=False, callback=self.update_levels)
@@ -334,6 +334,12 @@ class ImageColorSettingMixin:
 
         self._level_low_le.setPlaceholderText(rounded_levels[0])
         self._level_high_le.setPlaceholderText(rounded_levels[1])
+
+        enabled_level_settings = self.fixed_levels is None
+        self._level_low_le.setEnabled(enabled_level_settings)
+        self._level_high_le.setEnabled(enabled_level_settings)
+        self._threshold_low_slider.setEnabled(enabled_level_settings)
+        self._threshold_high_slider.setEnabled(enabled_level_settings)
 
         if self.fixed_levels is not None:
             self.img.setLevels(self.fixed_levels)


### PR DESCRIPTION
Fixes #422

Before, the levels for the color palette were set according to the displayed image values. For selections of the data, some values can be missing. If missing values were on the edges of variable.values, the colors were wrong. Color palette levels for categoric variables are now manually set to span all possible values.

Also disable color legend when not applicable.