### PR TITLE
[ENH] RGB Visualization added to HyperSpectra Widget

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -119,6 +119,19 @@ class TestOWHyper(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWHyper)  # type: OWHyper
 
+    def test_feature_init(self):
+        self.send_signal("Data", self.iris)
+        self.assertEqual(self.widget.attr_value, self.iris.domain.class_var)
+        attr1, attr2, attr3 = self.iris.domain.attributes[:3]
+        self.assertEqual(self.widget.rgb_red_value, attr1)
+        self.assertEqual(self.widget.rgb_green_value, attr2)
+        self.assertEqual(self.widget.rgb_blue_value, attr3)
+        self.send_signal("Data", self.iris1)
+        self.assertEqual(self.widget.attr_value, attr1)
+        self.assertIsNone(self.widget.rgb_red_value)
+        self.assertIsNone(self.widget.rgb_green_value)
+        self.assertIsNone(self.widget.rgb_blue_value)
+
     def try_big_selection(self):
         self.widget.imageplot.select_square(QPointF(-100, -100), QPointF(100, 100))
         self.widget.imageplot.make_selection(None)

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -128,9 +128,9 @@ class TestOWHyper(WidgetTest):
         self.assertEqual(self.widget.rgb_blue_value, attr3)
         self.send_signal("Data", self.iris1)
         self.assertEqual(self.widget.attr_value, attr1)
-        self.assertIsNone(self.widget.rgb_red_value)
-        self.assertIsNone(self.widget.rgb_green_value)
-        self.assertIsNone(self.widget.rgb_blue_value)
+        self.assertEqual(self.widget.rgb_red_value, attr1)
+        self.assertEqual(self.widget.rgb_green_value, attr1)
+        self.assertEqual(self.widget.rgb_blue_value, attr1)
 
     def try_big_selection(self):
         self.widget.imageplot.select_square(QPointF(-100, -100), QPointF(100, 100))

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -290,6 +290,12 @@ def color_palette_model(palettes, iconsize=QSize(64, 16)):
 class ImageColorSettingMixin:
     threshold_low = Setting(0.0, schema_only=True)
     threshold_high = Setting(1.0, schema_only=True)
+    red_threshold_low = Setting(0.0, schema_only=True)
+    red_threshold_high =  Setting(1.0, schema_only=True)
+    green_threshold_low = Setting(0.0, schema_only=True)
+    green_threshold_high =  Setting(1.0, schema_only=True)
+    blue_threshold_low = Setting(0.0, schema_only=True)
+    blue_threshold_high =  Setting(1.0, schema_only=True)
     level_low = Setting(None, schema_only=True)
     level_high = Setting(None, schema_only=True)
     show_legend = Setting(True)
@@ -341,8 +347,42 @@ class ImageColorSettingMixin:
             step=0.05, ticks=True, intOnly=False,
             createLabel=False, callback=self.update_levels)
 
