### PR TITLE
owpreprocess: fix scroll area size propagation into controlArea

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -1717,6 +1717,14 @@ class SpectralPreprocess(OWWidget, ConcurrentWidgetMixin, openclass=True):
         sh = self.flow_view.minimumSizeHint()
         self.scroll_area.setMinimumWidth(max(sh.width() + 50, 200))
 
+        # call updateGeometry on the controlArea's scroll area, to expand/squeeze
+        # it with widget-base 4.12.0 if a big preprocessor widget is added
+        parent = self.controlArea
+        while parent is not None and not isinstance(parent, gui.VerticalScrollArea):
+            parent = parent.parentWidget()
+        if parent is not None:
+            parent.updateGeometry()
+
     def sizeHint(self):
         sh = super().sizeHint()
         return sh.expandedTo(QSize(sh.width(), 500))


### PR DESCRIPTION
This fix is needed because the scroll area from orange-widget-base 4.12.0 (and possibly 4.11.0) reacts to size changes differently.

The problem looked like this (hiding and showing the control area would fix it though).

![image](https://user-images.githubusercontent.com/552182/109948639-d13bbd00-7cda-11eb-9b4e-1aa9b268f947.png)