### PR TITLE
[FIX] Agilent visible image loading on case-sensitive systems

### DIFF
--- a/orangecontrib/spectroscopy/utils/agilent.py
+++ b/orangecontrib/spectroscopy/utils/agilent.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 import configparser
 from pathlib import Path
@@ -219,7 +219,7 @@ def get_visible_images(p):
     visible_images = []
 
     config = configparser.ConfigParser()
-    config.read(p.parent.joinpath("IRMosaicInfo.cfg"))
+    config.read(p.parent.joinpath("IrMosaicInfo.cfg"))
     config.read(p.parent.joinpath("VisMosaicInfo.cfg"))
 
     cutout_path = p.parent.joinpath("IrCutout.bmp")


### PR DESCRIPTION
`agilent` module had a (case) typo in the hard-coded filenames for visible image loading. Doesn't show up on Windows as it is case-insensitive.

I added some files for testing in https://github.com/stuart-cls/python-agilent-file-formats/commit/07f278a33da008fc4e21872b9d4e98a35e02acc7 but I wasn't sure if we wanted even those small-ish `.bmp` files here. If yes, I can add a similar test to this PR