### PR TITLE
[FIX] AsciiColReader: .dpt files can also be comma-delimited

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -45,7 +45,10 @@ class AsciiColReader(FileFormat, SpectralFileFormat):
     DESCRIPTION = 'Spectra ASCII'
 
     def read_spectra(self):
-        tbl = np.loadtxt(self.filename, ndmin=2)
+        try:
+            tbl = np.loadtxt(self.filename, ndmin=2)
+        except ValueError:
+            tbl = np.loadtxt(self.filename, ndmin=2, delimiter=',')
         wavenumbers = tbl.T[0]  # first column is attribute name
         datavals = tbl.T[1:]
         return wavenumbers, datavals, None

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -71,6 +71,12 @@ class TestDat(unittest.TestCase):
             d2 = Orange.data.Table(fn)
             np.testing.assert_equal(d1.X, d2.X)
 
+    def test_comma_delim(self):
+        with named_file("15,500\n30,650\n", suffix=".dpt") as fn:
+            d = Orange.data.Table(fn)
+            np.testing.assert_equal(d.X, [[500., 650.]])
+
+
 
 try:
     no_visible_image = FileFormat.locate("opus/no_visible_images.0",


### PR DESCRIPTION
In fact, comma-delimited is the default output for OPUS!

I added a test as well with some simple synthetic data.