### PR TITLE
[FIX] Don't put bytes in Visible Images dict

### DIFF
--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 import configparser
 from pathlib import Path
@@ -210,7 +210,7 @@ def get_visible_images(p):
 
     Each item is a dict with at least:
       'name':           IR Cutout or Entire Image
-      'image_bytes'     Image Bytes()
+      'image_ref'       Path to image file
       'pos_x'           Bottom-left corner, x (microns)
       'pos_y'           Bottom-left corner, y (microns)
       'img_size_x'      Width of image (microns)
@@ -224,11 +224,8 @@ def get_visible_images(p):
 
     cutout_path = p.parent.joinpath("IrCutout.bmp")
     if cutout_path.is_file() and config.has_section('MicronMeasurements'):
-        with open(cutout_path, mode='rb') as file:
-            img_bytes = file.read()
-
         d = {'name': "IR Cutout",
-             'image_bytes': img_bytes,
+             'image_ref': cutout_path,
              'pos_x': 0,
              'pos_y': 0,
              'img_size_x': float(config['MicronMeasurements']['IrCollectWidthMicrons']),
@@ -239,11 +236,8 @@ def get_visible_images(p):
     full_img_path = p.parent.joinpath("VisMosaicCollectImages_Thumbnail.bmp")
     if full_img_path.is_file() and config.has_section('MicronMeasurements') \
             and config.has_section('VisMosaicDefinition'):
-        with open(full_img_path, mode='rb') as file:
-            img_bytes = file.read()
-
         d = {'name': "Entire Image",
-             'image_bytes': img_bytes,
+             'image_ref': full_img_path,
              'pos_x': -1 * float(config['MicronMeasurements']['IrCollectStartLocationMicronsX']),
              'pos_y': float(config['MicronMeasurements']['IrCollectStartLocationMicronsY'])
                       + float(config['MicronMeasurements']['IrCollectHeightMicrons'])

--- a/orangecontrib/spectroscopy/agilent.py
+++ b/orangecontrib/spectroscopy/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 import configparser
 from pathlib import Path
@@ -218,13 +218,12 @@ def get_visible_images(p):
     """
     visible_images = []
 
-    config_ir = configparser.ConfigParser()
-    config_ir.read(p.parent.joinpath("IRMosaicInfo.cfg"))
-    config_vis = configparser.ConfigParser()
-    config_vis.read(p.parent.joinpath("VisMosaicInfo.cfg"))
+    config = configparser.ConfigParser()
+    config.read(p.parent.joinpath("IRMosaicInfo.cfg"))
+    config.read(p.parent.joinpath("VisMosaicInfo.cfg"))
 
     cutout_path = p.parent.joinpath("IrCutout.bmp")
-    if cutout_path.is_file() and config_ir.has_section('MicronMeasurements'):
+    if cutout_path.is_file() and config.has_section('MicronMeasurements'):
         with open(cutout_path, mode='rb') as file:
             img_bytes = file.read()
 
@@ -232,25 +231,25 @@ def get_visible_images(p):
              'image_bytes': img_bytes,
              'pos_x': 0,
              'pos_y': 0,
-             'img_size_x': float(config_ir['MicronMeasurements']['IrCollectWidthMicrons']),
-             'img_size_y': float(config_ir['MicronMeasurements']['IrCollectHeightMicrons']),
+             'img_size_x': float(config['MicronMeasurements']['IrCollectWidthMicrons']),
+             'img_size_y': float(config['MicronMeasurements']['IrCollectHeightMicrons']),
              }
         visible_images.append(d)
 
     full_img_path = p.parent.joinpath("VisMosaicCollectImages_Thumbnail.bmp")
-    if full_img_path.is_file() and config_ir.has_section('MicronMeasurements') \
-            and config_vis.has_section('VisMosaicDefinition'):
+    if full_img_path.is_file() and config.has_section('MicronMeasurements') \
+            and config.has_section('VisMosaicDefinition'):
         with open(full_img_path, mode='rb') as file:
             img_bytes = file.read()
 
         d = {'name': "Entire Image",
              'image_bytes': img_bytes,
-             'pos_x': -1 * float(config_ir['MicronMeasurements']['IrCollectStartLocationMicronsX']),
-             'pos_y': float(config_ir['MicronMeasurements']['IrCollectStartLocationMicronsY'])
-                      + float(config_ir['MicronMeasurements']['IrCollectHeightMicrons'])
-                      - float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsY']),
-             'img_size_x': float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsX']),
-             'img_size_y': float(config_vis['VisMosaicDefinition']['MosaicSizeMicronsY']),
+             'pos_x': -1 * float(config['MicronMeasurements']['IrCollectStartLocationMicronsX']),
+             'pos_y': float(config['MicronMeasurements']['IrCollectStartLocationMicronsY'])
+                      + float(config['MicronMeasurements']['IrCollectHeightMicrons'])
+                      - float(config['VisMosaicDefinition']['MosaicSizeMicronsY']),
+             'img_size_x': float(config['VisMosaicDefinition']['MosaicSizeMicronsX']),
+             'img_size_y': float(config['VisMosaicDefinition']['MosaicSizeMicronsY']),
              }
         visible_images.append(d)
 

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -457,6 +457,7 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         am = agilentMosaic(self.filename, dtype=np.float64)
         info = am.info
         X = am.data
+        visible_images = am.vis
 
         try:
             features = info['wavenumbers']
@@ -472,7 +473,11 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         x_locs = np.linspace(0, X.shape[1]*px_size, num=X.shape[1], endpoint=False)
         y_locs = np.linspace(0, X.shape[0]*px_size, num=X.shape[0], endpoint=False)
 
-        return _spectra_from_image(X, features, x_locs, y_locs)
+        features, data, additional_table = _spectra_from_image(X, features, x_locs, y_locs)
+
+        if visible_images:
+            additional_table.attributes['visible_images'] = visible_images
+        return features, data, additional_table
 
 
 class agilentMosaicIFGReader(FileFormat, SpectralFileFormat):

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1,3 +1,4 @@
+import io
 from collections import defaultdict
 from functools import reduce
 import numbers
@@ -786,7 +787,7 @@ class OPUSReader(FileFormat):
             try:
                 visible_images.append({
                     'name': img['Title'],
-                    'image_bytes': img['image'],
+                    'image_ref': io.BytesIO(img['image']),
                     'pos_x': img['Pos. X'] * img['PixelSizeX'],
                     'pos_y': img['Pos. Y'] * img['PixelSizeY'],
                     'pixel_size_x': img['PixelSizeX'],

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -364,6 +364,14 @@ class TestVisibleImage(WidgetTest):
                 "pixel_size_x": 1,
                 "pixel_size_y": 0.3
             },
+            {
+                "name": "Image 03",
+                "image_bytes": red_img,
+                "pos_x": 100,
+                "pos_y": 100,
+                "img_size_x": 17.0,
+                "img_size_y": 23.0
+            },
         ]
 
     @classmethod
@@ -511,3 +519,21 @@ class TestVisibleImage(WidgetTest):
                 name = w.controls.visible_image_composition.currentText()
                 mode = w.visual_image_composition_modes[name]
                 m.assert_called_once_with(mode)
+
+    def test_visible_image_img_size(self):
+        w = self.widget
+        data = self.data_with_visible_images
+        self.send_signal("Data", data)
+        wait_for_image(w)
+
+        w.controls.show_visible_image.setChecked(True)
+        vis_img = w.imageplot.vis_img
+        with patch.object(vis_img, 'setRect', wraps=vis_img.setRect) as mock_rect:
+            w.controls.visible_image.setCurrentIndex(2)
+            # since activated signal emitted only by visual interaction
+            # we need to trigger it by hand here.
+            w.controls.visible_image.activated.emit(2)
+
+            self.assert_same_visible_image(data.attributes["visible_images"][0],
+                                           w.imageplot.vis_img,
+                                           mock_rect)

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -338,19 +338,19 @@ class TestVisibleImage(WidgetTest):
 
     @classmethod
     def mock_visible_image_data(cls):
-        red_img = b64decode("iVBORw0KGgoAAAANSUhEUgAAAA"
-                            "oAAAAKCAYAAACNMs+9AAAAFUlE"
-                            "QVR42mP8z8AARIQB46hC+ioEAG"
-                            "X8E/cKr6qsAAAAAElFTkSuQmCC")
-        black_img = b64decode("iVBORw0KGgoAAAANSUhEUgAAA"
-                              "AoAAAAKCAQAAAAnOwc2AAAAEU"
-                              "lEQVR42mNk+M+AARiHsiAAcCI"
-                              "KAYwFoQ8AAAAASUVORK5CYII=")
+        red_img = io.BytesIO(b64decode("iVBORw0KGgoAAAANSUhEUgAAAA"
+                                       "oAAAAKCAYAAACNMs+9AAAAFUlE"
+                                       "QVR42mP8z8AARIQB46hC+ioEAG"
+                                       "X8E/cKr6qsAAAAAElFTkSuQmCC"))
+        black_img = io.BytesIO(b64decode("iVBORw0KGgoAAAANSUhEUgAAA"
+                                         "AoAAAAKCAQAAAAnOwc2AAAAEU"
+                                         "lEQVR42mNk+M+AARiHsiAAcCI"
+                                         "KAYwFoQ8AAAAASUVORK5CYII="))
 
         return [
             {
                 "name": "Image 01",
-                "image_bytes": red_img,
+                "image_ref": red_img,
                 "pos_x": 100,
                 "pos_y": 100,
                 "pixel_size_x": 1.7,
@@ -358,7 +358,7 @@ class TestVisibleImage(WidgetTest):
             },
             {
                 "name": "Image 02",
-                "image_bytes": black_img,
+                "image_ref": black_img,
                 "pos_x": 0.5,
                 "pos_y": 0.5,
                 "pixel_size_x": 1,
@@ -366,7 +366,7 @@ class TestVisibleImage(WidgetTest):
             },
             {
                 "name": "Image 03",
-                "image_bytes": red_img,
+                "image_ref": red_img,
                 "pos_x": 100,
                 "pos_y": 100,
                 "img_size_x": 17.0,
@@ -387,7 +387,7 @@ class TestVisibleImage(WidgetTest):
         self.widget = self.create_widget(OWHyper)  # type: OWHyper
 
     def assert_same_visible_image(self, img_info, vis_img, mock_rect):
-        img = Image.open(io.BytesIO(img_info["image_bytes"])).convert('RGBA')
+        img = Image.open(img_info["image_ref"]).convert('RGBA')
         img = np.array(img)[::-1]
         rect = QRectF(img_info['pos_x'], img_info['pos_y'],
                       img.shape[1] * img_info['pixel_size_x'],

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -111,7 +111,7 @@ class TestOpusReader(unittest.TestCase):
 
         img_info = d.attributes["visible_images"][0]
         # decompress bytes only in widgets to reduce memory footprint
-        self.assertEqual(type(img_info["image_bytes"]), bytes)
+        self.assertEqual(type(img_info["image_ref"].getvalue()), bytes)
         self.assertEqual(img_info["name"], "Image 01")
         self.assertAlmostEqual(img_info["pixel_size_x"], 0.90088498)
         self.assertAlmostEqual(img_info["pixel_size_y"], 0.89284902)
@@ -121,7 +121,7 @@ class TestOpusReader(unittest.TestCase):
                                20727.0 * img_info["pixel_size_y"])
 
         # test image
-        with BytesIO(img_info["image_bytes"]) as f:
+        with img_info["image_ref"] as f:
             img = Image.open(f)
             img = np.array(img)
             self.assertEqual(img.shape, (538, 666, 3))

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1,7 +1,6 @@
 import collections.abc
 from collections import OrderedDict
 from xml.sax.saxutils import escape
-import io
 
 from AnyQt.QtWidgets import QWidget, QPushButton, \
     QGridLayout, QFormLayout, QAction, QVBoxLayout, QWidgetAction, QSplitter, \
@@ -1225,7 +1224,7 @@ class OWHyper(OWWidget):
         img_info = self.visible_image
         if self.show_visible_image and img_info is not None:
             self.visible_image_name = img_info["name"]  # save visual image name
-            img = Image.open(io.BytesIO(img_info['image_bytes'])).convert('RGBA')
+            img = Image.open(img_info['image_ref']).convert('RGBA')
             # image must be vertically flipped
             # https://github.com/pyqtgraph/pyqtgraph/issues/315#issuecomment-214042453
             # Behavior may change at pyqtgraph 1.0 version

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1230,10 +1230,14 @@ class OWHyper(OWWidget):
             # https://github.com/pyqtgraph/pyqtgraph/issues/315#issuecomment-214042453
             # Behavior may change at pyqtgraph 1.0 version
             img = np.array(img)[::-1]
+            width = img_info['img_size_x'] if 'img_size_x' in img_info \
+                else img.shape[1] * img_info['pixel_size_x']
+            height = img_info['img_size_y'] if 'img_size_y' in img_info \
+                else img.shape[0] * img_info['pixel_size_y']
             rect = QRectF(img_info['pos_x'],
                           img_info['pos_y'],
-                          img.shape[1] * img_info['pixel_size_x'],
-                          img.shape[0] * img_info['pixel_size_y'])
+                          width,
+                          height)
             self.imageplot.set_visible_image(img, rect)
             self.imageplot.show_visible_image()
         else:


### PR DESCRIPTION
(Builds on #483, look at last commit for changes just in this PR)

Fixes the problem discussed in #483 where **Data Info** and `print(data.attributes)` struggle with printing large amounts of image `bytes`. 

My solution is to change the object passed in the dict to be something directly consumable by `PIL.Image.open()`:
* `io.BytesIO` for OPUS
* `pathlib.Path` for agilent

A few notes:

1. I found the tests insensitive to changing the structure of the img dict to remove img_bytes. I guess because the tests use a lot of synthetic code paths to avoid large actual data files. 
2. I don't seem to have the file for `test_one_visible_image_read` in `test_readers.TestOpusReader` so unsure if I correctly adapted those.
3. Also in this file is the comment (L113)
	`# decompress bytes only in widgets to reduce memory footprint`
Which I'm not sure if it's a test comment or architecture comment, and in any case, is it still accurate with this change?