### PR TITLE
[FIX] hyper: Use Feature combobox show all variables and searchable

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -943,10 +943,11 @@ class OWHyper(OWWidget):
 
         self.box_values_feature = gui.indentedBox(rbox)
 
-        self.feature_value_model = DomainModel(DomainModel.METAS | DomainModel.CLASSES,
+        self.feature_value_model = DomainModel(DomainModel.SEPARATED,
                                                valid_types=DomainModel.PRIMITIVE)
         self.feature_value = gui.comboBox(
             self.box_values_feature, self, "attr_value",
+            contentsLength=12, searchable=True,
             callback=self.update_feature_value, model=self.feature_value_model)
 
         splitter = QSplitter(self)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -865,7 +865,7 @@ class OWHyper(OWWidget):
     replaces = ["orangecontrib.infrared.widgets.owhyper.OWHyper"]
     keywords = ["image", "spectral", "chemical", "imaging"]
 
-    settings_version = 4
+    settings_version = 5
     settingsHandler = DomainContextHandler()
 
     imageplot = SettingProvider(ImagePlot)


### PR DESCRIPTION
Fixes #330

Earlier, I wasn't sure how to handle backwards compatibility but I think our minimum supported Orange version contains this `comboBox` now.