### PR TITLE
Fixed-width label font for crosshair label

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -9,10 +9,9 @@ from xml.sax.saxutils import escape
 from AnyQt.QtWidgets import QWidget, QGraphicsItem, QPushButton, QMenu, \
     QGridLayout, QAction, QVBoxLayout, QApplication, QWidgetAction, QLabel, \
     QShortcut, QToolTip, QGraphicsRectItem, QGraphicsTextItem
-from AnyQt.QtGui import QColor, QPixmapCache, QPen, QKeySequence
+from AnyQt.QtGui import QColor, QPixmapCache, QPen, QKeySequence, QFontDatabase
 from AnyQt.QtCore import Qt, QRectF, QPointF, QObject
 from AnyQt.QtCore import pyqtSignal
-from AnyQt.QtGui import QFont
 
 import bottleneck
 import numpy as np
@@ -711,7 +710,8 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
         self.label = pg.TextItem("", anchor=(1, 0), fill="#FFFFFFBB")
         self.label.setText("", color=(0, 0, 0))
-        self.label.setFont(QFont("Courier"))
+        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        self.label.setFont(font)
         self.label.setZValue(100000)
 
         self.discrete_palette = None

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -12,6 +12,7 @@ from AnyQt.QtWidgets import QWidget, QGraphicsItem, QPushButton, QMenu, \
 from AnyQt.QtGui import QColor, QPixmapCache, QPen, QKeySequence
 from AnyQt.QtCore import Qt, QRectF, QPointF, QObject
 from AnyQt.QtCore import pyqtSignal
+from AnyQt.QtGui import QFont
 
 import bottleneck
 import numpy as np
@@ -707,8 +708,12 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         self.pen_normal = defaultdict(lambda: pen_normal)
         self.pen_subset = defaultdict(lambda: pen_subset)
         self.pen_selected = defaultdict(lambda: pen_selected)
-        self.label = pg.TextItem("", anchor=(1, 0))
+
+        self.label = pg.TextItem("", anchor=(1, 0), fill="#FFFFFFBB")
         self.label.setText("", color=(0, 0, 0))
+        self.label.setFont(QFont("Courier"))
+        self.label.setZValue(100000)
+
         self.discrete_palette = None
         QPixmapCache.setCacheLimit(max(QPixmapCache.cacheLimit(), 100 * 1024))
         self.curves_cont = PlotCurvesItem()
@@ -1195,7 +1200,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
             self.crosshair_hidden = bool(labels)
 
             if self.location and not labels:
-                labels = strdec(posx, self.important_decimals[0]) + " " + \
+                labels = strdec(posx, self.important_decimals[0]) + "  " + \
                          strdec(posy, self.important_decimals[1])
             self.label.setText(labels, color=(0, 0, 0))
 


### PR DESCRIPTION
The crosshair label was always jumping because the number digits are not the same width. Now I changed the font to a fixed-width font so this problem goes away. Also added an opaque BG to the label and moved it onto the top of the GUI elements stack so that the crosshair and other elements don't make the reading hard when overlapping.