### PR TITLE
[ENH] Atmospheric gas correction

### DIFF
--- a/doc/widgets/atmcorr.md
+++ b/doc/widgets/atmcorr.md
@@ -10,7 +10,7 @@ and 2190-2480 cm<sup>-1</sup> for CO<sub>2</sub>.
 In each of these ranges (individually), the preprocessor either subtracts
 (or adds) as much of the reference spectrum as necessary to maximize the
 smoothness of the output (**Correct**), replaces the data with a smooth line
-(**Remove**) or does nothing (**Ignore**). Ranges to be corrected must not overlap.
+(**Bridge**) or does nothing (**No-op**). Ranges to be corrected must not overlap.
 
 For each range to be **Correct**ed and for each spectrum, the amount of reference
 subtracted from (or added to) the spectrum is chosen such that the sum of
@@ -25,9 +25,10 @@ references; this should be investigated and developed further.
 Optionally, the corrected ranges are smoothed with a Savitzky-Golay
 filter of user-defined **Savitzky-Golay window size** and polynomial order 3.
 
-For each range to be **Remove**d, data are replaced with a non-overshooting
-spline that merges gradually with the data at its edges (using a Tukey
-window with alpha=0.3).
+For each range to be **Bridge**d, data are replaced with a spline that merges
+gradually with the data at its edges. The spline is derived from the level and
+slope in a window of **Bridge base window size** points, while the transition
+between data and spline follows a Tukey window with alpha=0.2.
 
 **Reference spectrum**
 

--- a/doc/widgets/atmcorr.md
+++ b/doc/widgets/atmcorr.md
@@ -1,0 +1,42 @@
+# Atmospheric gas correction
+
+The **Atmospheric gas correction** preprocessor is designed to remove
+H<sub>2</sub>0 and CO<sub>2</sub> gas lines from spectra, based on a user-supplied
+reference spectrum.
+
+The user defines a set of spectral ranges that will be corrected. The default
+ranges are 1330-2100 cm<sup>-1</sup> and 3410-3850 cm<sup>-1</sup> for H<sub>2</sub>0
+and 2190-2480 cm<sup>-1</sup> for CO<sub>2</sub>.
+In each of these ranges (individually), the preprocessor either subtracts
+(or adds) as much of the reference spectrum as necessary to maximize the
+smoothness of the output (**Correct**), replaces the data with a smooth line
+(**Remove**) or does nothing (**Ignore**). Ranges to be corrected must not overlap.
+
+For each range to be **Correct**ed and for each spectrum, the amount of reference
+subtracted from (or added to) the spectrum is chosen such that the sum of
+squares of the first derivative (differences between consecutive points) is
+minimized.
+
+If **Use mean of references** is unchecked and multiple reference spectra
+are used, the subtracted reference is a weighted sum of all the references.
+In practice, this may be a poor replacement for arbitrary linear mixes of the
+references; this should be investigated and developed further.
+
+Optionally, the corrected ranges are smoothed with a Savitzky-Golay
+filter of user-defined **Savitzky-Golay window size** and polynomial order 3.
+
+For each range to be **Remove**d, data are replaced with a non-overshooting
+spline that merges gradually with the data at its edges (using a Tukey
+window with alpha=0.3).
+
+**Reference spectrum**
+
+To generate a suitable reference spectrum for your machine, measure the same
+sample at different levels of atmospheric gases (e.g. evacuating with clean air
+versus ambient air after breathing in the room), take the difference and pass
+it through a background correction such as ALS. (Suggested ASL parameters:
+smoothing constant 1000, weighting deviations 0.0001.)
+
+**Publication**
+
+https://doi.org/10.3390/mps3020034

--- a/doc/widgets/preprocess-spectra.md
+++ b/doc/widgets/preprocess-spectra.md
@@ -51,8 +51,9 @@ Preprocessing Methods
 - Absorbance to Transmittance: convert absorbance spectra to transmittance.
 - Shift spectra: shift things around.
 - EMSC: special Norweigan method.
-- Spike Removal: Removes spikes in spectra through a modified z-score. [More...](SpikeRemoval.md).
-- Asymmetric Least Squares Smoothing: Three ALS methods which can be used for baseline subtraction. [More...](als.md) 
+- Spike Removal: Removes spikes in spectra through a modified z-score. [More...](SpikeRemoval.md)
+- Asymmetric Least Squares Smoothing: Three ALS methods which can be used for baseline subtraction. [More...](als.md)
+- Atmospheric gas correction: remove H20/CO2 contributions using a reference spectrum. [More...](atmcorr.md)
 
 Example
 -------

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -68,6 +68,9 @@ class _AtmCorr(CommonDomainOrderUnknowns):
 
         y = X.copy()
 
+        if y.size == 0:
+            return y
+
         ranges = find_wn_ranges(wavenumbers, self.correct_ranges)
         ranges = [[p, q] for p, q in ranges if q - p > 1]
         if ranges:

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -63,13 +63,11 @@ class _AtmCorr(CommonDomainOrderUnknowns):
             y[:, p:q] -= az[:, i, None] @ atm[None, p:q]
 
         # Smoothing of atmospheric regions
-        savgolwin = 1 + 2 * int(self.smooth_win * (len(wavenumbers) - 1) /
-                                np.abs(wavenumbers[-1] - wavenumbers[0]))
-        if savgolwin > 1:
+        if self.smooth_win > 3:
             for i in range(corr_ranges):
                 p, q = ranges[i]
-                if q - p < savgolwin: continue
-                y[:, p:q] = savgol_filter(y[:, p:q], savgolwin, 3, axis=1)
+                if q - p >= self.smooth_win:
+                    y[:, p:q] = savgol_filter(y[:, p:q], self.smooth_win, 3, axis=1)
 
         # Replace CO2 region with spline
         if self.spline_co2:

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -79,8 +79,6 @@ class _AtmCorr(CommonDomainOrderUnknowns):
                         ((dhdy[:,r] - dhdy[:,p-1]) / (dh2[r] - dh2[p-1])) \
                             if p > 0 else (dhdy[:,r] / dh2[r])
             az = az * az / az.sum(0)