+        ##RGB Sliders
+        self._threshold_red_low_slider = redlowslider = gui.hSlider(
+            box, self, "red_threshold_low", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+        self._threshold_red_high_slider = redhighslider = gui.hSlider(
+            box, self, "red_threshold_high", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+        self._threshold_green_low_slider = greenlowslider = gui.hSlider(
+            box, self, "green_threshold_low", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+        self._threshold_green_high_slider = greenhighslider = gui.hSlider(
+            box, self, "green_threshold_high", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+        self._threshold_blue_low_slider = bluelowslider = gui.hSlider(
+            box, self, "blue_threshold_low", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+        self._threshold_blue_high_slider = bluehighslider = gui.hSlider(
+            box, self, "blue_threshold_high", minValue=0.0, maxValue=1.0,
+            step=0.05, ticks=True, intOnly=False,
+            createLabel=False, callback=self.update_levels)
+
+
         form.addRow("Low:", lowslider)
         form.addRow("High:", highslider)
+        form.addRow("Red Low: ",redlowslider)
+        form.addRow("Red High: ",redhighslider)
+        form.addRow("Green Low: ",greenlowslider)
+        form.addRow("Green High: ",greenhighslider)
+        form.addRow("Blue Low: ",bluelowslider)
+        form.addRow("Blue High: ",bluehighslider)
+
         box.layout().addLayout(form)
 
         self.update_legend_visible()
@@ -368,6 +408,43 @@ class ImageColorSettingMixin:
 
         if len(levels) == 3:
             self.img.setLevels(levels)
+            enabled_level_settings = self.fixed_levels is None
+            self._threshold_red_low_slider.setEnabled(enabled_level_settings)
+            self._threshold_red_high_slider.setEnabled(enabled_level_settings)
+
+            if not self.red_threshold_low < self.red_threshold_high:
+                # TODO this belongs here, not in the parent
+                self.parent.Warning.threshold_error()
+                return
+            else:
+                self.parent.Warning.threshold_error.clear()
+            if not self.green_threshold_low < self.green_threshold_high:
+                # TODO this belongs here, not in the parent
+                self.parent.Warning.threshold_error()
+                return
+            else:
+                self.parent.Warning.threshold_error.clear()
+            if not self.blue_threshold_low < self.blue_threshold_high:
+                # TODO this belongs here, not in the parent
+                self.parent.Warning.threshold_error()
+                return
+            else:
+                self.parent.Warning.threshold_error.clear()
+
+            new_levels = levels
+
+            rll_threshold = new_levels[0][0] * self.red_threshold_low
+            rlh_threshold = new_levels[0][1] * self.red_threshold_high
+            gll_threshold = new_levels[1][0] * self.green_threshold_low
+            glh_threshold = new_levels[1][1] * self.green_threshold_high
+            bll_threshold = new_levels[2][0] * self.blue_threshold_low
+            blh_threshold = new_levels[2][1] * self.blue_threshold_high
+
+            new_levels = [[rll_threshold,rlh_threshold],[gll_threshold,glh_threshold],[bll_threshold,blh_threshold]]
+            self.img.setLevels(new_levels)
+
+
+
             return
 
         prec = pixels_to_decimals((levels[1] - levels[0])/1000)
@@ -1143,6 +1220,10 @@ class OWHyper(OWWidget):
         domain = data.domain if data is not None else None
         self.feature_value_model.set_domain(domain)
         self.attr_value = self.feature_value_model[0] if self.feature_value_model else None
+        rgb_attrs = [a for a in self.feature_value_model[:3]] if self.feature_value_model else [None]
+        rgb_attrs = (rgb_attrs + rgb_attrs[-1:]*3)[:3]
+        self.rgb_red_value,self.rgb_green_value,self.rgb_blue_value = rgb_attrs
+        ##TODO test datasets with features <3
 
     def init_visible_images(self, data):
         self.visible_image_model.clear()

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -22,6 +22,7 @@ from PIL import Image
 
 import Orange.data
 from Orange.data import Domain
+from Orange.preprocess.transformation import Identity
 from Orange.widgets.widget import OWWidget, Msg, OWComponent, Input, Output
 from Orange.widgets import gui
 from Orange.widgets.settings import \
@@ -824,7 +825,7 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         self.data_imagepixels = None
         self.data_valid_positions = None
 
-        if self.data and self.attr_x and self.attr_y and self.parent.image_values():
+        if self.data and self.attr_x and self.attr_y:
             self.start(self.compute_image, self.data, self.attr_x, self.attr_y,
                        self.parent.image_values(),
                        self.parent.image_values_fixed_levels())
@@ -1257,13 +1258,11 @@ class OWHyper(OWWidget):
             return lambda data, attr=self.attr_value: \
                 data.transform(Domain([data.domain[attr]]))
         elif self.value_type == 2:  # RGB
-            # Ensure all RGB variables are unique
-            if len({self.rgb_red_value, self.rgb_green_value, self.rgb_blue_value}) == 3:
-                return lambda data, \
-                    attr_red=self.rgb_red_value, attr_green=self.rgb_green_value, attr_blue=self.rgb_blue_value: \
-                    data.transform(Domain([data.domain[attr_red], data.domain[attr_green], data.domain[attr_blue]]))
-            else:
-                return
+            red = ContinuousVariable("red", compute_value=Identity(self.rgb_red_value))
+            green = ContinuousVariable("green", compute_value=Identity(self.rgb_green_value))
+            blue = ContinuousVariable("blue", compute_value=Identity(self.rgb_blue_value))
+            return lambda data: \
+                    data.transform(Domain([red, green, blue]))
 
     def image_values_fixed_levels(self):
         if self.value_type == 1 and isinstance(self.attr_value, DiscreteVariable):

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -285,19 +285,13 @@ class ImageColorSettingMixin:
     threshold_high = Setting(1.0, schema_only=True)
     level_low = Setting(None, schema_only=True)
     level_high = Setting(None, schema_only=True)
-    red_level_low = Setting(None, schema_only=True)
-    red_level_high = Setting(None, schema_only=True)
-    green_level_low = Setting(None, schema_only=True)
-    green_level_high = Setting(None, schema_only=True)
-    blue_level_low = Setting(None, schema_only=True)
-    blue_level_high = Setting(None, schema_only=True)
     show_legend = Setting(True)
     palette_index = Setting(0)
 
     def __init__(self):
         self.fixed_levels = None  # fixed level settings for categoric data
 
-    def color_settings_box(self):
+    def setup_color_settings_box(self):
         box = gui.vBox(self)
         self.color_cb = gui.comboBox(box, self, "palette_index", label="Color:",
                                      labelWidth=50, orientation=Qt.Horizontal)
@@ -340,30 +334,6 @@ class ImageColorSettingMixin:
             step=0.05, ticks=True, intOnly=False,
             createLabel=False, callback=self.update_levels)
 
-        self._red_level_low_le = lineEditDecimalOrNone(self, self, "red_level_low", callback=limit_changed)
-        self._red_level_low_le.validator().setDefault(0)
-        form.addRow("Red Low limit:", self._red_level_low_le)
-
-        self._red_level_high_le = lineEditDecimalOrNone(self, self, "red_level_high", callback=limit_changed)
-        self._red_level_high_le.validator().setDefault(1)
-        form.addRow("Red High limit:", self._red_level_high_le)
-
-        self._green_level_low_le = lineEditDecimalOrNone(self, self, "green_level_low", callback=limit_changed)
-        self._green_level_low_le.validator().setDefault(0)
-        form.addRow("Green Low limit:", self._green_level_low_le)
-
-        self._green_level_high_le = lineEditDecimalOrNone(self, self, "green_level_high", callback=limit_changed)
-        self._green_level_high_le.validator().setDefault(1)
-        form.addRow("Green High limit:", self._green_level_high_le)
-
-        self._blue_level_low_le = lineEditDecimalOrNone(self, self, "blue_level_low", callback=limit_changed)
-        self._blue_level_low_le.validator().setDefault(0)
-        form.addRow("Blue Low limit:", self._blue_level_low_le)
-
-        self._blue_level_high_le = lineEditDecimalOrNone(self, self, "blue_level_high", callback=limit_changed)
-        self._blue_level_high_le.validator().setDefault(1)
-        form.addRow("Blue High limit:", self._blue_level_high_le)
-
         form.addRow("Low:", lowslider)
         form.addRow("High:", highslider)
         box.layout().addLayout(form)
@@ -373,7 +343,7 @@ class ImageColorSettingMixin:
         return box
 
     def update_legend_visible(self):
-        if self.fixed_levels is not None:
+        if self.fixed_levels is not None or self.parent.value_type == 2:
             self.legend.setVisible(False)
         else:
             self.legend.setVisible(self.show_legend)
@@ -390,58 +360,7 @@ class ImageColorSettingMixin:
             levels = [0, 255]
 
         if len(levels) == 3:
-            self.img.setLevels(levels)
-            red_prec = pixels_to_decimals((levels[0][1] - levels[0][0])/1000)
-
-            red_rounded_levels = [float_to_str_decimals(levels[0][0], red_prec),
-                          float_to_str_decimals(levels[0][1], red_prec)]
-
-            green_prec = pixels_to_decimals((levels[1][1] - levels[1][0])/1000)
-
-            green_rounded_levels = [float_to_str_decimals(levels[1][0], green_prec),
-                          float_to_str_decimals(levels[1][1], green_prec)]
-
-            blue_prec = pixels_to_decimals((levels[0][1] - levels[0][0])/1000)
-
-            blue_rounded_levels = [float_to_str_decimals(levels[2][0], blue_prec),
-                          float_to_str_decimals(levels[2][1], blue_prec)]
-
-            self._red_level_low_le.validator().setDefault(red_rounded_levels[0])
-            self._red_level_high_le.validator().setDefault(red_rounded_levels[1])
-
-            self._red_level_low_le.setPlaceholderText(red_rounded_levels[0])
-            self._red_level_high_le.setPlaceholderText(red_rounded_levels[1])
-
-            self._green_level_low_le.validator().setDefault(green_rounded_levels[0])
-            self._green_level_high_le.validator().setDefault(green_rounded_levels[1])
-
-            self._green_level_low_le.setPlaceholderText(green_rounded_levels[0])
-            self._green_level_high_le.setPlaceholderText(green_rounded_levels[1])
-
-            self._blue_level_low_le.validator().setDefault(blue_rounded_levels[0])
-            self._blue_level_high_le.validator().setDefault(blue_rounded_levels[1])
-
-            self._blue_level_low_le.setPlaceholderText(blue_rounded_levels[0])
-            self._blue_level_high_le.setPlaceholderText(blue_rounded_levels[1])
-
-            #this section may be unecessary if fixed levels is always none for RGB
-            enabled_level_settings = self.fixed_levels is None
-            self._red_level_low_le.setEnabled(enabled_level_settings)
-            self._red_level_high_le.setEnabled(enabled_level_settings)
-            self._green_level_low_le.setEnabled(enabled_level_settings)
-            self._green_level_high_le.setEnabled(enabled_level_settings)
-            self._blue_level_low_le.setEnabled(enabled_level_settings)
-            self._blue_level_high_le.setEnabled(enabled_level_settings)
-
-            rll = float(self.red_level_low) if self.red_level_low is not None else levels[0][0]
-            rlh = float(self.red_level_high) if self.red_level_high is not None else levels[0][1]
-            gll = float(self.green_level_low) if self.green_level_low is not None else levels[1][0]
-            glh = float(self.green_level_high) if self.green_level_high is not None else levels[1][1]
-            bll = float(self.blue_level_low) if self.blue_level_low is not None else levels[2][0]
-            blh = float(self.blue_level_high) if self.blue_level_high is not None else levels[2][1]
-            new_levels = levels
-            new_levels = [[rll,rlh],[gll,glh],[bll,blh]]
-            self.img.setLevels(new_levels)
+            self.update_rgb_levels()
             return
 
         prec = pixels_to_decimals((levels[1] - levels[0])/1000)
@@ -502,6 +421,90 @@ class ImageColorSettingMixin:
     def reset_thresholds(self):
         self.threshold_low = 0.
         self.threshold_high = 1.
+
+
+class ImageRGBSettingMixin:
+    red_level_low = Setting(None, schema_only=True)
+    red_level_high = Setting(None, schema_only=True)
+    green_level_low = Setting(None, schema_only=True)
+    green_level_high = Setting(None, schema_only=True)
+    blue_level_low = Setting(None, schema_only=True)
+    blue_level_high = Setting(None, schema_only=True)
+
+    def setup_rgb_settings_box(self):
+        box = gui.vBox(self)
+
+        form = QFormLayout(
+            formAlignment=Qt.AlignLeft,
+            labelAlignment=Qt.AlignLeft,
+            fieldGrowthPolicy=QFormLayout.AllNonFixedFieldsGrow
+        )
+
+        self._red_level_low_le = lineEditDecimalOrNone(self, self, "red_level_low", callback=self.update_rgb_levels)
+        self._red_level_low_le.validator().setDefault(0)
+        form.addRow("Red Low limit:", self._red_level_low_le)
+
+        self._red_level_high_le = lineEditDecimalOrNone(self, self, "red_level_high", callback=self.update_rgb_levels)
+        self._red_level_high_le.validator().setDefault(1)
+        form.addRow("Red High limit:", self._red_level_high_le)
+
+        self._green_level_low_le = lineEditDecimalOrNone(self, self, "green_level_low", callback=self.update_rgb_levels)
+        self._green_level_low_le.validator().setDefault(0)
+        form.addRow("Green Low limit:", self._green_level_low_le)
+
+        self._green_level_high_le = lineEditDecimalOrNone(self, self, "green_level_high", callback=self.update_rgb_levels)
+        self._green_level_high_le.validator().setDefault(1)
+        form.addRow("Green High limit:", self._green_level_high_le)
+
+        self._blue_level_low_le = lineEditDecimalOrNone(self, self, "blue_level_low", callback=self.update_rgb_levels)
+        self._blue_level_low_le.validator().setDefault(0)
+        form.addRow("Blue Low limit:", self._blue_level_low_le)
+
+        self._blue_level_high_le = lineEditDecimalOrNone(self, self, "blue_level_high", callback=self.update_rgb_levels)
+        self._blue_level_high_le.validator().setDefault(1)
+        form.addRow("Blue High limit:", self._blue_level_high_le)
+
+        box.layout().addLayout(form)
+        return box
+
+    def update_rgb_levels(self):
+        if not self.data:
+            return
+
+        if self.img.image is not None:
+            levels = get_levels(self.img.image)
+        else:
+            levels = [0, 255]
+
+        if len(levels) != 3:
+            return
+
+        rgb_le = [
+            [self._red_level_low_le, self._red_level_high_le],
+            [self._green_level_low_le, self._green_level_high_le],
+            [self._blue_level_low_le, self._blue_level_high_le]
+        ]
+
+        for i, (low_le, high_le) in enumerate(rgb_le):
+            prec = pixels_to_decimals((levels[i][1] - levels[i][0]) / 1000)
+            rounded_levels = [float_to_str_decimals(levels[i][0], prec),
+                              float_to_str_decimals(levels[i][1], prec)]
+
+            low_le.validator().setDefault(rounded_levels[0])
+            high_le.validator().setDefault(rounded_levels[1])
+
+            low_le.setPlaceholderText(rounded_levels[0])
+            high_le.setPlaceholderText(rounded_levels[1])
+
+        rll = float(self.red_level_low) if self.red_level_low is not None else levels[0][0]
+        rlh = float(self.red_level_high) if self.red_level_high is not None else levels[0][1]
+        gll = float(self.green_level_low) if self.green_level_low is not None else levels[1][0]
+        glh = float(self.green_level_high) if self.green_level_high is not None else levels[1][1]
+        bll = float(self.blue_level_low) if self.blue_level_low is not None else levels[2][0]
+        blh = float(self.blue_level_high) if self.blue_level_high is not None else levels[2][1]
+
+        new_levels = [[rll, rlh], [gll, glh], [bll, blh]]
+        self.img.setLevels(new_levels)
 
 
 class ImageZoomMixin:
@@ -584,7 +587,8 @@ class ImageColorLegend(GraphicsWidget):
 
 
 class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
-                ImageColorSettingMixin, ImageZoomMixin, ConcurrentMixin):
+                ImageColorSettingMixin, ImageRGBSettingMixin,
+                ImageZoomMixin, ConcurrentMixin):
 
     attr_x = ContextSetting(None)
     attr_y = ContextSetting(None)
@@ -693,7 +697,11 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
             model=self.xy_model, **common_options)
         box.setFocusProxy(self.cb_attr_x)
 
-        box.layout().addWidget(self.color_settings_box())
+        self.color_settings_box = self.setup_color_settings_box()
+        self.rgb_settings_box = self.setup_rgb_settings_box()
+
+        box.layout().addWidget(self.color_settings_box)
+        box.layout().addWidget(self.rgb_settings_box)
 
         choose_xy.setDefaultWidget(box)
         view_menu.addAction(choose_xy)
@@ -1304,6 +1312,10 @@ class OWHyper(OWWidget):
             self.box_values_spectra.setDisabled(True)
             self.box_values_feature.setDisabled(True)
             self.box_values_RGB_feature.setDisabled(False)
+        # ImagePlot menu levels visibility
+        rgb = self.value_type == 2
+        self.imageplot.rgb_settings_box.setVisible(rgb)
+        self.imageplot.color_settings_box.setVisible(not rgb)
         QTest.qWait(1)  # first update the interface
 
     def _change_integration(self):

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -136,7 +136,6 @@ def get_levels(img):
         return [mn, mx]
 
 
-
 class VisibleImageListModel(PyListModel):
 
     def data(self, index, role=Qt.DisplayRole):
@@ -160,7 +159,6 @@ class ImageItemNan(pg.ImageItem):
 
     def render(self):
         # simplified pg.ImageITem
-
         if self.image is None or self.image.size == 0:
             return
         if isinstance(self.lut, collections.abc.Callable):
@@ -174,11 +172,9 @@ class ImageItemNan(pg.ImageItem):
         if self.axisOrder == 'col-major':
             image = image.transpose((1, 0, 2)[:image.ndim])
 
-
         if image.ndim == 3:
             lut = None
         argb, alpha = pg.makeARGB(image, lut=lut, levels=levels)  # format is bgra
-
 
         if image.ndim == 3:
             argb[np.isnan(image)[:,:,0]] = 100
@@ -283,12 +279,6 @@ def color_palette_model(palettes, iconsize=QSize(64, 16)):
 class ImageColorSettingMixin:
     threshold_low = Setting(0.0, schema_only=True)
     threshold_high = Setting(1.0, schema_only=True)
-    red_threshold_low = Setting(0.0, schema_only=True)
-    red_threshold_high =  Setting(1.0, schema_only=True)
-    green_threshold_low = Setting(0.0, schema_only=True)
-    green_threshold_high =  Setting(1.0, schema_only=True)
-    blue_threshold_low = Setting(0.0, schema_only=True)
-    blue_threshold_high =  Setting(1.0, schema_only=True)
     level_low = Setting(None, schema_only=True)
     level_high = Setting(None, schema_only=True)
     red_level_low = Setting(None, schema_only=True)
@@ -346,7 +336,6 @@ class ImageColorSettingMixin:
             step=0.05, ticks=True, intOnly=False,
             createLabel=False, callback=self.update_levels)
 
