### PR TITLE
[FIX] Non-limited and typing-friendly spin-boxes

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - recommonmark
   run:
     - python
-    - orange3 >=3.25
+    - orange3 >=3.28
     - scipy >=0.14.0
     - spectral >=0.18
     - serverfiles >=0.2

--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -48,7 +48,7 @@ class IntegrateOneEditor(BaseEditorOrange):
             v = 0.
             self.__values[name] = v
 
-            e = SetXDoubleSpinBox(decimals=4, minimum=minf, maximum=maxf,
+            e = SetXDoubleSpinBox(minimum=minf, maximum=maxf,
                                   singleStep=0.5, value=v)
             e.focusIn = self.activateOptions
             e.editingFinished.connect(self.edited)

--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -60,7 +60,9 @@ class IntegrateOneEditor(BaseEditorOrange):
             layout.addRow(name, e)
 
             l = MovableVline(position=v, label=name)
-            l.sigMoved.connect(cf)
+            def set_rounded(_, line=l, name=name):
+                cf(float(line.rounded_value()), name)
+            l.sigMoved.connect(set_rounded)
             self.__lines[name] = l
 
         self.focusIn = self.activateOptions

--- a/orangecontrib/spectroscopy/widgets/peak_editors.py
+++ b/orangecontrib/spectroscopy/widgets/peak_editors.py
@@ -268,9 +268,9 @@ class ModelEditor(BaseEditorOrange):
             if name in self.model_lines():
                 l = MovableVline(position=0.0, label=name)
 
-                def change_value(x, name=name):
+                def change_value(_, line=l, name=name):
                     self.edited.emit()
-                    return self.set_hint(name, value=x)
+                    return self.set_hint(name, value=float(line.rounded_value()))
                 l.sigMoved.connect(change_value)
                 self.__lines[name] = l
 

--- a/orangecontrib/spectroscopy/widgets/peak_editors.py
+++ b/orangecontrib/spectroscopy/widgets/peak_editors.py
@@ -19,6 +19,10 @@ from orangecontrib.spectroscopy.widgets.preprocessors.utils import \
 
 class CompactDoubleSpinBox(SetXDoubleSpinBox):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs,
+                         buttonSymbols=2)
+
     def sizeHint(self) -> QSize:
         sh = super().sizeHint()
         sh.setWidth(int(sh.width() / 2))
@@ -26,7 +30,6 @@ class CompactDoubleSpinBox(SetXDoubleSpinBox):
 
     def minimumSizeHint(self) -> QSize:
         return self.sizeHint()
