### PR TITLE
[FIX] A migration for a wrongly released owmultifile_vesna

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owmultifile.py
+++ b/orangecontrib/spectroscopy/widgets/owmultifile.py
@@ -185,7 +185,10 @@ class OWMultifile(widget.OWWidget, RelocatablePathsWidgetMixin):
                   "and send a data table to the output."
     priority = 10000
     replaces = ["orangecontrib.infrared.widgets.owfiles.OWFiles",
-                "orangecontrib.infrared.widgets.owmultifile.OWMultifile"]
+                "orangecontrib.infrared.widgets.owmultifile.OWMultifile",
+                # next file: a file unintentionally added in one version
+                "orangecontrib.spectroscopy.widgets.owmultifile_vesna.OWMultifile",
+                ]
     keywords = ["file", "files", "multiple"]
 
     class Outputs:


### PR DESCRIPTION
0.6.0 packages (git repo was fine) unintentionally included a file owmultifile_vesna, which was a multifile widget with differently written internals. Because I deleted that file later, here is a migration (if users used that one).