### PR TITLE
[FIX] Multifile widget: proper handling of nominal features with non-overlapping values

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owmultifile.py
+++ b/orangecontrib/spectroscopy/tests/test_owmultifile.py
@@ -326,3 +326,21 @@ class TestOWMultifile(WidgetTest):
                     self.load_files(fn2, reader=AsciiColReader)
                     out = self.get_output(self.widget.Outputs.data)
                     np.testing.assert_equal(out.X, concat[[0, 2, 1]])
+
+    def test_special_spectral_reader_metas(self):
+        n =  """\
+        100.000000\t200.000000\t300.000000\tmeta
+        \t\t\tstring\n
+        \t\t\tmeta\n
+        4\t5\t6\thello
+        """
+        with named_file(n, suffix=".tab") as fn:
+            self.load_files("small_diamond_nxs.nxs")  # special spectral rader
+            self.load_files(fn)
+            out = self.get_output(self.widget.Outputs.data)
+            self.assertEqual([a.name for a in out.domain.metas[:3]],
+                             ["map_x", "map_y", "meta"])
+            self.assertAlmostEqual(out[0]['map_x'], -1.77900021)
+            self.assertAlmostEqual(out[0]['map_y'], -2.74319824)
+            self.assertEqual(out[0]['meta'].value, "")
+            self.assertEqual(out[-1]['meta'].value, "hello")

--- a/orangecontrib/spectroscopy/tests/test_owmultifile.py
+++ b/orangecontrib/spectroscopy/tests/test_owmultifile.py
@@ -12,6 +12,7 @@ from Orange.widgets.tests.base import WidgetTest
 from Orange.data import FileFormat, dataset_dirs, Table
 from Orange.widgets.utils.filedialogs import format_filter
 from Orange.data.io import TabReader
+from Orange.tests import named_file
 
 from orangecontrib.spectroscopy.data import SPAReader
 from orangecontrib.spectroscopy.widgets.owmultifile import OWMultifile, numpy_union_keep_order
@@ -258,3 +259,23 @@ class TestOWMultifile(WidgetTest):
         self.assertEqual(2, self.widget.sheet_combo.currentIndex())
         out = self.get_output(self.widget.Outputs.data)
         self.assertAlmostEqual(0.91213142, out.X[0][0])
+
+    def test_repeated_discrete_disjuct_values(self):
+        f1 = """\
+        Disjunct values\tCommon values
+        M      \tM
+        M      \tF
+        """
+        f2 = """\
+        Disjunct values\tCommon values
+        F      \tF
+        F      \tM
+        """
+        with named_file(f1, suffix=".tab") as fn1:
+            with named_file(f2, suffix=".tab") as fn2:
+                self.load_files(fn1, fn2)
+                out = self.get_output(self.widget.Outputs.data)
+                disjunct = [str(a[0]) for a in out]
+                self.assertEqual(disjunct, ['M', 'M', 'F', "F"])
+                common = [str(a[1]) for a in out]
+                self.assertEqual(common, ['M', 'F', 'F', "M"])


### PR DESCRIPTION
The code had bugs after Orange transitioned from `Variable.make` to a different kind of handling values for `DiscreteVariables`; see the tests in the first commit.

Thanks to @VesnaT for finding the bug and working out the solution for non-spectral files.