-            print('azz', az[:,0,:])
-            print('  sum', az[:,0,:].sum(0))
             for ia, atm in enumerate(atms):
                 for i in range(corr_ranges):
                     p, q = ranges[i]

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -89,8 +89,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
                 dh = atm[:-1] - atm[1:]
                 dh2 = np.cumsum(dh * dh)
                 dhdy = np.cumsum(dy * dh, 1)
-                for i in range(len(ranges)):
-                    p, q = ranges[i]
+                for i, (p, q) in enumerate(ranges):
                     r = q - 2
                     az[ia, :, i] = \
                         ((dhdy[:,r] - dhdy[:,p-1]) / (dh2[r] - dh2[p-1])) \
@@ -98,8 +97,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
             az2sum = (az * az).sum(0)
             az = az**3 / az2sum
             for ia, atm in enumerate(atms):
-                for i in range(len(ranges)):
-                    p, q = ranges[i]
+                for i, (p, q) in enumerate(ranges):
                     y[:, p:q] -= az[ia, :, i, None] @ atm[None, p:q]
 
         # Smoothing of atmospheric regions

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -44,6 +44,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
             self.spline_ranges = [[2190, 2480]]
         self.smooth_win = smooth_win
         self.spline_base_win = spline_base_win
+        self.spline_tukey_param = 0.2
         self.mean_reference = mean_reference
 
     def transformed(self, X, wavenumbers):
@@ -107,7 +108,6 @@ class _AtmCorr(CommonDomainOrderUnknowns):
                 y[:, p:q] = savgol_filter(y[:, p:q], self.smooth_win, 3, axis=1)
 
         # Replace (CO2) region(s) with spline(s)
-        tukey_smoothness = 0
         for srange in self.spline_ranges:
             P, Q = find_wn_ranges(wavenumbers, [srange]).flatten()
             Q = min(Q, len(wavenumbers) - 1)
@@ -128,7 +128,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
             t = np.interp(wavenumbers[P:Q+1], [Pw, Qw], [0, 1])
             tt = np.array([t**3-2*t**2+t, 2*t**3-3*t**2+1, t**3-t**2, -2*t**3+3*t**2])
             pt = a.T @ tt
-            y[:, P:Q+1] += (pt - y[:, P:Q+1]) * tukey(len(t), tukey_smoothness)
+            y[:, P:Q+1] += (pt - y[:, P:Q+1]) * tukey(len(t), self.spline_tukey_param)
 
         return y
 

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -11,9 +11,27 @@ from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDoma
 
 
 class _AtmCorr(CommonDomainOrderUnknowns):
+    """
+    Atmospheric gas correction. Removes reference spectrum (or spectra) from
+    the input spectra.
 
+    correct_range and spline_range are lists of [x1, x2] that define
+    non-overlapping x-value ranges that are individually corrected. For each
+    range in correct_ranges and for each spectrum, the amount of reference
+    subtracted from (or added to) the spectrum is chosen such that the
+    resulting spectrum is maximally smooth; the sum of squares of the first
+    derivative (differences between consecutive points) is minimized.
+    If multiple references are used (mean_reference=False), the subtracted
+    reference is a weighted sum of all the references. (In practice, this may
+    be a poor replacement for arbitrary linear combinations of the references.)
+    Optionally, the ranges in correct_ranges are smoothed with a Savitzky-Golay
+    filter (poly-order 3, window width smooth_win).
+    For each range in spline_ranges, data are replaced with a non-overshooting
+    spline that merges gradually with the data at its edges (using a Tukey
+    window with alpha=0.3).
+    """
     def __init__(self, reference, *, correct_ranges, spline_ranges,
-                 smooth_win, mean_reference, domain):
+                 smooth_win, spline_base_win, mean_reference, domain):
         super().__init__(domain)
         self.reference = reference
         if correct_ranges is not None:
@@ -25,6 +43,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
         else:
             self.spline_ranges = [[2190, 2480]]
         self.smooth_win = smooth_win
+        self.spline_base_win = spline_base_win
         self.mean_reference = mean_reference
 
     def transformed(self, X, wavenumbers):
@@ -38,81 +57,78 @@ class _AtmCorr(CommonDomainOrderUnknowns):
 
         def find_wn_ranges(wn, ranges):
             # Find indexes of a list of ranges of wavenumbers.
+            if not len(ranges):
+                return np.zeros((0, 0))
             ranges = np.asarray(ranges)
             r = np.stack((np.searchsorted(wn, ranges[:,0]),
                           np.searchsorted(wn, ranges[:,1], 'right')), 1)
-            r[r == len(wn)] = len(wn) - 1
+            # r[r == len(wn)] = len(wn) - 1
             return r
 
         y = X.copy()
 
-        corr_ranges = len(self.correct_ranges)
-        if corr_ranges:
-            ranges = find_wn_ranges(wavenumbers, self.correct_ranges)
-
+        ranges = find_wn_ranges(wavenumbers, self.correct_ranges)
+        ranges = [[p, q] for p, q in ranges if q - p > 1]
+        if ranges:
             if self.mean_reference:
                 atms = np.atleast_2d(spectra_mean(self.reference.X))
-                atms = interpolate_to_data(getx(self.reference), atms)
             else:
                 atms = np.atleast_2d(self.reference.X)
-                atms = interpolate_to_data(getx(self.reference), atms)
-
+            atms = interpolate_to_data(getx(self.reference), atms)
 
             # remove baseline in reference (skip this?)
-            for i in range(corr_ranges):
-                p, q = ranges[i]
-                if q - p < 2: continue
-                atms[:, p:q] -= interp1d(wavenumbers[[p,q-1]], atms[:, [p,q-1]])(wavenumbers[p:q])
+            for p, q in ranges:
+                atms[:, p:q] -= interp1d(wavenumbers[[p,q-1]],
+                                         atms[:, [p,q-1]])(wavenumbers[p:q])
 
             # Basic removal of atmospheric spectrum
             dy = X[:,:-1] - X[:,1:]
