### PR TITLE
[FIX] PLS: Decorate overridden input handler

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpls.py
+++ b/orangecontrib/spectroscopy/widgets/owpls.py
@@ -59,6 +59,7 @@ class OWPLS(OWBaseLearner):
             coef_table.name = "coefficients"
         self.Outputs.coefsdata.send(coef_table)
 
+    @OWBaseLearner.Inputs.data
     def set_data(self, data):
         self.Warning.sparse_data.clear()
         super().set_data(data)


### PR DESCRIPTION
##### Issue
Summary info on input dataset is missing.
Similar to https://github.com/biolab/orange3/issues/5834

##### Description of changes
Decorate overridden set_data().