### PR TITLE
Use bottleneck for np.array operations with nans

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - renishawWiRE >=0.1.8
     - pillow
     - lmfit
+    - bottleneck
 
 test:
   imports:

--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -5,6 +5,7 @@ import numbers
 import struct
 from html.parser import HTMLParser
 
+import bottleneck
 import numpy as np
 import spectral.io.envi
 from scipy.interpolate import interp1d
@@ -1140,7 +1141,7 @@ class DatMetaReader(FileFormat):
 
 
 def spectra_mean(X):
-    return np.nanmean(X, axis=0, dtype=np.float64)
+    return bottleneck.nanmean(X, axis=0)
 
 
 def reader_gsf(file_path):

--- a/orangecontrib/spectroscopy/preprocess/integrate.py
+++ b/orangecontrib/spectroscopy/preprocess/integrate.py
@@ -1,14 +1,11 @@
 from collections.abc import Iterable
 
-import Orange
+import bottleneck
 import numpy as np
-from Orange.data.util import SharedComputeValue
-from Orange.preprocess.preprocess import Preprocess
 
-try:  # get_unique_names was introduced in Orange 3.20
-    from Orange.widgets.utils.annotated_data import get_next_name as get_unique_names
-except ImportError:
-    from Orange.data.util import get_unique_names
+import Orange
+from Orange.data.util import SharedComputeValue, get_unique_names
+from Orange.preprocess.preprocess import Preprocess
 
 from AnyQt.QtCore import Qt
 
@@ -126,11 +123,11 @@ class IntegrateFeaturePeakEdgeBaseline(IntegrateFeature):
         y_s = y_s - self.compute_baseline(x_s, y_s)
         if len(x_s) == 0:
             return np.zeros((y_s.shape[0],)) * np.nan
-        return np.nanmax(y_s, axis=1)
+        return bottleneck.nanmax(y_s, axis=1)
 
     def compute_draw_info(self, x, ys):
         bs = self.compute_baseline(x, ys)