-            az = np.zeros((len(atms), len(X), corr_ranges))
+            az = np.zeros((len(atms), len(X), len(ranges)))
             for ia, atm in enumerate(atms):
                 dh = atm[:-1] - atm[1:]
                 dh2 = np.cumsum(dh * dh)
                 dhdy = np.cumsum(dy * dh, 1)
-                for i in range(corr_ranges):
+                for i in range(len(ranges)):
                     p, q = ranges[i]
-                    if q - p < 2: continue
-                    r = q - 2 if q <= len(wavenumbers) else q - 1
+                    r = q - 2
                     az[ia, :, i] = \
                         ((dhdy[:,r] - dhdy[:,p-1]) / (dh2[r] - dh2[p-1])) \
                             if p > 0 else (dhdy[:,r] / dh2[r])
-            az = az * az / az.sum(0)
+            az2sum = (az * az).sum(0)
+            az = az**3 / az2sum
             for ia, atm in enumerate(atms):
-                for i in range(corr_ranges):
+                for i in range(len(ranges)):
                     p, q = ranges[i]
-                    if q - p < 2: continue
                     y[:, p:q] -= az[ia, :, i, None] @ atm[None, p:q]
 
         # Smoothing of atmospheric regions
-        if self.smooth_win > 3:
-            for i in range(corr_ranges):
-                p, q = ranges[i]
-                if q - p >= self.smooth_win:
-                    y[:, p:q] = savgol_filter(y[:, p:q], self.smooth_win, 3, axis=1)
+        for p, q in ranges:
+            if q - p >= self.smooth_win > 3:
+                y[:, p:q] = savgol_filter(y[:, p:q], self.smooth_win, 3, axis=1)
 
         # Replace (CO2) region(s) with spline(s)
-        # ranges = find_wn_ranges(wavenumbers, self.spline_ranges)
+        tukey_smoothness = 0
         for srange in self.spline_ranges:
-            w = (srange[1] - srange[0]) * .24
-            rng = np.array([[srange[0], srange[0] + w],
-                            [srange[1] - w, srange[1]]])
-            rngm = rng.mean(1)
-            rngd = rngm[1] - rngm[0]
-            cr = find_wn_ranges(wavenumbers, rng).flatten()
+            P, Q = find_wn_ranges(wavenumbers, [srange]).flatten()
+            Q = min(Q, len(wavenumbers) - 1)
+            # TODO: Handle small Q - P better
+            if P >= Q:
+                continue
+            Pw, Qw = wavenumbers[[P, Q]]
+            bw = int(self.spline_base_win) // 2
+            cr = [max(P - bw, 0), min(P + bw + 1, len(wavenumbers)),
+                  max(Q - bw, 0), min(Q + bw + 1, len(wavenumbers))]
 
-            if cr[1] - cr[0] > 2 and cr[3] - cr[2] > 2:
-                a = np.empty((4, len(y)))
-                a[0:2,:] = np.polyfit((wavenumbers[cr[0]:cr[1]]-rngm[0])/rngd,
-                                      y[:,cr[0]:cr[1]].T, deg=1)
-                a[2:4,:] = np.polyfit((wavenumbers[cr[2]:cr[3]]-rngm[1])/rngd,
-                                      y[:,cr[2]:cr[3]].T, deg=1)
-                P, Q = find_wn_ranges(wavenumbers, rngm[None,:])[0]
-                t = np.interp(wavenumbers[P:Q], wavenumbers[[P,Q]], [1, 0])
-                tt = np.array([-t**3+t**2, -2*t**3+3*t**2, -t**3+2*t**2-t, 2*t**3-3*t**2+1])
-                pt = a.T @ tt
-                y[:, P:Q] += (pt - y[:, P:Q]) * tukey(len(t), .3)
+            a = np.empty((4, len(y)))
+            a[0:2,:] = np.polyfit(wavenumbers[cr[0]:cr[1]] - Pw,
+                                  y[:,cr[0]:cr[1]].T, deg=1)
+            a[2:4,:] = np.polyfit(wavenumbers[cr[2]:cr[3]] - Qw,
+                                  y[:,cr[2]:cr[3]].T, deg=1)
+            a[::2,:] = a[::2,:] * (Qw - Pw)
+            t = np.interp(wavenumbers[P:Q+1], [Pw, Qw], [0, 1])
+            tt = np.array([t**3-2*t**2+t, 2*t**3-3*t**2+1, t**3-t**2, -2*t**3+3*t**2])
+            pt = a.T @ tt
+            y[:, P:Q+1] += (pt - y[:, P:Q+1]) * tukey(len(t), tukey_smoothness)
 
         return y
 
@@ -120,13 +136,15 @@ class _AtmCorr(CommonDomainOrderUnknowns):
 class AtmCorr(Preprocess):
 
     def __init__(self, reference=None, correct_ranges=None,
-                 spline_ranges=None, smooth_win=0, mean_reference=True):
+                 spline_ranges=None, smooth_win=0, spline_base_win=9,
+                 mean_reference=True):
         if reference is None:
             raise MissingReferenceException()
         self.reference = reference
         self.correct_ranges = correct_ranges
         self.spline_ranges = spline_ranges
         self.smooth_win = smooth_win
+        self.spline_base_win = spline_base_win
         self.mean_reference = mean_reference
 
     def __call__(self, data):
@@ -135,6 +153,7 @@ class AtmCorr(Preprocess):
                           correct_ranges=self.correct_ranges,
                           spline_ranges=self.spline_ranges,
                           smooth_win=self.smooth_win,
+                          spline_base_win=self.spline_base_win,
                           mean_reference=self.mean_reference,
                           domain=data.domain)
         # takes care of domain column-wise, by above transformation function

