### PR TITLE
peakfit: fix working with overridden wavenumbers

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -13,7 +13,7 @@ def getx(data):
     Return x of the data. If all attribute names are numbers,
     return their values. If not, return indices.
     """
-    x = np.arange(len(data.domain.attributes), dtype="f")
+    x = np.arange(len(data.domain.attributes), dtype=np.float_)  # float64
     try:
         x = np.array([float(a.name) for a in data.domain.attributes])
     except:

--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -17,7 +17,8 @@ import orangecontrib.spectroscopy.widgets.owpeakfit as owpeakfit
 from orangecontrib.spectroscopy.widgets.owpeakfit import OWPeakFit, fit_peaks, PREPROCESSORS, \
     create_model, prepare_params, unique_prefix, create_composite_model, pack_model_editor
 from orangecontrib.spectroscopy.widgets.peak_editors import ParamHintBox, VoigtModelEditor, \
-    PseudoVoigtModelEditor, ExponentialGaussianModelEditor, PolynomialModelEditor
+    PseudoVoigtModelEditor, ExponentialGaussianModelEditor, PolynomialModelEditor, \
+    GaussianModelEditor
 
 
 # shorter initializations in tests
@@ -130,6 +131,17 @@ class TestOWPeakFit(WidgetTest):
                       'gamma2': {'expr': '', 'max': 1.0, 'min': -1.0,
                                  'value': 0.0, 'vary': 'limits'}})
         self.assertEqual(settings["storedsettings"]["preprocessors"], [o1, o2])
+
+    def test_bug_iris_crash(self):
+        # bug with override wavenumbers:
+        # TypeError: Object of type 'float32' is not JSON serializable
+        data = Orange.data.Table('iris')
+        self.send_signal("Data", data)
+        # fixing getx output type fixes the bug
+        self.assertEqual(getx(data).dtype, np.float_)
+        self.widget.add_preprocessor(pack_model_editor(GaussianModelEditor))
+        self.widget.unconditional_commit()
+        wait_for_preview(self.widget, 10000)
 
     def tearDown(self):
         self.widget.onDeleteWidget()


### PR DESCRIPTION
getx() used to return `float32` arrays in some cases, which could not be serialized by python's json module within the lmfit library. Now it always returns `float64` arrays.

Had lmfit's `Model` had pickle, the world would have been a nicer place.