### PR TITLE
Fix cursor position display in numeric line edits

### DIFF
--- a/orangecontrib/spectroscopy/widgets/gui.py
+++ b/orangecontrib/spectroscopy/widgets/gui.py
@@ -190,7 +190,7 @@ class LineEdit(LineEditMarkFinished):
 
     def focusInEvent(self, *e):
         self.focusIn.emit()
-        return QWidget.focusInEvent(self, *e)
+        return super().focusInEvent(*e)
 
     def sizeHint(self):
         sh = super().sizeHint()


### PR DESCRIPTION
The text cursor was not shown in validated line edits.