### PR TITLE
Replacing slow numpy functions with faster bottleneck imlementations

### DIFF
--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -61,6 +61,7 @@ def index_values_nan(vals, linspace):
     positions = location_values(vals, linspace)
     return np.round(positions).astype(int), np.isnan(positions)
 
+
 class NanInsideHypercube(Exception):
     pass
 

--- a/orangecontrib/spectroscopy/widgets/owstackalign.py
+++ b/orangecontrib/spectroscopy/widgets/owstackalign.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pyqtgraph as pg
+import bottleneck as bn
 
 from scipy.ndimage import sobel
 from scipy.ndimage.interpolation import shift
@@ -25,6 +26,7 @@ from orangecontrib.spectroscopy.utils.skimage.register_translation import regist
 # instead of from skimage.feature import register_translation
 
 # stack alignment code originally from: https://github.com/jpacold/STXM_live
+
 
 class RegisterTranslation:
 
@@ -77,8 +79,8 @@ def alignstack(raw, shiftfn, ref_frame_num=0, filterfn=lambda x: x):
 
 def process_stack(data, xat, yat, upsample_factor=100, use_sobel=False, ref_frame_num=0):
     hypercube, lsx, lsy = get_hypercube(data, xat, yat)
-    if np.any(np.isnan(hypercube)):
-        raise NanInsideHypercube(np.sum(np.isnan(hypercube)))
+    if bn.anynan(hypercube):
+        raise NanInsideHypercube(True)
 
     calculate_shift = RegisterTranslation(upsample_factor=upsample_factor)
     filterfn = sobel if use_sobel else lambda x: x
@@ -104,7 +106,7 @@ def process_stack(data, xat, yat, upsample_factor=100, use_sobel=False, ref_fram
                                                          np.linspace(*lsy)[slicey]))
 
 
-class   OWStackAlign(OWWidget):
+class OWStackAlign(OWWidget):
     # Widget's name as displayed in the canvas
     name = "Align Stack"
 


### PR DESCRIPTION
A very low hanging fruit after @markotoplak told me about it but I am willing to do the easy stuff ;)

If this makes sense, we could replace those functions that have been implemented in faster libraries.

In this case I got a 10x speedup for a 1E6 size vector with 2 NaNs. Admittedly, the speedup was from 500 µs to 5 µs, but still, the 10x sounds good. I can't verify if this saves any memory though.

@markotoplak: should I move on with hunting down all the instances for this function? I can just add everything to this same pull request.