### PR TITLE
Add lmfit to requirements

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - extranormal3 >=0.0.3
     - renishawWiRE >=0.1.8
     - pillow
+    - lmfit
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ if __name__ == '__main__':
             'extranormal3',
             'renishawWiRE>=0.1.8',
             'pillow',
+            'lmfit',
         ],
         entry_points=ENTRY_POINTS,
         keywords=KEYWORDS,


### PR DESCRIPTION
Christophe requested it because he would like fitting scripts to work easily in a new Quasar installation. Additional dependencies are negligible.