--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -1,0 +1,114 @@
+import numpy as np
+from scipy.signal import savgol_filter, tukey
+from scipy.interpolate import interp1d
+
+import Orange
+from Orange.preprocess.preprocess import Preprocess
+
+from orangecontrib.spectroscopy.data import getx, spectra_mean
+from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDomainOrderUnknowns, \
+    interp1d_with_unknowns_numpy, nan_extend_edges_and_interpolate, MissingReferenceException
+
+
+class _AtmCorr(CommonDomainOrderUnknowns):
+
+    def __init__(self, reference, spline_co2, smooth_win, domain):
+        super().__init__(domain)
+        self.reference = reference
+        self.spline_co2 = spline_co2
+        self.smooth_win = smooth_win
+
+    def transformed(self, X, wavenumbers):
+
+        def interpolate_to_data(other_xs, other_data):
+            # all input data needs to be interpolated (and NaNs removed)
+            interpolated = interp1d_with_unknowns_numpy(other_xs, other_data, wavenumbers)
+            # we know that X is not NaN. same handling of reference as of X
+            interpolated, _ = nan_extend_edges_and_interpolate(wavenumbers, interpolated)
+            return interpolated
+
+        def find_wn_ranges(wn, ranges):
+            # Find indexes of a list of ranges of wavenumbers.
+            ranges = np.asarray(ranges)
+            return np.stack((np.searchsorted(wn, ranges[:,0]),
+                             np.searchsorted(wn, ranges[:,1], 'right')), 1)
+
+        # wavenumber have to be input as sorted
+        atm = np.atleast_2d(spectra_mean(self.reference.X))
+        atm = interpolate_to_data(getx(self.reference), atm).mean(0)
+
+        ranges = [[1300, 2100], [3410, 3850], [2190, 2480]]
+        ranges = find_wn_ranges(wavenumbers, ranges)
+        corr_ranges = 2 if self.spline_co2 else 3
+
+        # remove baseline in reference (skip this?)
+        for i in range(corr_ranges):
+            p, q = ranges[i]
+            if q - p < 2: continue
+            atm[p:q] -= interp1d(wavenumbers[[p,q-1]], atm[[p,q-1]])(wavenumbers[p:q])
+
+        # Basic removal of atmospheric spectrum
+        dh = atm[:-1] - atm[1:]
+        dy = X[:,:-1] - X[:,1:]
+        dh2 = np.cumsum(dh * dh)
+        dhdy = np.cumsum(dy * dh, 1)
+        az = np.zeros((len(X), corr_ranges))
+        y = X.copy()
+        for i in range(corr_ranges):
+            p, q = ranges[i]
+            if q - p < 2: continue
+            r = q - 2 if q <= len(wavenumbers) else q - 1
+            az[:, i] = ((dhdy[:,r] - dhdy[:,p-1]) / (dh2[r] - dh2[p-1])
+                        ) if p > 0 else (dhdy[:,r] / dh2[r])
+            y[:, p:q] -= az[:, i, None] @ atm[None, p:q]
+
+        # Smoothing of atmospheric regions
+        savgolwin = 1 + 2 * int(self.smooth_win * (len(wavenumbers) - 1) /
+                                np.abs(wavenumbers[-1] - wavenumbers[0]))
+        if savgolwin > 1:
+            for i in range(corr_ranges):
+                p, q = ranges[i]
+                if q - p < savgolwin: continue
+                y[:, p:q] = savgol_filter(y[:, p:q], savgolwin, 3, axis=1)
+
+        # Replace CO2 region with spline
+        if self.spline_co2:
+            rng = np.array([[2190, 2260], [2410, 2480]])
+            rngm = rng.mean(1)
+            rngd = rngm[1] - rngm[0]
+            cr = find_wn_ranges(wavenumbers, rng).flatten()
+            if cr[1] - cr[0] > 2 and cr[3] - cr[2] > 2:
+                a = np.empty((4, len(y)))
+                a[0:2,:] = np.polyfit((wavenumbers[cr[0]:cr[1]]-rngm[0])/rngd,
+                                      y[:,cr[0]:cr[1]].T, deg=1)
+                a[2:4,:] = np.polyfit((wavenumbers[cr[2]:cr[3]]-rngm[1])/rngd,
+                                      y[:,cr[2]:cr[3]].T, deg=1)
+                P, Q = find_wn_ranges(wavenumbers, rngm[None,:])[0]
+                t = np.interp(wavenumbers[P:Q], wavenumbers[[P,Q]], [1, 0])
+                tt = np.array([-t**3+t**2, -2*t**3+3*t**2, -t**3+2*t**2-t, 2*t**3-3*t**2+1])
+                pt = a.T @ tt
+                y[:, P:Q] += (pt - y[:, P:Q]) * tukey(len(t), .3)
+
+        return y
+
+
+class AtmCorr(Preprocess):
+
+    def __init__(self, reference=None, spline_co2=False, smooth_win=0):
+        if reference is None:
+            raise MissingReferenceException()
+        self.reference = reference
+        self.spline_co2 = spline_co2
+        self.smooth_win = smooth_win
+
+    def __call__(self, data):
+        # creates function for transforming data
+        common = _AtmCorr(reference=self.reference, spline_co2=self.spline_co2,
+                          smooth_win=self.smooth_win, domain=data.domain)
+        # takes care of domain column-wise, by above transformation function
+        atts = [a.copy(compute_value=SelectColumn(i, common))
+                for i, a in enumerate(data.domain.attributes)]
+
+        domain = Orange.data.Domain(atts, data.domain.class_vars,
+                                    data.domain.metas)
+        return data.from_table(domain, data)

--- a/orangecontrib/spectroscopy/tests/test_atm_corr.py
+++ b/orangecontrib/spectroscopy/tests/test_atm_corr.py
@@ -19,7 +19,17 @@ class TestAtmCorr(unittest.TestCase):
         sp = np.sin(wn*.005)**2 * (1-((wn-2400)/1600)**2)
         data = spectra_table(wn, [sp + .3 * atm(wn)])
         ref = spectra_table(awn, [atm(awn)])
