### PR TITLE
[FIX] Peakfit: clear preview markings before calculation

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -222,6 +222,8 @@ class PeakPreviewRunner(PreviewRunner):
         pp_def = [master.preprocessormodel.item(i)
                   for i in range(master.preprocessormodel.rowCount())]
         if master.data is not None:
+            # Clear markings to indicate preview is running
+            refresh_integral_markings([], master.markings_list, master.curveplot)
             data = master.sample_data(master.data)
             # Pass preview data to widgets here as we don't use on_partial_result()
             for w in self.master.flow_view.widgets():


### PR DESCRIPTION
Built on #588 

Testing the changes above reminded me about one of the improvements stemming from #578 which is to provide good feedback to the user that the preview calculation is running (and therefore has been updated).

All this does is clear the results markings before starting the calculation.