### PR TITLE
[ENH] Peak Fit: finally responsive (with multiprocessing)

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -69,9 +69,9 @@ class TestOWPeakFit(WidgetTest):
                 if settings is None:
                     self.widget.add_preprocessor(p)
                 wait_for_preview(self.widget, 10000)
+                self.widget.onDeleteWidget()
 
     def test_outputs(self):
-        self.widget = self.create_widget(OWPeakFit)
         self.send_signal("Data", self.data)
         self.widget.add_preprocessor(PREPROCESSORS[0])
         wait_for_preview(self.widget)
@@ -130,6 +130,10 @@ class TestOWPeakFit(WidgetTest):
                       'gamma2': {'expr': '', 'max': 1.0, 'min': -1.0,
                                  'value': 0.0, 'vary': 'limits'}})
         self.assertEqual(settings["storedsettings"]["preprocessors"], [o1, o2])
+
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
 
 
 class TestPeakFit(unittest.TestCase):
@@ -218,6 +222,10 @@ class ModelEditorTest(WidgetTest):
     def get_params_single(self, model):
         m_def = self.widget.preprocessormodel.item(0)
         return prepare_params(m_def, model)
+
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
 
 
 class TestVoigtEditor(ModelEditorTest):

--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -18,6 +18,7 @@ from orangecontrib.spectroscopy.widgets.owpeakfit import OWPeakFit, fit_peaks, P
 from orangecontrib.spectroscopy.widgets.peak_editors import ParamHintBox, VoigtModelEditor, \
     PseudoVoigtModelEditor, ExponentialGaussianModelEditor, PolynomialModelEditor
 
+
 COLLAGEN = Orange.data.Table("collagen")[0:3]
 COLLAGEN_2 = LinearBaseline()(Cut(lowlim=1500, highlim=1700)(COLLAGEN))
 COLLAGEN_1 = LinearBaseline()(Cut(lowlim=1600, highlim=1700)(COLLAGEN_2))

--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -13,10 +13,15 @@ from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.preprocess import Cut, LinearBaseline, Integrate
 from orangecontrib.spectroscopy.tests.spectral_preprocess import wait_for_preview
 from orangecontrib.spectroscopy.widgets.gui import MovableVline
+import orangecontrib.spectroscopy.widgets.owpeakfit as owpeakfit
 from orangecontrib.spectroscopy.widgets.owpeakfit import OWPeakFit, fit_peaks, PREPROCESSORS, \
     create_model, prepare_params, unique_prefix, create_composite_model, pack_model_editor
 from orangecontrib.spectroscopy.widgets.peak_editors import ParamHintBox, VoigtModelEditor, \
     PseudoVoigtModelEditor, ExponentialGaussianModelEditor, PolynomialModelEditor
+
+
+# shorter initializations in tests
+owpeakfit.N_PROCESSES = 1
 
 
 COLLAGEN = Orange.data.Table("collagen")[0:3]

--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -32,49 +32,11 @@ from orangecontrib.spectroscopy.widgets.peak_editors import GaussianModelEditor,
     ExponentialGaussianModelEditor, SkewedGaussianModelEditor, SkewedVoigtModelEditor, \
     ThermalDistributionModelEditor, DoniachModelEditor, ConstantModelEditor, \
     LinearModelEditor, QuadraticModelEditor, PolynomialModelEditor, set_default_vary
-
+from orangecontrib.spectroscopy.widgets.peakfit_compute import n_best_fit_parameters, \
+    best_fit_results, LMFIT_LOADS_KWARGS, pool_initializer, pool_fit, pool_fit2
 
 # number of processes used for computation
 N_PROCESSES = None
