### PR TITLE
Readme for PyPI

### DIFF
--- a/README.pypi
+++ b/README.pypi
@@ -4,3 +4,17 @@ Spectral Orange
 Orange add-on for spectral data analysis. Provides spectra and
 hyperspectra plotting, interpolation, preprocessing (cutting, smoothing,
 normalization), and integration. Supports common spectral file formats.
+See [documentation](https://orange-spectroscopy.readthedocs.io/).
+
+Features
+--------
+### Load and process data
+* Load the spectroscopy data
+* Preprocess and interpolate spectra
+* Integrate spectra
+* Average spectra
+* Performs Fast Fourier Transform
+
+### Visualisation
+* Visually explore series of spectra
+* Plots 2D map of hyperspectra

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ if __name__ == '__main__':
         name="Orange-Spectroscopy",
         description='Extends Orange to handle spectral and hyperspectral analysis.',
         long_description=LONG_DESCRIPTION,
+        long_description_content_type='text/markdown',
         author='Canadian Light Source, Biolab UL, Soleil, Elettra',
         author_email='marko.toplak@gmail.com',
         version="0.5.5",


### PR DESCRIPTION
I am opening this pull request to format the PyPI readme with the same format than other Orange3 addons use. This way all addons have the same format for description in the Orange add-on dialogue. 

You are welcome to suggest any modification to this PR.