-        method = AtmCorr(reference=ref, spline_co2=True, smooth_win=9)
+        method = AtmCorr(reference=ref, smooth_win=9)
+        process = method(data)
+        delta = ((data.X[0] - process.X[0])**2).sum()
+        assert 10 < delta < 11
+        method = AtmCorr(reference=ref, correct_ranges=[], spline_ranges=[])
+        process = method(data)
+        delta = ((data.X[0] - process.X[0])**2).sum()
+        assert delta == 0
+        # Test with multiple references
+        ref = spectra_table(awn, 3 * [atm(awn)])
+        method = AtmCorr(reference=ref, smooth_win=9, mean_reference=False)
         process = method(data)
         delta = ((data.X[0] - process.X[0])**2).sum()
         assert 10 < delta < 11

--- a/orangecontrib/spectroscopy/tests/test_atm_corr.py
+++ b/orangecontrib/spectroscopy/tests/test_atm_corr.py
@@ -1,0 +1,25 @@
+import unittest
+
+import numpy as np
+
+from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
+from orangecontrib.spectroscopy.tests.util import spectra_table
+
+
+class TestAtmCorr(unittest.TestCase):
+    def test_atm_corr(self):
+        # Fake atmospheric spectrum
+        def atm(wn):
+            return np.sin(wn*.0373)**2 * \
+                ((np.abs(wn-1700)<300) + (np.abs(wn-3630)<150))
+        # Make some fake data with different resolution than the atm spectrum
+        wn = np.arange(800, 4000, 3)
+        awn = np.arange(800, 4000, 1)
+        # The CO2 region happens to be nearly straight with this function
+        sp = np.sin(wn*.005)**2 * (1-((wn-2400)/1600)**2)
+        data = spectra_table(wn, [sp + .3 * atm(wn)])
+        ref = spectra_table(awn, [atm(awn)])
+        method = AtmCorr(reference=ref, spline_co2=True, smooth_win=9)
+        process = method(data)
+        delta = ((data.X[0] - process.X[0])**2).sum()
+        assert 10 < delta < 11

--- a/orangecontrib/spectroscopy/tests/test_editor_als.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_als.py
@@ -9,10 +9,6 @@ class A(unittest.TestCase): pass
 
 class TestALSEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(ALSEditor, self.widget)

--- a/orangecontrib/spectroscopy/tests/test_editor_atm_corr.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_atm_corr.py
@@ -28,7 +28,6 @@ class TestAtmCorrEditor(PreprocessorEditorTest):
 
     def test_interaction(self):
         self.send_signal(self.widget.Inputs.reference, SMALL_COLLAGEN)
-        self.editor.spline_button.click()
         self.editor.smooth_button.click()
         self.editor.smooth_win_spin.setValue(17)
         self.widget.unconditional_commit()

--- a/orangecontrib/spectroscopy/tests/test_editor_atm_corr.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_atm_corr.py
@@ -1,0 +1,35 @@
+from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
+
+from orangecontrib.spectroscopy.tests.test_owpreprocess import PreprocessorEditorTest
+from orangecontrib.spectroscopy.tests.test_preprocess import SMALL_COLLAGEN
+from orangecontrib.spectroscopy.widgets.owpreprocess import OWPreprocess
+from orangecontrib.spectroscopy.widgets.preprocessors.atm_corr import AtmCorrEditor
+
+
+class TestAtmCorrEditor(PreprocessorEditorTest):
+
+    def get_preprocessor(self):
+        out = self.get_output(self.widget.Outputs.preprocessor)
+        return out.preprocessors[0]
+
+    def setUp(self):
+        self.widget = self.create_widget(OWPreprocess)
+        self.editor = self.add_editor(AtmCorrEditor, self.widget)
+        self.data = SMALL_COLLAGEN
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.wait_for_preview()  # ensure initialization with preview data
+
+    def test_no_interaction(self):
+        self.send_signal(self.widget.Inputs.reference, SMALL_COLLAGEN)
+        self.widget.unconditional_commit()
+        self.wait_until_finished()
+        p = self.get_preprocessor()
+        self.assertIsInstance(p, AtmCorr)
+
+    def test_interaction(self):
+        self.send_signal(self.widget.Inputs.reference, SMALL_COLLAGEN)
+        self.editor.spline_button.click()
+        self.editor.smooth_button.click()
+        self.editor.smooth_win_spin.setValue(17)
+        self.widget.unconditional_commit()
+        self.wait_until_finished()

--- a/orangecontrib/spectroscopy/tests/test_editor_baseline.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_baseline.py
@@ -10,10 +10,6 @@ from orangecontrib.spectroscopy.widgets.preprocessors.utils import layout_widget
 
 class TestBaselineEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(BaselineEditor, self.widget)

--- a/orangecontrib/spectroscopy/tests/test_editor_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_emsc.py
@@ -10,10 +10,6 @@ from orangecontrib.spectroscopy.widgets.preprocessors.emsc import EMSCEditor
 
 class TestEMSCEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(EMSCEditor, self.widget)  # type: EMSCEditor

