### PR TITLE
[RFH][FIX] Preprocessors should not crash when samples have one attribute

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -421,6 +421,15 @@ class TestCommon(unittest.TestCase):
         for proc in PREPROCESSORS:
             _ = proc(data)
 
+    def test_one_attribute(self):
+        """ Preprocessors should not crash when samples have one attribute. """
+        data = SMALL_COLLAGEN
+        data = data.transform(Orange.data.Domain([data.domain.attributes[0]],
+                                                 class_vars=data.domain.class_vars,
+                                                 metas=data.domain.metas))
+        for proc in PREPROCESSORS:
+            _ = proc(data)
+
     def test_all_nans(self):
         """ Preprocessors should not crash when there are all-nan samples. """
         for proc in PREPROCESSORS:


### PR DESCRIPTION
So far this is mostly a bug report. I'm not sure the best way to handle this

It affects at least Interpolate and Integrate.