-        ## RGB Level Numbers
         self._red_level_low_le = lineEditDecimalOrNone(self, self, "red_level_low", callback=limit_changed)
         self._red_level_low_le.validator().setDefault(0)
         form.addRow("Red Low limit:", self._red_level_low_le)
@@ -371,42 +360,8 @@ class ImageColorSettingMixin:
         self._blue_level_high_le.validator().setDefault(1)
         form.addRow("Blue High limit:", self._blue_level_high_le)
 
-        ##RGB Sliders
-        self._threshold_red_low_slider = redlowslider = gui.hSlider(
-            box, self, "red_threshold_low", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-        self._threshold_red_high_slider = redhighslider = gui.hSlider(
-            box, self, "red_threshold_high", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-        self._threshold_green_low_slider = greenlowslider = gui.hSlider(
-            box, self, "green_threshold_low", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-        self._threshold_green_high_slider = greenhighslider = gui.hSlider(
-            box, self, "green_threshold_high", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-        self._threshold_blue_low_slider = bluelowslider = gui.hSlider(
-            box, self, "blue_threshold_low", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-        self._threshold_blue_high_slider = bluehighslider = gui.hSlider(
-            box, self, "blue_threshold_high", minValue=0.0, maxValue=1.0,
-            step=0.05, ticks=True, intOnly=False,
-            createLabel=False, callback=self.update_levels)
-
-
         form.addRow("Low:", lowslider)
         form.addRow("High:", highslider)
-        form.addRow("Red Low: ",redlowslider)
-        form.addRow("Red High: ",redhighslider)
-        form.addRow("Green Low: ",greenlowslider)
-        form.addRow("Green High: ",greenhighslider)
-        form.addRow("Blue Low: ",bluelowslider)
-        form.addRow("Blue High: ",bluehighslider)
-
         box.layout().addLayout(form)
 
         self.update_legend_visible()
@@ -429,7 +384,7 @@ class ImageColorSettingMixin:
             levels = get_levels(self.img.image)
         else:
             levels = [0, 255]
-        #RGB Addition (Pretty repetitive to original code outside of the if statement)
+
         if len(levels) == 3:
             self.img.setLevels(levels)
             red_prec = pixels_to_decimals((levels[0][1] - levels[0][0])/1000)
@@ -474,48 +429,14 @@ class ImageColorSettingMixin:
             self._blue_level_low_le.setEnabled(enabled_level_settings)
             self._blue_level_high_le.setEnabled(enabled_level_settings)
 
-            self._threshold_red_low_slider.setEnabled(enabled_level_settings)
-            self._threshold_red_high_slider.setEnabled(enabled_level_settings)
-            self._threshold_green_low_slider.setEnabled(enabled_level_settings)
-            self._threshold_green_high_slider.setEnabled(enabled_level_settings)
-            self._threshold_blue_low_slider.setEnabled(enabled_level_settings)
-            self._threshold_blue_high_slider.setEnabled(enabled_level_settings)
-
-            if not self.red_threshold_low < self.red_threshold_high:
-                # TODO this belongs here, not in the parent
-                self.parent.Warning.threshold_error()
-                return
-            else:
-                self.parent.Warning.threshold_error.clear()
-            if not self.green_threshold_low < self.green_threshold_high:
-                # TODO this belongs here, not in the parent
-                self.parent.Warning.threshold_error()
-                return
-            else:
-                self.parent.Warning.threshold_error.clear()
-            if not self.blue_threshold_low < self.blue_threshold_high:
-                # TODO this belongs here, not in the parent
-                self.parent.Warning.threshold_error()
-                return
-            else:
-                self.parent.Warning.threshold_error.clear()
-
-            new_levels = levels
-
             rll = float(self.red_level_low) if self.red_level_low is not None else levels[0][0]
             rlh = float(self.red_level_high) if self.red_level_high is not None else levels[0][1]
             gll = float(self.green_level_low) if self.green_level_low is not None else levels[1][0]
             glh = float(self.green_level_high) if self.green_level_high is not None else levels[1][1]
             bll = float(self.blue_level_low) if self.blue_level_low is not None else levels[2][0]
             blh = float(self.blue_level_high) if self.blue_level_high is not None else levels[2][1]
-            rll_threshold = rll + (rlh-rll) * self.red_threshold_low
-            rlh_threshold = rll+(rlh-rll) * self.red_threshold_high
-            gll_threshold = gll + (glh-gll) * self.green_threshold_low
-            glh_threshold = gll + (glh-gll) * self.green_threshold_high
-            bll_threshold = bll + (blh-bll) * self.blue_threshold_low
-            blh_threshold = bll + (blh-bll) * self.blue_threshold_high
-
-            new_levels = [[rll_threshold,rlh_threshold],[gll_threshold,glh_threshold],[bll_threshold,blh_threshold]]
+            new_levels = levels
+            new_levels = [[rll,rlh],[gll,glh],[bll,blh]]
             self.img.setLevels(new_levels)
             return
 
@@ -977,7 +898,6 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         d = np.concatenate(parts)
 
         res.d = d
-
         progress_interrupt(0)
 
         return res
@@ -1150,8 +1070,7 @@ class OWHyper(OWWidget):
 
         gui.appendRadioButton(rbox, "RGB")
         self.box_values_RGB_feature = gui.indentedBox(rbox)
-        
-        #RGB radio buttons
+
         self.RGB_feature_value_model = DomainModel(DomainModel.SEPARATED,
                                                valid_types=DomainModel.PRIMITIVE)
 

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1198,9 +1198,11 @@ class OWHyper(OWWidget):
         self.feature_value_model.set_domain(domain)
         self.rgb_value_model.set_domain(domain)
         self.attr_value = self.feature_value_model[0] if self.feature_value_model else None
-        if self.rgb_value_model and len(self.rgb_value_model) >= 3:
+        if self.rgb_value_model:
             # Filter PyListModel.Separator objects
             rgb_attrs = [a for a in self.feature_value_model if isinstance(a, ContinuousVariable)]
+            if len(rgb_attrs) <= 3:
+                rgb_attrs = (rgb_attrs + rgb_attrs[-1:]*3)[:3]
             self.rgb_red_value, self.rgb_green_value, self.rgb_blue_value = rgb_attrs[:3]
         else:
             self.rgb_red_value = self.rgb_green_value = self.rgb_blue_value = None

--- a/orangecontrib/spectroscopy/widgets/owspectralseries.py
+++ b/orangecontrib/spectroscopy/widgets/owspectralseries.py
@@ -106,7 +106,7 @@ class LineScanPlot(QWidget, OWComponent, SelectionGroupMixin,
 
         box.setFocusProxy(self.cb_attr_x)
 
-        box.layout().addWidget(self.color_settings_box())
+        box.layout().addWidget(self.setup_color_settings_box())
 
         choose_xy.setDefaultWidget(box)
         view_menu.addAction(choose_xy)


### PR DESCRIPTION
Closes #487 
Added an option within the HyperSpectra widget to display an RGB image of 3 different, selected features. It contains GUI level controls which can be changed for each individual colour, however, there is no slider thresholding.

Tests and Documentation not yet done
@stuart-cls @markotoplak 

![image](https://user-images.githubusercontent.com/86018274/129932619-8e0ba100-c24d-48bf-b6de-d3eb6923da5e.png)