-
-
-def constant(x, c=0.0):
-    return c
-
-
-# WORKAROUND  lmfit's inability to load constant models
-# Add this as kwargs to .loads
-LMFIT_LOADS_KWARGS = {"funcdefs": {"constant": constant}}
-
-
-def n_best_fit_parameters(model, params):
-    """Number of output parameters for best fit results"""
-    number_of_peaks = len(model.components)
-    var_params = [name for name, par in params.items() if par.vary]
-    number_of_params = len(var_params)
-    return number_of_peaks + number_of_params + 1
-
-
-def best_fit_results(model_result, x, shape):
-    """Return array of best-fit results"""
-    out = model_result
-    sorted_x = np.sort(x)
-    comps = out.eval_components(x=sorted_x)
-    best_values = out.best_values
-
-    output = np.zeros(shape)
-
-    # add peak values to output storage
-    col = 0
-    for comp in out.model.components:
-        # Peak area
-        output[col] = np.trapz(np.broadcast_to(comps[comp.prefix], x.shape), sorted_x)
-        col += 1
-        for param in [n for n in out.var_names if n.startswith(comp.prefix)]:
-            output[col] = best_values[param]
-            col += 1
-    output[-1] = out.redchi
-    return output
 
 
 def fit_results_table(output, model_result, orig_data):
@@ -280,6 +242,7 @@ class PeakPreviewRunner(PreviewRunner):
 
         model, parameters = create_composite_model(m_def)
 
+
         model_result = {}
         x = getx(data)
         if data is not None and model is not None:
@@ -384,7 +347,7 @@ class OWPeakFit(SpectralPreprocess):
         self.start(self.run_task, self.data, m_def)
 
     @staticmethod
-    def run_task(data: Table, m_def, state):
+    def run_task(data: Table, m_def, state: TaskState):
 
         def progress_interrupt(i: float):
             state.set_progress_value(i)
@@ -483,39 +446,6 @@ class OWPeakFit(SpectralPreprocess):
                     settings[n] = h
             version = 2
         return [((name, settings), version)]
-
-
-lmfit_model = None
-lmfit_x = None
-
-
-def pool_initializer(model, parameters, x):
-    # Pool initializer is used because lmfit's CompositeModel is not picklable.
-    # Therefore we need to use loads() and dumps() to transfer it between processes.
-    global lmfit_model
-    global lmfit_x
-    lmfit_model = Model(None).loads(model, **LMFIT_LOADS_KWARGS), parameters
-    lmfit_x = x
-
-
-def pool_fit(v):
-    x = lmfit_x
-    model, parameters = lmfit_model
-    model_result = model.fit(v, params=parameters, x=x)
-    shape = n_best_fit_parameters(model, parameters)
-    bpar = best_fit_results(model_result, x, shape)
-    fitted = np.broadcast_to(model_result.eval(x=x), x.shape)
-
-    return model_result.dumps(), \
-           bpar, \
-           fitted, \
-           model_result.residual
-
-
-def pool_fit2(v, model, parameters, x):
-    model = Model(None).loads(model, **LMFIT_LOADS_KWARGS)
-    model_result = model.fit(v, params=parameters, x=x)
-    return model_result.dumps()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -34,6 +34,10 @@ from orangecontrib.spectroscopy.widgets.peak_editors import GaussianModelEditor,
     LinearModelEditor, QuadraticModelEditor, PolynomialModelEditor, set_default_vary
 
 
+# number of processes used for computation
+N_PROCESSES = None
+
+
 def constant(x, c=0.0):
     return c
 
@@ -406,7 +410,7 @@ class OWPeakFit(SpectralPreprocess):
             fits = []
             residuals = []
 