--- a/orangecontrib/spectroscopy/tests/test_editor_gaussian.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_gaussian.py
@@ -7,10 +7,6 @@ from orangecontrib.spectroscopy.widgets.owpreprocess import OWPreprocess, Gaussi
 
 class TestGaussianEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(GaussianSmoothingEditor,

--- a/orangecontrib/spectroscopy/tests/test_editor_me_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_me_emsc.py
@@ -10,10 +10,6 @@ from orangecontrib.spectroscopy.widgets.preprocessors.me_emsc import MeEMSCEdito
 
 class TestMeEMSCEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(MeEMSCEditor, self.widget)  # type: MeEMSCEditor
@@ -21,11 +17,6 @@ class TestMeEMSCEditor(PreprocessorEditorTest):
         # FIXME: current ME-EMSC can not handle same data and reference
         self.data = SMALL_COLLAGEN[1:3]
         self.send_signal(self.widget.Inputs.data, self.data)
-
-    def commit_get_preprocessor(self):
-        self.widget.unconditional_commit()
-        self.wait_until_finished()
-        return self.get_preprocessor()
 
     def test_no_interaction(self):
         reference = SMALL_COLLAGEN[:1]

--- a/orangecontrib/spectroscopy/tests/test_editor_spikeremoval.py
+++ b/orangecontrib/spectroscopy/tests/test_editor_spikeremoval.py
@@ -7,10 +7,6 @@ from orangecontrib.spectroscopy.preprocess import Despike
 
 class TestSpikeRemovalEditor(PreprocessorEditorTest):
 
-    def get_preprocessor(self):
-        out = self.get_output(self.widget.Outputs.preprocessor)
-        return out.preprocessors[0]
-
     def setUp(self):
         self.widget = self.create_widget(OWPreprocess)
         self.editor = self.add_editor(SpikeRemovalEditor, self.widget)

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -376,3 +376,12 @@ class PreprocessorEditorTest(WidgetTest):
         editor = widget.flow_view.widgets()[-1]
         self.process_events()
         return editor
+
+    def get_preprocessor(self):
+        out = self.get_output(self.widget.Outputs.preprocessor)
+        return out.preprocessors[0]
+
+    def commit_get_preprocessor(self):
+        self.widget.unconditional_commit()
+        self.wait_until_finished()
+        return self.get_preprocessor()

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -16,6 +16,7 @@ from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     PreprocessException, NormalizePhaseReference, Despike, SpSubtract
 from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
 from orangecontrib.spectroscopy.preprocess.me_emsc import ME_EMSC
+from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
 from orangecontrib.spectroscopy.tests.util import smaller_data
 
 
@@ -148,6 +149,10 @@ PREPROCESSORS_INDEPENDENT_SAMPLES += list(
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(
     add_edge_case_data_parameter(EMSC, "badspectra", SMALL_COLLAGEN[0:2],
                                  reference=SMALL_COLLAGEN[-1:]))
+
+# AtmCorr with different kinds of reference
+PREPROCESSORS_INDEPENDENT_SAMPLES += list(
+    add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1]))
 
 PREPROCESSORS_INDEPENDENT_SAMPLES += \
     list(add_edge_case_data_parameter(NormalizeReference, "reference", SMALL_COLLAGEN[:1]))

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -152,7 +152,8 @@ PREPROCESSORS_INDEPENDENT_SAMPLES += list(
 
 # AtmCorr with different kinds of reference
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(
-    add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1]))
+    add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1],
+                                 correct_ranges=[(1300, 2100)], smooth_win=5))
 
 PREPROCESSORS_INDEPENDENT_SAMPLES += \
     list(add_edge_case_data_parameter(NormalizeReference, "reference", SMALL_COLLAGEN[:1]))

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -60,6 +60,7 @@ from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditor, B
 from orangecontrib.spectroscopy.widgets.gui import ValueTransform, connect_settings, float_to_str_decimals
 from orangecontrib.spectroscopy.widgets.preprocessors.spikeremoval import SpikeRemovalEditor
 from orangecontrib.spectroscopy.widgets.preprocessors.als import ALSEditor
+from orangecontrib.spectroscopy.widgets.preprocessors.atm_corr import AtmCorrEditor
 
 
 PREVIEW_COLORS = [QColor(*a).name() for a in DefaultColorBrewerPalette[8]]
@@ -1114,6 +1115,12 @@ PREPROCESSORS = [
         Description("Asymmetric Least Squares Smoothing",
                     icon_path("Discretize.svg")),
         ALSEditor
+    ),
+    PreprocessAction(
+        "Atmospheric Correction", "preprocessors.atm_corr", "Atmospheric Correction",
+        Description("Atmospheric gas (CO2/H2O) correction",
+                    icon_path("Discretize.svg")),
+        AtmCorrEditor
     ),
     ]
 

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -58,7 +58,7 @@ class AtmCorrEditor(BaseEditorOrange):
         self.smooth_win_spin = gui.spin(self.controlArea, self, "smooth_win",
                  label="Savitzky-Golay window size", minv=5, maxv=35,
                  step=2, controlWidth=60, callback=self.edited.emit)