-
 
 class ParamHintBox(QWidget):
     """
@@ -57,18 +60,17 @@ class ParamHintBox(QWidget):
 
         minf, maxf, neginf = -sys.float_info.max, sys.float_info.max, float('-inf')
 
-        self.min_e = CompactDoubleSpinBox(decimals=2, minimum=neginf, maximum=maxf,
-                                       singleStep=0.5, value=self.init_hints.get('min', neginf),
-                                       buttonSymbols=2, specialValueText="None")
-        self.val_e = CompactDoubleSpinBox(decimals=2, minimum=minf, maximum=maxf,
-                                       singleStep=0.5, value=self.init_hints.get('value', 0),
-                                       buttonSymbols=2)
-        self.max_e = CompactDoubleSpinBox(decimals=2, minimum=neginf, maximum=maxf,
-                                       singleStep=0.5, value=self.init_hints.get('max', neginf),
-                                       buttonSymbols=2, specialValueText="None")
-        self.delta_e = CompactDoubleSpinBox(decimals=2, minimum=minf, maximum=maxf,
-                                         singleStep=0.5, value=1, prefix="±",
-                                         buttonSymbols=2, visible=False)
+        self.min_e = CompactDoubleSpinBox(minimum=neginf, maximum=maxf,
+                                          singleStep=0.5, value=self.init_hints.get('min', neginf),
+                                          specialValueText="None")
+        self.val_e = CompactDoubleSpinBox(minimum=minf, maximum=maxf,
+                                          singleStep=0.5, value=self.init_hints.get('value', 0))
+        self.max_e = CompactDoubleSpinBox(minimum=neginf, maximum=maxf,
+                                          singleStep=0.5, value=self.init_hints.get('max', neginf),
+                                          specialValueText="None")
+        self.delta_e = CompactDoubleSpinBox(minimum=minf, maximum=maxf,
+                                            singleStep=0.5, value=1, prefix="±",
+                                            visible=False)
         self.vary_e = QComboBox()
         v_opt = ('fixed', 'limits', 'delta', 'expr') if 'expr' in self.init_hints \
             else ('fixed', 'limits', 'delta')

--- a/orangecontrib/spectroscopy/widgets/preprocessors/integrate.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/integrate.py
@@ -211,7 +211,7 @@ class LimitsBox(QHBoxLayout):
         self.valueChanged.emit(newlimits, self)
 
     def lineLimitChanged(self):
-        newlimits = [self.line1.value(), self.line2.value()]
+        newlimits = [self.line1.rounded_value(), self.line2.rounded_value()]
         self.lowlime.setValue(newlimits[0])
         self.highlime.setValue(newlimits[1])
         self.limitChanged()

--- a/orangecontrib/spectroscopy/widgets/preprocessors/integrate.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/integrate.py
@@ -164,10 +164,10 @@ class LimitsBox(QHBoxLayout):
         if label:
             self.addWidget(QLabel(label))
 
-        self.lowlime = SetXDoubleSpinBox(decimals=2, minimum=minf,
+        self.lowlime = SetXDoubleSpinBox(minimum=minf,
                                          maximum=maxf, singleStep=0.5,
                                          value=limits[0], maximumWidth=75)
-        self.highlime = SetXDoubleSpinBox(decimals=2, minimum=minf,
+        self.highlime = SetXDoubleSpinBox(minimum=minf,
                                           maximum=maxf, singleStep=0.5,
                                           value=limits[1], maximumWidth=75)
         self.lowlime.setValue(limits[0])

--- a/orangecontrib/spectroscopy/widgets/preprocessors/normalize.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/normalize.py
@@ -90,11 +90,14 @@ class NormalizeEditor(BaseEditorOrange):
         self.int_method_cb.currentIndexChanged.connect(self.setinttype)
         self.int_method_cb.activated.connect(self.edited)
 
+        def rounded(line):
+            return float(line.rounded_value())
+
         self.lline = MovableVline(position=self.lower, label="Low limit")
-        self.lline.sigMoved.connect(self.setL)
+        self.lline.sigMoved.connect(lambda _: self.setL(rounded(self.lline)))
         self.lline.sigMoveFinished.connect(self.reorderLimits)
         self.uline = MovableVline(position=self.upper, label="High limit")
-        self.uline.sigMoved.connect(self.setU)
+        self.uline.sigMoved.connect(lambda _: self.setU(rounded(self.uline)))
         self.uline.sigMoveFinished.connect(self.reorderLimits)
 
         self.user_changed = False

--- a/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
@@ -1,6 +1,6 @@
 from AnyQt.QtWidgets import QWidget
-from PyQt5.QtCore import pyqtSignal as Signal
-from PyQt5.QtWidgets import QVBoxLayout, QSizePolicy, QLayout
+from AnyQt.QtCore import pyqtSignal as Signal, QLocale
+from AnyQt.QtWidgets import QVBoxLayout, QSizePolicy, QLayout
 
 from Orange.widgets.data.utils.preprocess import BaseEditor
 from Orange.widgets.gui import OWComponent
@@ -69,6 +69,16 @@ class SetXDoubleSpinBox(DoubleSpinBox):
         if hasattr(self, "focusIn"):
             self.focusIn()
         return super().focusInEvent(*e)
+
+    # so that scrolling does not accidentally influence values
+    def wheelEvent(self, event):
+        event.ignore()
+
+    # omit group separator
+    def locale(self):
+        locale = super().locale()
+        locale.setNumberOptions(QLocale.OmitGroupSeparator)
+        return locale
 
 
 class PreviewMinMaxMixin:

--- a/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
@@ -1,10 +1,11 @@
 from AnyQt.QtWidgets import QWidget
 from PyQt5.QtCore import pyqtSignal as Signal
-from PyQt5.QtWidgets import QVBoxLayout, QSizePolicy, QDoubleSpinBox, QLayout
+from PyQt5.QtWidgets import QVBoxLayout, QSizePolicy, QLayout
 
 from Orange.widgets.data.utils.preprocess import BaseEditor
 from Orange.widgets.gui import OWComponent
 from Orange.widgets.utils.messages import WidgetMessagesMixin
+from Orange.widgets.utils.spinbox import DoubleSpinBox
 from Orange.widgets.widget import Msg
 from orangecontrib.spectroscopy.data import getx
 
@@ -57,13 +58,16 @@ class BaseEditorOrange(BaseEditor, OWComponent, WidgetMessagesMixin):
         return {k: getattr(self, k) for k in self.controlled_attributes}
 
 
-class SetXDoubleSpinBox(QDoubleSpinBox):
+class SetXDoubleSpinBox(DoubleSpinBox):
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs,
+                         keyboardTracking=False  # disable valueChanged while typing
+                         )
 
     def focusInEvent(self, *e):
-        self.focusIn()
+        if hasattr(self, "focusIn"):
+            self.focusIn()
         return super().focusInEvent(*e)
 
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,9 @@ if __name__ == '__main__':
         package_data=PACKAGE_DATA,
         data_files=DATA_FILES,
         install_requires=[
-            'Orange3>=3.25.0',
+            'Orange3>=3.28.0',
+            'orange-canvas-core>=0.1.19',
+            'orange-widget-base>=4.12.0',
             'scipy>=0.14.0',
             'spectral>=0.18',
             'serverfiles>=0.2',

--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,9 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: orange3==3.25.0
-    # use newer canvas-core and widget-base to avoid segfaults on windows
-    oldest: orange-canvas-core==0.1.9 ; sys_platform != 'win32'
-    oldest: orange-canvas-core==0.1.15 ; sys_platform == 'win32'
-    oldest: orange-widget-base==4.5.0 ; sys_platform != 'win32'
-    oldest: orange-widget-base==4.9.0 ; sys_platform == 'win32'
+    oldest: orange3==3.28.0
+    oldest: orange-canvas-core==0.1.19
+    oldest: orange-widget-base==4.12.0
     oldest: scikit-learn~=0.22.0
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core


### PR DESCRIPTION
I always disliked decimal limitations for input wavenumbers. I reviewed biolab/orange3#5647 today which used just what we need here.

Also, now spin boxes now do not call valueChanged after each edit which means that strange issues while typing are gone! So, fixes #564.

TODO:
- [x] Now that there are no decimal limitations, change vertical lines not to set needlessly precise numbers.
- [ ] After moving VerticalLine in PeakFit the fit is not updated; fix this.