-            with multiprocessing.Pool(processes=None,
+            with multiprocessing.Pool(processes=N_PROCESSES,
                                       initializer=pool_initializer,
                                       initargs=(model.dumps(), parameters, x)) as p:
                 res = p.map_async(pool_fit, data.X, chunksize=1)

--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -251,6 +251,11 @@ class PeakPreviewRunner(PreviewRunner):
             master.curveplot.set_data(None)
             master.curveplot_after.set_data(None)
 
+    def shutdown(self):
+        super().shutdown()
+        self.pool.stop()
+        self.pool.join()
+
     @staticmethod
     def run_preview(data: Table,
                     m_def, pool, state: TaskState):

--- a/orangecontrib/spectroscopy/widgets/peak_editors.py
+++ b/orangecontrib/spectroscopy/widgets/peak_editors.py
@@ -594,21 +594,9 @@ class BaselineModelEditor(ModelEditor):
         return tuple()
 
 
-# lmfit.Model.copy is marked NotImplemented to communicate to users, not meant to be overridden
-#pylint: disable=abstract-method
-class EvalConstantModel(lmfit.models.ConstantModel):
-
-    def eval(self, params=None, **kwargs):
-        c = super().eval(params, **kwargs)
-        if 'x' in kwargs:
-            return np.full_like(kwargs['x'], c)
-        else:
-            return c
-
-
 class ConstantModelEditor(BaselineModelEditor):
     name = "Constant"
-    model = EvalConstantModel
+    model = lmfit.models.ConstantModel
     prefix_generic = "const"
 
     @staticmethod

--- a/orangecontrib/spectroscopy/widgets/peakfit_compute.py
+++ b/orangecontrib/spectroscopy/widgets/peakfit_compute.py
@@ -1,0 +1,78 @@
+# functions used by multiprocessing are in a separate file
+# for faster process initialization, so that the whole owpeakfit
+# does not have to be imported on child processes
+
+from lmfit import Model
+import numpy as np
+
+
+def constant(x, c=0.0):
+    return c
+
+
+# WORKAROUND  lmfit's inability to load constant models
+# Add this as kwargs to .loads
+LMFIT_LOADS_KWARGS = {"funcdefs": {"constant": constant}}
+
+
+def n_best_fit_parameters(model, params):
+    """Number of output parameters for best fit results"""
+    number_of_peaks = len(model.components)
+    var_params = [name for name, par in params.items() if par.vary]
+    number_of_params = len(var_params)
+    return number_of_peaks + number_of_params + 1
+
+
+def best_fit_results(model_result, x, shape):
+    """Return array of best-fit results"""
+    out = model_result
+    sorted_x = np.sort(x)
+    comps = out.eval_components(x=sorted_x)
+    best_values = out.best_values
+
+    output = np.zeros(shape)
+
+    # add peak values to output storage
+    col = 0
+    for comp in out.model.components:
+        # Peak area
+        output[col] = np.trapz(np.broadcast_to(comps[comp.prefix], x.shape), sorted_x)
+        col += 1
+        for param in [n for n in out.var_names if n.startswith(comp.prefix)]:
+            output[col] = best_values[param]
+            col += 1
+    output[-1] = out.redchi
+    return output
+
+
+lmfit_model = None
+lmfit_x = None
+
+
+def pool_initializer(model, parameters, x):
+    # Pool initializer is used because lmfit's CompositeModel is not picklable.
+    # Therefore we need to use loads() and dumps() to transfer it between processes.
+    global lmfit_model
+    global lmfit_x
+    lmfit_model = Model(None).loads(model, **LMFIT_LOADS_KWARGS), parameters
+    lmfit_x = x
+
+
+def pool_fit(v):
+    x = lmfit_x
+    model, parameters = lmfit_model
+    model_result = model.fit(v, params=parameters, x=x)
+    shape = n_best_fit_parameters(model, parameters)
+    bpar = best_fit_results(model_result, x, shape)
+    fitted = np.broadcast_to(model_result.eval(x=x), x.shape)
+
+    return model_result.dumps(), \
+           bpar, \
+           fitted, \
+           model_result.residual
+
+
+def pool_fit2(v, model, parameters, x):
+    model = Model(None).loads(model, **LMFIT_LOADS_KWARGS)
+    model_result = model.fit(v, params=parameters, x=x)
+    return model_result.dumps()

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ if __name__ == '__main__':
             'pillow',
             'lmfit>=1.0.2',
             'bottleneck',
+            'pebble',
         ],
         extras_require={
             'test': ['coverage']


### PR DESCRIPTION
`lmfit` uses `scipy.optimize`'s functions to perform the actual fitting. The problem there is that the optimizing functions block other threads from executing (time between threads is not shared). Therefore the interface blocks while fitting a single row, which, in some cases, can take long.

This PR aims to use multiprocessing in the processing threads.

On my Linux machine I get completely non-problematic previews. @stuart-cls, could you test this on Windows? Is it responsive? Asking because there might be a substantial process-spin-up difference between platforms.