### PR TITLE
[FIX] Hyperspectra: do not crash with continous attributes

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -250,11 +250,17 @@ class TestOWHyper(WidgetTest):
         self.send_signal("Data", data)
         self.widget.controls.value_type.buttons[1].click()
         with patch("orangecontrib.spectroscopy.widgets.owhyper.ImageItemNan.setLookupTable") as p:
-            self.widget.attr_value = "iris"
+            # a discrete variable
+            self.widget.attr_value = data.domain["iris"]
             self.widget.imageplot.update_color_schema()
+            self.widget.update_feature_value()
+            wait_for_image(self.widget)
             np.testing.assert_equal(len(p.call_args[0][0]), 3)  # just 3 colors for 3 values
-            self.widget.attr_value = "petal width"
+            # a continuous variable
+            self.widget.attr_value = data.domain["petal width"]
             self.widget.imageplot.update_color_schema()
+            self.widget.update_feature_value()
+            wait_for_image(self.widget)
             np.testing.assert_equal(len(p.call_args[0][0]), 256)  # 256 for a continuous variable
 
     def test_color_variable_levels(self):

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1121,10 +1121,9 @@ class OWHyper(OWWidget):
                 data.transform(Domain([data.domain[attr]]))
 
     def image_values_fixed_levels(self):
-        if self.value_type == 0:  # integrals
-            return None
-        else:
+        if self.value_type == 1 and isinstance(self.attr_value, DiscreteVariable):
             return 0, len(self.attr_value.values) - 1
+        return None
 
     def redraw_data(self):
         self.redraw_integral_info()


### PR DESCRIPTION
A bug caused by a fix in #462. Sorry.

This bug is present in the latests Spectroscopy release (0.5.5). Release 0.5.4 (and the latest Quasar) are fine. @borondics already reported this in the beginning of September.