### PR TITLE
[ENH] Agilent: Load visible images for mosaic data

### DIFF
--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 import configparser
 from pathlib import Path
@@ -218,13 +218,12 @@ def get_visible_images(p):
     """
     visible_images = []
 
-    config_ir = configparser.ConfigParser()
-    config_ir.read(p.parent.joinpath("IRMosaicInfo.cfg"))
-    config_vis = configparser.ConfigParser()
-    config_vis.read(p.parent.joinpath("VisMosaicInfo.cfg"))
+    config = configparser.ConfigParser()
+    config.read(p.parent.joinpath("IRMosaicInfo.cfg"))
+    config.read(p.parent.joinpath("VisMosaicInfo.cfg"))
 
     cutout_path = p.parent.joinpath("IrCutout.bmp")
-    if cutout_path.is_file() and config_ir.has_section('MicronMeasurements'):
+    if cutout_path.is_file() and config.has_section('MicronMeasurements'):
         with open(cutout_path, mode='rb') as file:
             img_bytes = file.read()
 
@@ -232,25 +231,25 @@ def get_visible_images(p):
              'image_bytes': img_bytes,
              'pos_x': 0,
              'pos_y': 0,
-             'img_size_x': float(config_ir['MicronMeasurements']['IrCollectWidthMicrons']),
-             'img_size_y': float(config_ir['MicronMeasurements']['IrCollectHeightMicrons']),
+             'img_size_x': float(config['MicronMeasurements']['IrCollectWidthMicrons']),
+             'img_size_y': float(config['MicronMeasurements']['IrCollectHeightMicrons']),
              }
         visible_images.append(d)
 
     full_img_path = p.parent.joinpath("VisMosaicCollectImages_Thumbnail.bmp")
-    if full_img_path.is_file() and config_ir.has_section('MicronMeasurements') \
-            and config_vis.has_section('VisMosaicDefinition'):
+    if full_img_path.is_file() and config.has_section('MicronMeasurements') \
+            and config.has_section('VisMosaicDefinition'):
         with open(full_img_path, mode='rb') as file:
             img_bytes = file.read()
 
         d = {'name': "Entire Image",
              'image_bytes': img_bytes,
-             'pos_x': -1 * float(config_ir['MicronMeasurements']['IrCollectStartLocationMicronsX']),
-             'pos_y': float(config_ir['MicronMeasurements']['IrCollectStartLocationMicronsY'])
-                      + float(config_ir['MicronMeasurements']['IrCollectHeightMicrons'])
-                      - float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsY']),
-             'img_size_x': float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsX']),
-             'img_size_y': float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsY']),
+             'pos_x': -1 * float(config['MicronMeasurements']['IrCollectStartLocationMicronsX']),
+             'pos_y': float(config['MicronMeasurements']['IrCollectStartLocationMicronsY'])
+                      + float(config['MicronMeasurements']['IrCollectHeightMicrons'])
+                      - float(config['VisMosaicDefinition']['MosaicSizeMicronsY']),
+             'img_size_x': float(config['VisMosaicDefinition']['MosaicSizeMicronsX']),
+             'img_size_y': float(config['VisMosaicDefinition']['MosaicSizeMicronsY']),
              }
         visible_images.append(d)
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -457,6 +457,7 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         am = agilentMosaic(self.filename, dtype=np.float64)
         info = am.info
         X = am.data
+        visible_images = am.vis
 
         try:
             features = info['wavenumbers']
@@ -472,7 +473,11 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
         y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
-        return _spectra_from_image(X, features, x_locs, y_locs)
+        features, data, additional_table = _spectra_from_image(X, features, x_locs, y_locs)
+
+        if visible_images:
+            additional_table.attributes['visible_images'] = visible_images
+        return features, data, additional_table
 
 
 class agilentMosaicIFGReader(FileFormat, SpectralFileFormat):

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -364,6 +364,14 @@ class TestVisibleImage(WidgetTest):
                 "pixel_size_x": 1,
                 "pixel_size_y": 0.3
             },
+            {
+                "name": "Image 03",
+                "image_bytes": red_img,
+                "pos_x": 100,
+                "pos_y": 100,
+                "img_size_x": 17.0,
+                "img_size_y": 23.0
+            },
         ]
 
     @classmethod
@@ -511,3 +519,21 @@ class TestVisibleImage(WidgetTest):
                 name = w.controls.visible_image_composition.currentText()
                 mode = w.visual_image_composition_modes[name]
                 m.assert_called_once_with(mode)
+
+    def test_visible_image_img_size(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        w.controls.show_visible_image.setChecked(True)
+        vis_img = w.imageplot.vis_img
+        with patch.object(vis_img, 'setRect', wraps=vis_img.setRect) as mock_rect:
+            w.controls.visible_image.setCurrentIndex(2)
+            # since activated signal emitted only by visual interaction
+            # we need to trigger it by hand here.
+            w.controls.visible_image.activated.emit(2)
+
+            self.assert_same_visible_image(data.attributes["visible_images"][0],
+                                           w.imageplot.vis_img,
+                                           mock_rect)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1230,10 +1230,14 @@ class OWHyper(OWWidget):
             # https://github.com/pyqtgraph/pyqtgraph/issues/315#issuecomment-214042453
             # Behavior may change at pyqtgraph 1.0 version
             img = np.array(img)[::-1]
+            width = img_info['img_size_x'] if 'img_size_x' in img_info \
+                else img.shape[1] * img_info['pixel_size_x']
+            height = img_info['img_size_y'] if 'img_size_y' in img_info \
+                else img.shape[0] * img_info['pixel_size_y']
             rect = QRectF(img_info['pos_x'],
                           img_info['pos_y'],
-                          img.shape[1] * img_info['pixel_size_x'],
-                          img.shape[0] * img_info['pixel_size_y'])
+                          width,
+                          height)
             self.imageplot.set_visible_image(img, rect)
             self.imageplot.show_visible_image()
         else:


### PR DESCRIPTION
Building on the great work in #443 , thanks again @pisarik 

Ref #118 

One thing I've noticed is that having the image stored in `attributes` dict as bytes makes the **Data Info** widget and `data.attributes` command slow / unusable. I think because they try to print/format megabytes of data. 

Not for this PR, but what about passing around a `BytesIO` object (or basically anything that could be an input to the `Image.open()` function in `update_visible_image()`)? 

For the latter the Agilent data could then wait to actually load the image data until requested, since the images are stored as separate files. 