### PR TITLE
[ENH] Visualizations: selection outputs groups

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -625,10 +625,10 @@ class TestVisibleImage(WidgetTest):
         OWHyper.migrate_settings(settings, 6)
         self.assertEqual(settings, {})
         self.widget = self.create_widget(OWHyper, stored_settings=settings)
-        self.assertFalse(self.widget.Information.compat_no_group.is_shown())
+        self.assertFalse(self.widget.compat_no_group)
 
         settings = {}
         OWHyper.migrate_settings(settings, 5)
         self.assertEqual(settings, {"compat_no_group": True})
         self.widget = self.create_widget(OWHyper, stored_settings=settings)
-        self.assertTrue(self.widget.Information.compat_no_group.is_shown())
+        self.assertTrue(self.widget.compat_no_group)

--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -518,10 +518,14 @@ class TestOWSpectra(WidgetTest):
         OWSpectra.migrate_settings(settings, 3)
         self.assertEqual(settings, {})
         self.widget = self.create_widget(OWSpectra, stored_settings=settings)
-        self.assertFalse(self.widget.Information.compat_no_group.is_shown())
+        self.assertFalse(self.widget.compat_no_group)
+        # We decided to remove the info box
+        # self.assertFalse(self.widget.Information.compat_no_group.is_shown())
 
         settings = {}
         OWSpectra.migrate_settings(settings, 2)
         self.assertEqual(settings, {"compat_no_group": True})
         self.widget = self.create_widget(OWSpectra, stored_settings=settings)
-        self.assertTrue(self.widget.Information.compat_no_group.is_shown())
+        self.assertTrue(self.widget.compat_no_group)
+        # We decided to remove the info box
+        # self.assertTrue(self.widget.Information.compat_no_group.is_shown())

--- a/orangecontrib/spectroscopy/tests/test_owspectralseries.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectralseries.py
@@ -131,10 +131,10 @@ class TestOWSpectralSeries(WidgetTest):
         OWSpectralSeries.migrate_settings(settings, 2)
         self.assertEqual(settings, {})
         self.widget = self.create_widget(OWSpectralSeries, stored_settings=settings)
-        self.assertFalse(self.widget.Information.compat_no_group.is_shown())
+        self.assertFalse(self.widget.compat_no_group)
 
         settings = {}
         OWSpectralSeries.migrate_settings(settings, 1)
         self.assertEqual(settings, {"compat_no_group": True})
         self.widget = self.create_widget(OWSpectralSeries, stored_settings=settings)
-        self.assertTrue(self.widget.Information.compat_no_group.is_shown())
+        self.assertTrue(self.widget.compat_no_group)

--- a/orangecontrib/spectroscopy/tests/test_owspectralseries.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectralseries.py
@@ -80,6 +80,7 @@ class TestOWSpectralSeries(WidgetTest):
         out = self.get_output("Selection")
         np.testing.assert_equal(out.metas[:, 0], 1)
         np.testing.assert_equal(out.metas[:, 1], 99)
+        np.testing.assert_equal(out.Y, 0)  # selection group
         # select a feature
         self.widget.imageplot.attr_x = "map_x"
         self.widget.imageplot.update_attr()
@@ -87,6 +88,7 @@ class TestOWSpectralSeries(WidgetTest):
         out = self.get_output("Selection")
         np.testing.assert_equal(out.metas[:, 0], 1)
         np.testing.assert_equal(out.metas[:, 1], list(reversed(np.arange(100))))
+        np.testing.assert_equal(out.Y, 0)  # selection group
 
     def test_single_update_view(self):
         uw = "orangecontrib.spectroscopy.widgets.owspectralseries.LineScanPlot.update_view"
@@ -123,3 +125,16 @@ class TestOWSpectralSeries(WidgetTest):
                 self.assertIn("value = {}".format(data[3, 2]), text)
                 self.assertIn("value = {}".format(data[51, 2]), text)
                 self.assertEqual(2, text.count("iris ="))
+
+    def test_compat_no_group(self):
+        settings = {}
+        OWSpectralSeries.migrate_settings(settings, 2)
+        self.assertEqual(settings, {})
+        self.widget = self.create_widget(OWSpectralSeries, stored_settings=settings)
+        self.assertFalse(self.widget.Information.compat_no_group.is_shown())
+
+        settings = {}
+        OWSpectralSeries.migrate_settings(settings, 1)
+        self.assertEqual(settings, {"compat_no_group": True})
+        self.widget = self.create_widget(OWSpectralSeries, stored_settings=settings)
+        self.assertTrue(self.widget.Information.compat_no_group.is_shown())

--- a/orangecontrib/spectroscopy/widgets/utils.py
+++ b/orangecontrib/spectroscopy/widgets/utils.py
@@ -1,7 +1,12 @@
 import array
 
 import numpy as np
