### PR TITLE
[FIX] Always set correct feature comboboxes

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -167,10 +167,7 @@ class OWBin(OWWidget):
 
     def _init_interface_data(self, args):
         data = args[0]
-        same_domain = (self.data and data and
-                       data.domain == self.data.domain)
-        if not same_domain:
-            self._init_attr_values(data)
+        self._init_attr_values(data)
         self._init_attrs()
 
     def _update_attrs(self):

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -699,10 +699,7 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         self.data_ids = {}
 
     def init_interface_data(self, data):
-        same_domain = (self.data and data and
-                       data.domain == self.data.domain)
-        if not same_domain:
-            self.init_attr_values(data)
+        self.init_attr_values(data)
 
     def help_event(self, ev):
         pos = self.plot.vb.mapSceneToView(ev.scenePos())
@@ -1168,10 +1165,7 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         self.imageplot.set_visible_image_opacity(self.visible_image_opacity)
 
     def init_interface_data(self, data):
-        same_domain = (self.data and data and
-                       data.domain == self.data.domain)
-        if not same_domain:
-            self.init_attr_values(data)
+        self.init_attr_values(data)
         self.init_visible_images(data)
 
     def output_image_selection(self):

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -905,11 +905,9 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         return legend
 
     def init_interface_data(self, data):
-        old_domain = self.data.domain if self.data else None
         domain = data.domain if data is not None else None
         self.feature_color_model.set_domain(domain)
-        if old_domain is not None and domain != old_domain:  # do not reset feature_color
-            self.feature_color = self.feature_color_model[0] if self.feature_color_model else None
+        self.feature_color = self.feature_color_model[0] if self.feature_color_model else None
 
     def line_select_start(self):
         if self.viewtype == INDIVIDUAL:

--- a/orangecontrib/spectroscopy/widgets/owspectralseries.py
+++ b/orangecontrib/spectroscopy/widgets/owspectralseries.py
@@ -118,10 +118,7 @@ class LineScanPlot(QWidget, OWComponent, SelectionGroupMixin,
         self.data_ids = {}
 
     def init_interface_data(self, data):
-        same_domain = (self.data and data and
-                       data.domain == self.data.domain)
-        if not same_domain:
-            self.init_attr_values(data)
+        self.init_attr_values(data)
 
     def help_event(self, ev):
         pos = self.plot.vb.mapSceneToView(ev.scenePos())

--- a/orangecontrib/spectroscopy/widgets/owstackalign.py
+++ b/orangecontrib/spectroscopy/widgets/owstackalign.py
@@ -183,7 +183,6 @@ class OWStackAlign(OWWidget):
 
         gui.auto_commit(self.controlArea, self, "autocommit", "Send Data")
 
-
     def _sanitize_ref_frame(self):
         if self.ref_frame_num > self.data.X.shape[1]:
             self.ref_frame_num = self.data.X.shape[1]
@@ -204,10 +203,7 @@ class OWStackAlign(OWWidget):
 
     def _init_interface_data(self, args):
         data = args[0]
-        same_domain = (self.data and data and
-                       data.domain == self.data.domain)
-        if not same_domain:
-            self._init_attr_values(data)
+        self._init_attr_values(data)
 
     def _update_attr(self):
         self.commit()


### PR DESCRIPTION
This PR removed checks for unchanged domains in the input; before, selected features were not updated if domains were the same. This could lead to problems with discrete variables, which now for some time have relaxed equality checking.

This is done with hopes of fixing exceptions when variables from settings and those available do not match. I saw bugs like this and have seen error reports on Sentry, but I do not know how to reproduce the bug. I do not know whether this change will fix the bugs I saw, but it seems to remove one possibility for errors.

An exception that I see on Sentry ([ORANGE3-2RF](https://sentry.io/organizations/biolab/issues/2755974424/?project=124497)) looks like this:
```
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangecontrib/spectroscopy/widgets/owspectra.py\", line 1590, in set_data",
        "    self.openContext(data)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/widget.py\", line 1110, in openContext",
        "    self.settingsHandler.open_context(self, *a)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/Orange/widgets/settings.py\", line 125, in open_context",
        "    super().open_context(widget, domain, *self.encode_domain(domain))",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/settings.py\", line 833, in open_context",
        "    self.settings_to_widget(widget, *args)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/settings.py\", line 945, in settings_to_widget",
        "    _apply_setting(setting, instance, value)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/settings.py\", line 204, in _apply_setting",
        "    setattr(instance, setting.name, value)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/gui.py\", line 187, in __setattr__",
        "    callback(value)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/gui.py\", line 2281, in __call__",
        "    self.action(*args)",
        "  File \"/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/orangewidget/gui.py\", line 2371, in action",
        "    raise ValueError(\"Combo box does not contain item \" + repr(value))",
        "ValueError: Combo box does not contain item DiscreteVariable(name='group', values=('Breast cancer', 'Healthy', 'Lung cancer'))",
````

For me, this PR not change the behavior, because Orange's contexts themselves should restore current values after they are reopened. I have to admit I do not quite understand why I wrote this code in 2017 and then copied it multiple times. Perhaps I did not use contexts then? No idea.

Could anyone please give this PR a spin and report if you see any problems?

@stuart-cls, did you ever see this? @borondics told me he does not remember it happening to him. But as I see, it is something that happens quite often, Sentry shows 14 reports of this in 1 month.