-        im = np.nanargmax(ys-bs, axis=1)
+        im = bottleneck.nanargmax(ys-bs, axis=1)
         lines = (x[im], bs[np.arange(bs.shape[0]), im]), (x[im], ys[np.arange(ys.shape[0]), im])
         return [("curve", (x, self.compute_baseline(x, ys), INTEGRATE_DRAW_BASELINE_PENARGS)),
                 ("curve", (x, ys, INTEGRATE_DRAW_BASELINE_PENARGS)),
@@ -168,14 +165,14 @@ class IntegrateFeaturePeakXEdgeBaseline(IntegrateFeature):
         whole_nan_rows = np.isnan(y_s).all(axis=1)
         y_s[whole_nan_rows] = 0
         # select positions
-        pos = x_s[np.nanargmax(y_s, axis=1)]
+        pos = x_s[bottleneck.nanargmax(y_s, axis=1)]
         # set unknown results
         pos[whole_nan_rows] = np.nan
         return pos
 
     def compute_draw_info(self, x, ys):
         bs = self.compute_baseline(x, ys)
-        im = np.nanargmax(ys-bs, axis=1)
+        im = bottleneck.nanargmax(ys-bs, axis=1)
         lines = (x[im], bs[np.arange(bs.shape[0]), im]), (x[im], ys[np.arange(ys.shape[0]), im])
         return [("curve", (x, self.compute_baseline(x, ys), INTEGRATE_DRAW_BASELINE_PENARGS)),
                 ("curve", (x, ys, INTEGRATE_DRAW_BASELINE_PENARGS)),
@@ -211,12 +208,12 @@ class IntegrateFeatureAtPeak(IntegrateFeature):
     def compute_integral(self, x_s, y_s):
         if len(x_s) == 0:
             return np.zeros((y_s.shape[0],)) * np.nan
-        closer = np.nanargmin(abs(x_s - self.limits[0]))
+        closer = bottleneck.nanargmin(abs(x_s - self.limits[0]))
         return y_s[:, closer]
 
     def compute_draw_info(self, x, ys):
         bs = self.compute_baseline(x, ys)
-        im = np.array([np.nanargmin(abs(x - self.limits[0]))])
+        im = np.array([bottleneck.nanargmin(abs(x - self.limits[0]))])
         dx = [self.limits[0], self.limits[0]]
         dys = np.hstack((bs[:, im], ys[:, im]))
         return [("curve", (dx, dys, INTEGRATE_DRAW_EDGE_PENARGS)),  # line to value

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -1,3 +1,4 @@
+import bottleneck
 import numpy as np
 from Orange.data.util import SharedComputeValue
 from scipy.interpolate import interp1d
@@ -141,7 +142,7 @@ def nan_extend_edges_and_interpolate(xs, X):
     so that they do not propagate.
     """
     nans = None
-    if np.any(np.isnan(X)):
+    if bottleneck.anynan(X):
         nans = np.isnan(X)
         X = X.copy()
         xs, xsind, mon, X = transform_to_sorted_wavenumbers(xs, X)
@@ -184,7 +185,7 @@ def fill_edges(mat):
 
 def remove_whole_nan_ys(x, ys):
     """Remove whole NaN columns of ys with corresponding x coordinates."""
-    whole_nan_columns = np.isnan(ys).all(axis=0)
+    whole_nan_columns = bottleneck.allnan(ys, axis=0)
     if np.any(whole_nan_columns):
         x = x[~whole_nan_columns]
         ys = ys[:, ~whole_nan_columns]

--- a/orangecontrib/spectroscopy/utils/binning.py
+++ b/orangecontrib/spectroscopy/utils/binning.py
@@ -1,3 +1,4 @@
+import bottleneck
 import numpy as np
 
 from Orange.data import Domain, Table
@@ -32,7 +33,7 @@ def bin_mean(data, bin_shape, n_attrs):
     except ValueError as e:
         raise InvalidBlockShape(str(e))
     flatten_view = view.reshape(view.shape[0], view.shape[1], -1, n_attrs)
-    mean_view = np.nanmean(flatten_view, axis=2)
+    mean_view = bottleneck.nanmean(flatten_view, axis=2)
     return mean_view
 
 

--- a/orangecontrib/spectroscopy/widgets/line_geometry.py
+++ b/orangecontrib/spectroscopy/widgets/line_geometry.py
@@ -1,3 +1,4 @@
+import bottleneck
 import numpy as np
 
 
@@ -127,9 +128,9 @@ def distance_curves(x, ys, q1):
     xp = rolling_window(x, 2)
     ysp = rolling_window(ys, 2)
 
-    r = np.nanmin(distance_line_segment(xp[:, 0], ysp[:, :, 0],
-                              xp[:, 1], ysp[:, :, 1],
-                              q1[0], q1[1]), axis=1)
+    r = bottleneck.nanmin(distance_line_segment(xp[:, 0], ysp[:, :, 0],
+                                                xp[:, 1], ysp[:, :, 1],
+                                                q1[0], q1[1]), axis=1)
 
     return r
 

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -1,3 +1,4 @@
+import bottleneck
 import numpy as np
 
 import Orange.data
@@ -78,7 +79,7 @@ class OWAverage(OWWidget):
         """
         if len(table) == 0:
             return table
-        mean = np.nanmean(table.X, axis=0, keepdims=True)
+        mean = bottleneck.nanmean(table.X, axis=0).reshape(1, -1)
         avg_table = Orange.data.Table.from_numpy(table.domain,
                                                  X=mean,
                                                  Y=np.atleast_2d(table.Y[0].copy()),

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -13,6 +13,7 @@ from AnyQt.QtTest import QTest
 
 from AnyQt.QtCore import pyqtSignal as Signal
 
+import bottleneck
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph import GraphicsWidget
@@ -120,7 +121,7 @@ def get_levels(img):
     """ Compute levels. Account for NaN values. """
     while img.size > 2 ** 16:
         img = img[::2, ::2]
-    mn, mx = np.nanmin(img), np.nanmax(img)
+    mn, mx = bottleneck.nanmin(img), bottleneck.nanmax(img)
     if mn == mx:
         mn = 0
         mx = 255

--- a/orangecontrib/spectroscopy/widgets/owsnr.py
+++ b/orangecontrib/spectroscopy/widgets/owsnr.py
@@ -1,3 +1,4 @@
+import bottleneck
 import numpy as np
 
 import Orange.data
@@ -93,13 +94,13 @@ class OWSNR(OWWidget):
         if len(array) == 0:
             return array
         if self.out_choiced == 0: #snr
-            return self.make_table(np.nanmean(array, axis=0,
-                                              keepdims=True) / np.std(array, axis=0,
-                                                                      keepdims=True), self.data)
+            return self.make_table(
+                (bottleneck.nanmean(array, axis=0) /
+                 bottleneck.nanstd(array, axis=0)).reshape(1, -1), self.data)
         elif self.out_choiced == 1: #avg
-            return self.make_table(np.nanmean(array, axis=0, keepdims=True), self.data)
+            return self.make_table(bottleneck.nanmean(array, axis=0).reshape(1, -1), self.data)
         else: # std
-            return self.make_table(np.std(array, axis=0, keepdims=True), self.data)
+            return self.make_table(bottleneck.nanstd(array, axis=0).reshape(1, -1), self.data)
 
 
     @staticmethod

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -13,6 +13,7 @@ from AnyQt.QtGui import QColor, QPixmapCache, QPen, QKeySequence
 from AnyQt.QtCore import Qt, QRectF, QPointF, QObject
 from AnyQt.QtCore import pyqtSignal
 
+import bottleneck
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ViewBox import ViewBox
@@ -286,11 +287,11 @@ class ShowAverage(QObject, ConcurrentMixin):
                     part_selection = indices & subset_indices
                 if np.any(part_selection):
                     std = apply_columns_numpy(data.X,
-                                              lambda x: np.nanstd(x, axis=0),
+                                              lambda x: bottleneck.nanstd(x, axis=0),
                                               part_selection,
                                               callback=progress_interrupt)
                     mean = apply_columns_numpy(data.X,
-                                               lambda x: np.nanmean(x, axis=0),
+                                               lambda x: bottleneck.nanmean(x, axis=0),
                                                part_selection,
                                                callback=progress_interrupt)
                     std = std[data_xsind]
@@ -1333,8 +1334,9 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
             self.add_curve(x, y, ignore_bounds=True)
 
         if x.size and ys.size:
-            bounding_rect = QGraphicsRectItem(QRectF(QPointF(np.nanmin(x), np.nanmin(ys)),
-                                                     QPointF(np.nanmax(x), np.nanmax(ys))))
+            bounding_rect = QGraphicsRectItem(QRectF(
+                QPointF(bottleneck.nanmin(x), bottleneck.nanmin(ys)),
+                QPointF(bottleneck.nanmax(x), bottleneck.nanmax(ys))))
             bounding_rect.setPen(QPen(Qt.NoPen))  # prevents border of 1
             self.curves_cont.add_bounds(bounding_rect)
 

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
             'renishawWiRE>=0.1.8',
             'pillow',
             'lmfit',
+            'bottleneck',
         ],
         extras_require={
             'test': ['coverage']


### PR DESCRIPTION
This is faster and more memory-efficient.

For example, `np.nanmean` makes some auxiliary arrays and thus needs much more memory (at least 2x).

@borondics, I try to replace most of them, but I am sure I missed some. :) I focused on those working on big matrices, and I left some working on vectors as they were.

When I tried `numpy` vs bottleneck on 1GB array with `nanmean` I got significant differences. I think these won't turn into significant speedups except where `nanmean` used too much memory.
