### PR TITLE
[FIX] Fix loading pre-0.6.1 workflows with explicit reader settings

### DIFF
--- a/orangecontrib/spectroscopy/data.py
+++ b/orangecontrib/spectroscopy/data.py
@@ -1,5 +1,4 @@
-import bottleneck
-import numpy as np
+# pylint: disable=unused-import
 
 # import for compatibility before the restructure
 import Orange.data.io  # legacy import so that file readers are registered
@@ -7,19 +6,25 @@ from orangecontrib.spectroscopy.io.util import \
     _metatable_maplocs, _spectra_from_image, _spectra_from_image_2d,\
     build_spec_table
 
+from orangecontrib.spectroscopy.util import getx, spectra_mean
 
-def getx(data):
-    """
-    Return x of the data. If all attribute names are numbers,
-    return their values. If not, return indices.
-    """
-    x = np.arange(len(data.domain.attributes), dtype=np.float_)  # float64
-    try:
-        x = np.array([float(a.name) for a in data.domain.attributes])
-    except:
-        pass
-    return x
-
-
-def spectra_mean(X):
-    return bottleneck.nanmean(X, axis=0)
+# imports for workflow compatibility when a reader was explicitly selected
+# In the owfile settings, explicitly selected selected readers are stored with
+# full module and class name. Moving but not adding imports would show
+# the missing reader error.
+from orangecontrib.spectroscopy.io.agilent import AgilentImageReader, AgilentImageIFGReader,\
+    agilentMosaicReader, agilentMosaicIFGReader, agilentMosaicTileReader
+from orangecontrib.spectroscopy.io.ascii import AsciiColReader, AsciiMapReader
+from orangecontrib.spectroscopy.io.diamond import NXS_STXM_Diamond_I08
+from orangecontrib.spectroscopy.io.envi import EnviMapReader
+from orangecontrib.spectroscopy.io.gsf import GSFReader
+from orangecontrib.spectroscopy.io.matlab import MatlabReader
+from orangecontrib.spectroscopy.io.maxiv import HDRReader_STXM
+from orangecontrib.spectroscopy.io.meta import DatMetaReader, HDRMetaReader
+from orangecontrib.spectroscopy.io.neaspec import NeaReader, NeaReaderGSF
+from orangecontrib.spectroscopy.io.omnic import OmnicMapReader, SPCReader, SPAReader
+from orangecontrib.spectroscopy.io.opus import OPUSReader
+from orangecontrib.spectroscopy.io.ptir import PTIRFileReader
+from orangecontrib.spectroscopy.io.soleil import SelectColumnReader, HDF5Reader_HERMES, \
+    HDF5Reader_ROCK
+from orangecontrib.spectroscopy.io.wire import WiREReaders

--- a/orangecontrib/spectroscopy/io/ascii.py
+++ b/orangecontrib/spectroscopy/io/ascii.py
@@ -3,7 +3,7 @@ import numpy as np
 from Orange.data import FileFormat, ContinuousVariable, Table, Domain
 from Orange.data.io import CSVReader
 
-from orangecontrib.spectroscopy.data import getx
+from orangecontrib.spectroscopy.util import getx
 from orangecontrib.spectroscopy.io.util import SpectralFileFormat
 
 

--- a/orangecontrib/spectroscopy/util.py
+++ b/orangecontrib/spectroscopy/util.py
@@ -1,0 +1,19 @@
+import bottleneck
+import numpy as np
+
+
+def getx(data):
+    """
+    Return x of the data. If all attribute names are numbers,
+    return their values. If not, return indices.
+    """
+    x = np.arange(len(data.domain.attributes), dtype=np.float_)  # float64
+    try:
+        x = np.array([float(a.name) for a in data.domain.attributes])
+    except:
+        pass
+    return x
+
+
+def spectra_mean(X):
+    return bottleneck.nanmean(X, axis=0)


### PR DESCRIPTION
We were sloppy in #575. In the owfile settings, explicitly selected readers are stored with the full module and class names. Moving but not adding imports for compatibility showed the missing reader error. I remembered this bug while studying how owfile works.

I also needed to move `getx` somewhere out of `orangecontrib.spectroscopy.data` because of circular imports. `orangecontrib.spectroscopy.data.util` did not work because that still imported the parent module. I am open to better names than `orangecontrib.spectroscopy.util`.