### PR TITLE
Fixes DeprecationWarning for importing from collections

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1,5 +1,6 @@
 import random
-from collections import Iterable
+from collections.abc import Iterable
+
 from decimal import Decimal
 import time
 


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7