-from Orange.widgets.utils.annotated_data import create_annotated_table, create_groups_table
+
+from Orange.data import Table
+from Orange.widgets.utils.annotated_data import \
+    ANNOTATED_DATA_SIGNAL_NAME, create_annotated_table, create_groups_table
+from Orange.widgets.settings import Setting
+from Orange.widgets.widget import OWWidget, Msg, Output
 
 
 def pack_selection(selection_group):
@@ -58,3 +63,59 @@ def groups_or_annotated_table(data, selection):
         return create_groups_table(data, selection)
     else:
         return create_annotated_table(data, np.flatnonzero(selection))
+
+
+class SelectionGroupMixin:
+    selection_group_saved = Setting(None, schema_only=True)
+
+    def __init__(self):
+        self.selection_group = np.array([], dtype=np.uint8)
+        # Remember the saved state to restore with the first open file
+        self._pending_selection_restore = self.selection_group_saved
+
+    def restore_selection_settings(self):
+        self.selection_group = unpack_selection(self._pending_selection_restore)
+        self.selection_group = selections_to_length(self.selection_group, len(self.data))
+        self._pending_selection_restore = None
+
+    def prepare_settings_for_saving(self):
+        self.selection_group_saved = pack_selection(self.selection_group)
+
+
+class SelectionOutputsMixin:
+
+    # older versions did not include the "Group" feature
+    # fot the selected output
+    compat_no_group = Setting(False, schema_only=True)
+
+    class Outputs:
+        selected_data = Output("Selection", Table, default=True)
+        annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table)
+
+    class Information(OWWidget.Information):
+        compat_no_group = Msg("Compatibility mode: Selection does not output Groups.")
+
+    def __init__(self):
+        if self.compat_no_group:
+            self.Information.compat_no_group()
+
+    def _send_selection(self, data, selection_group, no_group=False):
+        annotated_data = groups_or_annotated_table(data, selection_group)
+        self.Outputs.annotated_data.send(annotated_data)
+
+        selected = None
+        if data:
+            if no_group and data:  # compatibility mode, the output used to lack the group column
+                selection_indices = np.flatnonzero(selection_group)
+                selected = data[selection_indices]
+            else:
+                selected = create_groups_table(data,
+                                               selection_group, False, "Group")
+        selected = selected if selected else None
+        self.Outputs.selected_data.send(selected if selected else None)
+
+        return annotated_data, selected
+
+    def send_selection(self, data, selection_group):
+        return self._send_selection(data, selection_group,
+                                    no_group=self.compat_no_group)

--- a/orangecontrib/spectroscopy/widgets/utils.py
+++ b/orangecontrib/spectroscopy/widgets/utils.py
@@ -97,7 +97,9 @@ class SelectionOutputsMixin:
 
     def __init__(self):
         if self.compat_no_group:
-            self.Information.compat_no_group()
+            # We decided not to show the warning explicitly
+            # self.Information.compat_no_group()
+            pass
 
     def _send_selection(self, data, selection_group, no_group=False):
         annotated_data = groups_or_annotated_table(data, selection_group)

--- a/setup.py
+++ b/setup.py
@@ -125,8 +125,8 @@ if __name__ == '__main__':
         data_files=DATA_FILES,
         install_requires=[
             'Orange3>=3.28.0',
-            'orange-canvas-core>=0.1.19',
-            'orange-widget-base>=4.12.0',
+            'orange-canvas-core>=0.1.20',
+            'orange-widget-base>=4.14.1',
             'scipy>=0.14.0',
             'spectral>=0.18',
             'serverfiles>=0.2',

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
     oldest: orange3==3.28.0
-    oldest: orange-canvas-core==0.1.19
-    oldest: orange-widget-base==4.12.0
+    oldest: orange-canvas-core==0.1.20
+    oldest: orange-widget-base==4.14.1
     oldest: scikit-learn~=0.22.0
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core


### PR DESCRIPTION
Orange widgets, like Scatterplot, add a "Group" feature also to their "Selected data" output. Spectroscopy widgets only outputted selected groups in their Data output.

Spectroscopy visualizations were modified to behave as Orange visualizations. Because a new feature is added, this should be backward compatible.

Implements #168

~~**TODO** Think if this really is backward compatible. Some basic contexts, like the ones in Scatterplot, should work. How about Select Columns or perhaps some weird PerfectDomain contexts? If it is not perfectly backward compatible, add compatibility mode to the widgets.~~

I added the compatibility mode because there are cases where the new column makes trouble. The most obvious ones are when there are other widgets in the pipeline that also add "Groups", such as Scatter Plot. Then, downstream widgets would mix these two. Also, if someone used a selection from Spectra and then created classes with, for example, Scatter Plot, these would work differently (the Group feature becomes the target if there is no target in the data).