-        self.smooth_win_spin = gui.spin(self.controlArea, self, "bridge_win",
+        self.bridge_win_spin = gui.spin(self.controlArea, self, "bridge_win",
                  label="Bridge base window size", minv=3, maxv=35,
                  step=2, controlWidth=60, callback=self.edited.emit)
         gui.checkBox(self.controlArea, self, "mean_reference",
@@ -85,12 +85,12 @@ class AtmCorrEditor(BaseEditorOrange):
             self.user_changed = True
         self.smooth = params.get("smooth", self.SMOOTH)
         self.smooth_win = params.get("smooth_win", self.SMOOTH_WIN)
+        self.bridge_win = params.get("bridge_win", self.BRIDGE_WIN)
         self.update_reference_info()
         self.smooth_win_spin.setEnabled(self.smooth)
         for an, v in self.get_range_defaults().items():
             setattr(self, an, params.get(an, v))
         self.mean_reference = params.get("mean_reference", self.MEAN_REF)
-
 
     def parameters(self):
         parameters = super().parameters()

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -1,0 +1,102 @@
+import numpy as np
+import pyqtgraph as pg
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QVBoxLayout, QLabel
+from Orange.widgets import gui
+from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange, \
+    REFERENCE_DATA_PARAM
+from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
+from orangecontrib.spectroscopy.data import spectra_mean, getx
+
+
+class AtmCorrEditor(BaseEditorOrange):
+    """
+       Atmospheric gas correction.
+    """
+
+    SPLINE_CO2 = True
+    SMOOTH = True
+    SMOOTH_WIN = 9
+
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.controlArea.setLayout(QVBoxLayout())
+
+        self.reference = None
+        self.preview_data = None
+        self.preview_data_max = 1
+
+        self.spline_co2 = self.SPLINE_CO2
+        self.smooth = self.SMOOTH
+        self.smooth_win = self.SMOOTH_WIN
+
+        gui.checkBox(self.controlArea, self, "spline_co2",
+                     "Spline over CO2 region", callback=self.edited.emit)
+        gui.checkBox(self.controlArea, self, "smooth",
+                     "Smooth corrected regions", callback=self.edited.emit)
+        self.smooth_win_spin = gui.spin(self.controlArea, self, "smooth_win",
+                 label="Savitzky-Golay window size", minv=5, maxv=25,
+                 step=2, controlWidth=60, callback=self.edited.emit)
+        self.reference_info = QLabel("", self)
+        self.controlArea.layout().addWidget(self.reference_info)
+
+        self.reference_curve = pg.PlotCurveItem()
+        self.reference_curve.setPen(pg.mkPen(color=QColor(Qt.red), width=1.5))
+        self.reference_curve.setZValue(10)
+
+        self.user_changed = False
+
+    def setParameters(self, params):
+        if params:
+            self.user_changed = True
+        self.spline_co2 = params.get("spline_co2", self.SPLINE_CO2)
+        self.smooth = params.get("smooth", self.SMOOTH)
+        self.smooth_win = params.get("smooth_win", self.SMOOTH_WIN)
+        self.update_reference_info()
+        self.smooth_win_spin.setEnabled(self.smooth)
+
+    def parameters(self):
+        parameters = super().parameters()
+        return parameters
+
+    def set_reference_data(self, reference):
+        self.reference = reference
+        self.update_reference_info()
+
+    def set_preview_data(self, data):
+        self.preview_data_max = spectra_mean(data.X).max()
+        self.update_reference_info()
+
+    def update_reference_info(self):
+        if self.reference_curve not in self.parent_widget.curveplot.markings:
+            self.parent_widget.curveplot.add_marking(self.reference_curve)
+        if not self.reference:
+            self.reference_curve.hide()
+            self.reference_info.setText("Reference: missing!")
+            self.reference_info.setStyleSheet("color: red")
+        else:
+            rinfo = "mean of %d spectra" % len(self.reference) \
+                if len(self.reference) > 1 else "1 spectrum"
+            self.reference_info.setText("Reference: " + rinfo)
+            self.reference_info.setStyleSheet("color: black")
+            X_ref = spectra_mean(self.reference.X)
+            X_ref = X_ref * (self.preview_data_max / X_ref.max())
+            x = getx(self.reference)
+            xsind = np.argsort(x)
+            self.reference_curve.setData(x=x[xsind], y=X_ref[xsind])
+            self.reference_curve.setVisible(True)
+
+    @classmethod
+    def createinstance(cls, params):
+        spline_co2 = params.get("spline_co2", cls.SPLINE_CO2)
+        smooth_win = params.get("smooth_win", cls.SMOOTH_WIN) if \
+            params.get("smooth", cls.SMOOTH) else 0
+
+        reference = params.get(REFERENCE_DATA_PARAM, None)
+
+        if reference is None:
+            return lambda data: data[:0]  # return an empty data table
+        else:
+            return AtmCorr(reference=reference, spline_co2=spline_co2,
+                           smooth_win=smooth_win)

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -96,8 +96,8 @@ class AtmCorrEditor(BaseEditorOrange):
         parameters = super().parameters()
         return parameters
 
-    def set_reference_data(self, reference):
-        self.reference = reference
+    def set_reference_data(self, data):
+        self.reference = data
         self.update_reference_info()
 
     def set_preview_data(self, data):

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -131,13 +131,14 @@ class AtmCorrEditor(BaseEditorOrange):
     def createinstance(cls, params):
         cranges = []
         sranges = []
+        rdefs = cls.get_range_defaults()
         for b in range(len(cls.RANGES)):
-            r = [params.get(f'{a}_{b}') for a in ['low', 'high']]
+            r = [params.get(f'{a}_{b}', rdefs.get(f'{a}_{b}')) for a in ['low', 'high']]
             try:
                 r = [float(v) for v in r]
             except (ValueError, TypeError):
                 continue
-            cm = params.get(f'corrmode_{b}')
+            cm = params.get(f'corrmode_{b}', rdefs.get(f'corrmode_{b}'))
             if cm == 1:
                 cranges.append(r)
             elif cm == 2:

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -31,9 +31,9 @@ class AtmCorrEditor(BaseEditorOrange):
         self.smooth = self.SMOOTH
         self.smooth_win = self.SMOOTH_WIN
 
-        gui.checkBox(self.controlArea, self, "spline_co2",
+        self.spline_button = gui.checkBox(self.controlArea, self, "spline_co2",
                      "Spline over CO2 region", callback=self.edited.emit)
-        gui.checkBox(self.controlArea, self, "smooth",
+        self.smooth_button = gui.checkBox(self.controlArea, self, "smooth",
                      "Smooth corrected regions", callback=self.edited.emit)
         self.smooth_win_spin = gui.spin(self.controlArea, self, "smooth_win",
                  label="Savitzky-Golay window size", minv=5, maxv=25,

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -2,10 +2,11 @@ import numpy as np
 import pyqtgraph as pg
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QVBoxLayout, QLabel, QLineEdit
 from Orange.widgets import gui
-from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange, \
-    REFERENCE_DATA_PARAM
+from orangecontrib.spectroscopy.widgets.gui import lineEditDecimalOrNone
+from orangecontrib.spectroscopy.widgets.preprocessors.utils import \
+    BaseEditorOrange, REFERENCE_DATA_PARAM
 from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
 from orangecontrib.spectroscopy.data import spectra_mean, getx
 
@@ -15,9 +16,11 @@ class AtmCorrEditor(BaseEditorOrange):
        Atmospheric gas correction.
     """
 
-    SPLINE_CO2 = True
+    RANGES = [[1300, 2100, False], [2190, 2480, True],
+              [3410, 3850, False], ['', '', False]]
     SMOOTH = True
     SMOOTH_WIN = 9
+    MEAN_REF = True
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
@@ -27,17 +30,39 @@ class AtmCorrEditor(BaseEditorOrange):
         self.preview_data = None
         self.preview_data_max = 1
 
-        self.spline_co2 = self.SPLINE_CO2
         self.smooth = self.SMOOTH
         self.smooth_win = self.SMOOTH_WIN
+        self.mean_reference = self.MEAN_REF
+        for an, v in self.get_range_defaults().items():
+            setattr(self, an, v)
 
-        self.spline_button = gui.checkBox(self.controlArea, self, "spline_co2",
-                     "Spline over CO2 region", callback=self.edited.emit)
+        self.controlArea.layout().addWidget(QLabel("Correction ranges", self))
+        self.range_boxes = []
+        for b in range(len(self.RANGES)):
+            box = gui.hBox(self.controlArea)
+            gui.lineEdit(box, self, "low_%d" % b, label="From",
+                          callback=self.edited.emit, orientation=Qt.Horizontal,
+                          controlWidth=75)
+            gui.lineEdit(box, self, "high_%d" % b, label="to",
+                          callback=self.edited.emit, orientation=Qt.Horizontal,
+                          controlWidth=75)
+            gui.checkBox(box, self, "spline_%d" % b,
+                         "spline", callback=self.edited.emit)
+            # box.layout().addWidget(QLabel("From"))
+            # lineEditDecimalOrNone(box, self, "low_%d" % b,
+            #              callback=self.edited.emit)
+            # box.layout().addWidget(QLabel("to"))
+            # lineEditDecimalOrNone(box, self, "high_%d" % b,
+            #              callback=self.edited.emit)
+            self.range_boxes.append(box)
+
         self.smooth_button = gui.checkBox(self.controlArea, self, "smooth",
                      "Smooth corrected regions", callback=self.edited.emit)
         self.smooth_win_spin = gui.spin(self.controlArea, self, "smooth_win",
                  label="Savitzky-Golay window size", minv=5, maxv=25,
                  step=2, controlWidth=60, callback=self.edited.emit)
+        gui.checkBox(self.controlArea, self, "mean_reference",
+                      "Use mean of references", callback=self.edited.emit)
         self.reference_info = QLabel("", self)
         self.controlArea.layout().addWidget(self.reference_info)
 
@@ -47,14 +72,25 @@ class AtmCorrEditor(BaseEditorOrange):
 
         self.user_changed = False
 
+    @classmethod
+    def get_range_defaults(cls):
+        defs = {}
+        for b, r in enumerate(cls.RANGES):
+            for i, a in enumerate(['low', 'high', 'spline']):
+                defs['%s_%d' % (a, b)] = r[i]
+        return defs
+
     def setParameters(self, params):
         if params:
             self.user_changed = True
-        self.spline_co2 = params.get("spline_co2", self.SPLINE_CO2)
         self.smooth = params.get("smooth", self.SMOOTH)
         self.smooth_win = params.get("smooth_win", self.SMOOTH_WIN)
         self.update_reference_info()
         self.smooth_win_spin.setEnabled(self.smooth)
+        for an, v in self.get_range_defaults().items():
+            setattr(self, an, params.get(an, v))
+        self.mean_reference = params.get("mean_reference", self.MEAN_REF)
+
 
     def parameters(self):
         parameters = super().parameters()
@@ -76,8 +112,12 @@ class AtmCorrEditor(BaseEditorOrange):
             self.reference_info.setText("Reference: missing!")
             self.reference_info.setStyleSheet("color: red")
         else:
-            rinfo = "mean of %d spectra" % len(self.reference) \
-                if len(self.reference) > 1 else "1 spectrum"
+            if len(self.reference) == 1:
+                rinfo = "1 spectrum"
+            elif self.mean_reference:
+                rinfo = "mean of %d spectra" % len(self.reference)
+            else:
+                rinfo = "%d individual spectra" % len(self.reference)
             self.reference_info.setText("Reference: " + rinfo)
             self.reference_info.setStyleSheet("color: black")
             X_ref = spectra_mean(self.reference.X)
@@ -89,14 +129,28 @@ class AtmCorrEditor(BaseEditorOrange):
 
     @classmethod
     def createinstance(cls, params):
-        spline_co2 = params.get("spline_co2", cls.SPLINE_CO2)
+        # spline_co2 = params.get("spline_co2", cls.SPLINE_CO2)
+        cranges = []
+        sranges = []
+        for b in range(len(cls.RANGES)):
+            r = [params.get('%s_%d' % (a, b)) for a in ['low', 'high']]
+            try:
+                r = [float(v) for v in r]
+            except (ValueError, TypeError):
+                continue
+            if r[1] > r[0]:
+                if params.get('spline_%d' % b):
+                    sranges.append(r)
+                else:
+                    cranges.append(r)
         smooth_win = params.get("smooth_win", cls.SMOOTH_WIN) if \
             params.get("smooth", cls.SMOOTH) else 0
-
+        mean_reference = params.get("mean_reference", cls.MEAN_REF)
         reference = params.get(REFERENCE_DATA_PARAM, None)
 
         if reference is None:
             return lambda data: data[:0]  # return an empty data table
         else:
-            return AtmCorr(reference=reference, spline_co2=spline_co2,
-                           smooth_win=smooth_win)
+            return AtmCorr(reference=reference, correct_ranges=cranges,
+                           spline_ranges=sranges, smooth_win=smooth_win,
+                           mean_reference=mean_reference)


### PR DESCRIPTION
Atmospheric gas correction, subtracting as much of a reference spectrum as needed to minimize the sum of squares of differences of consecutive points. Implemented as a preprocessor with options for the wavenumber ranges (which should be non-overlapping), replacing a region with a smooth curve, denoising the corrected region, and whether multiple reference spectra should be averaged first or later (with spectrum-specific weighting).