### PR TITLE
[FIX] OWPeakFit: Peak areas must account for x sample points

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -10,7 +10,7 @@ from Orange.widgets.tests.base import WidgetTest
 from orangewidget.tests.base import GuiTest
 
 from orangecontrib.spectroscopy.data import getx
-from orangecontrib.spectroscopy.preprocess import Cut, LinearBaseline
+from orangecontrib.spectroscopy.preprocess import Cut, LinearBaseline, Integrate
 from orangecontrib.spectroscopy.tests.spectral_preprocess import wait_for_preview
 from orangecontrib.spectroscopy.widgets.gui import MovableVline
 from orangecontrib.spectroscopy.widgets.owpeakfit import OWPeakFit, fit_peaks, PREPROCESSORS, \
@@ -309,6 +309,17 @@ class TestVoigtEditorMulti(ModelEditorTest):
 
         self.assertEqual(self.model.name, sv_model.name)
         self.assertEqual(set(self.params), set(sv_params))
+
+    def test_total_area(self):
+        """ Test v0 + v1 area == total fit area """
+        fit_params = self.get_output(self.widget.Outputs.fit_params)
+        fits = self.get_output(self.widget.Outputs.fits)
+        xs = getx(fits)
+        total_areas = Integrate(methods=Integrate.Simple, limits=[[xs.min(), xs.max()]])(fits)
+        total_area = total_areas.X[0, 0]
+        v0_area = fit_params[0]["v0 area"].value
+        v1_area = fit_params[0]["v1 area"].value
+        self.assertEqual(total_area, v0_area + v1_area)
 
 
 class TestParamHintBox(GuiTest):

--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -259,6 +259,9 @@ class TestVoigtEditorMulti(ModelEditorTest):
                         for _ in range(len(self.pcs))]
         self.data = COLLAGEN_2
         self.send_signal(self.widget.Inputs.data, self.data)
+        self.model, self.params = self.matched_models()
+        self.widget.unconditional_commit()
+        self.wait_until_finished()
 
     def matched_models(self):
         mlist = [lmfit.models.VoigtModel(prefix=f"v{i}_") for i in range(len(self.pcs))]
@@ -281,38 +284,31 @@ class TestVoigtEditorMulti(ModelEditorTest):
         return model, params
 
     def test_same_params(self):
-        model, params = self.matched_models()
         m_def = [self.widget.preprocessormodel.item(i)
                  for i in range(self.widget.preprocessormodel.rowCount())]
         ed_model, ed_params = create_composite_model(m_def)
 
-        self.assertEqual(model.name, ed_model.name)
-        self.assertEqual(set(params), set(ed_params))
-        for k, v in params.items():
+        self.assertEqual(self.model.name, ed_model.name)
+        self.assertEqual(set(self.params), set(ed_params))
+        for k, v in self.params.items():
             self.assertEqual(v, ed_params[k])
 
     def test_same_output(self):
-        model, params = self.matched_models()
-
-        out_fit = fit_peaks(self.data, model, params)
-
-        self.widget.unconditional_commit()
-        self.wait_until_finished()
+        out_fit = fit_peaks(self.data, self.model, self.params)
         out = self.get_output(self.widget.Outputs.fit_params)
 
         self.assertEqual(out_fit.domain.attributes, out.domain.attributes)
         np.testing.assert_array_equal(out_fit.X, out.X)
 
     def test_saving_model_params(self):
-        model, params = self.matched_models()
         settings = self.widget.settingsHandler.pack_data(self.widget)
-        self.widget = self.create_widget(OWPeakFit, stored_settings=settings)
-        m_def = [self.widget.preprocessormodel.item(i)
-                 for i in range(self.widget.preprocessormodel.rowCount())]
+        restored_widget = self.create_widget(OWPeakFit, stored_settings=settings)
+        m_def = [restored_widget.preprocessormodel.item(i)
+                 for i in range(restored_widget.preprocessormodel.rowCount())]
         sv_model, sv_params = create_composite_model(m_def)
 
-        self.assertEqual(model.name, sv_model.name)
-        self.assertEqual(set(params), set(sv_params))
+        self.assertEqual(self.model.name, sv_model.name)
+        self.assertEqual(set(self.params), set(sv_params))
 
 
 class TestParamHintBox(GuiTest):

--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -3,7 +3,6 @@ from functools import reduce
 
 from lmfit import Parameters
 import numpy as np
-from scipy import integrate
 
 from Orange.data import Table, ContinuousVariable, Domain
 from Orange.widgets.data.owpreprocess import PreprocessAction, Description, icon_path
@@ -49,7 +48,7 @@ def add_result_to_output_array(output, i, model_result, x):
     col = 0
     for comp in out.components:
         # Peak area
-        output[i, col] = integrate.trapz(comps[comp.prefix])
+        output[i, col] = np.trapz(comps[comp.prefix], x)
         col += 1
         for param in [n for n in out.var_names if n.startswith(comp.prefix)]:
             output[i, col] = best_values[param]


### PR DESCRIPTION
Fixes #556 

Tests will fail until #557 is fixed as well.