### PR TITLE
[FIX] Renishaw map reading

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -549,14 +549,12 @@ class WiREReaders(FileFormat, SpectralFileFormat):
         return table
 
     def single_reader(self, wdf_file):
-
         domvals = wdf_file.xdata # energies
         y_data = wdf_file.spectra # spectra
 
         return domvals, y_data, None
 
     def series_reader(self, wdf_file):
-
         domvals = wdf_file.xdata # energies
         y_data = wdf_file.spectra # spectra
         z_locs = wdf_file.zpos # depth info
@@ -570,14 +568,17 @@ class WiREReaders(FileFormat, SpectralFileFormat):
         return domvals, y_data, data
 
     def map_reader(self, wdf_file):
-
         domvals = wdf_file.xdata
-
-        y_data = wdf_file.spectra
-        x_locs = np.unique(wdf_file.xpos)
-        y_locs = np.unique(wdf_file.ypos)
-
-        return _spectra_from_image_2d(y_data, domvals, x_locs, y_locs)
+        X = wdf_file.spectra  # a (rows, cols, wn) array
+        if X.ndim == 2:  # line scan
+            spectra = X
+        elif X.ndim == 3:  # a map, X is as (rows, cols, wn) array
+            spectra = X.reshape((X.shape[0] * X.shape[1], X.shape[2]))
+        else:
+            raise NotImplementedError
+        x_locs = wdf_file.xpos
+        y_locs = wdf_file.ypos
+        return _spectra_from_image_2d(spectra, domvals, x_locs, y_locs)
 
 
 class SPCReader(FileFormat):

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -188,14 +188,14 @@ class TestRenishawReader(unittest.TestCase):
         self.assertEqual(min(getx(d)), 1226.275269)
         self.assertEqual(max(getx(d)), 2787.514404)
 
-    # tested on 20200727, now disabled because data was too large for the repo
+    # tested on 20201103, now disabled because data was too large for the repo
     def disabled_test_depth_reader(self):
         d = Orange.data.Table("renishaw_test_files/depth.wdf")
         self.assertEqual(d.X[3][4], 1.8102257251739502)
         self.assertEqual(min(getx(d)), 1226.605347)
         self.assertEqual(max(getx(d)), 2787.782959)
 
-    # tested on 20200727, now disabled because data was too large for the repo
+    # tested on 20201103, now disabled because data was too large for the repo
     def disabled_test_map_reader(self):
         # this is a line map, but the 2D maps are the same structure
         d = Orange.data.Table("renishaw_test_files/line.wdf")


### PR DESCRIPTION
The library we use to open the files opens maps and line scans differently. The current code can now do both.