### PR TITLE
Fix a crash in athmospheric correction (in an extremely degenerate case)

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_conversion.py
+++ b/orangecontrib/spectroscopy/tests/test_conversion.py
@@ -85,13 +85,14 @@ class TestConversion(unittest.TestCase):
         and applying is just on train data should yield the same transformation of
         the test data. """
         for proc in PREPROCESSORS_INDEPENDENT_SAMPLES:
-            data = preprocessor_data(proc)
-            _, test1 = separate_learn_test(proc(data))
-            train, test = separate_learn_test(data)
-            train = proc(train)
-            test_transformed = test.transform(train.domain)
-            np.testing.assert_almost_equal(test_transformed.X, test1.X,
-                                           err_msg="Preprocessor " + str(proc))
+            with self.subTest(proc):
+                data = preprocessor_data(proc)
+                _, test1 = separate_learn_test(proc(data))
+                train, test = separate_learn_test(data)
+                train = proc(train)
+                test_transformed = test.transform(train.domain)
+                np.testing.assert_almost_equal(test_transformed.X, test1.X,
+                                               err_msg="Preprocessor " + str(proc))
 
     def test_predict_savgov_same_domain(self):
         data = SavitzkyGolayFiltering(window=9, polyorder=2, deriv=2)(self.collagen)
@@ -118,26 +119,27 @@ class TestConversion(unittest.TestCase):
         for proc in PREPROCESSORS:
             if hasattr(proc, "skip_add_zeros"):
                 continue
-            # LR that can not handle unknown values
-            train, test = separate_learn_test(preprocessor_data(proc))
-            train1 = proc(train)
-            aucorig = AUC(TestOnTestData()(train1, test, [learner]))
-            test = slightly_change_wavenumbers(test, 0.00001)
-            test = odd_attr(test)
-            # a subset of points for training so that all test sets points
-            # are within the train set points, which gives no unknowns
-            train = Interpolate(points=getx(train)[1:-3])(train)  # interpolatable train
-            train = proc(train)
-            # explicit domain conversion test to catch exceptions that would
-            # otherwise be silently handled in TestOnTestData
-            _ = test.transform(train.domain)
-            aucnow = AUC(TestOnTestData()(train, test, [learner]))
-            self.assertAlmostEqual(aucnow, aucorig, delta=0.03, msg="Preprocessor " + str(proc))
-            test = Interpolate(points=getx(test) - 1.)(test)  # also do a shift
-            _ = test.transform(train.domain)  # explicit call again
-            aucnow = AUC(TestOnTestData()(train, test, [learner]))
-            # the difference should be slight
-            self.assertAlmostEqual(aucnow, aucorig, delta=0.05, msg="Preprocessor " + str(proc))
+            with self.subTest(proc):
+                # LR that can not handle unknown values
+                train, test = separate_learn_test(preprocessor_data(proc))
+                train1 = proc(train)
+                aucorig = AUC(TestOnTestData()(train1, test, [learner]))
+                test = slightly_change_wavenumbers(test, 0.00001)
+                test = odd_attr(test)
+                # a subset of points for training so that all test sets points
+                # are within the train set points, which gives no unknowns
+                train = Interpolate(points=getx(train)[1:-3])(train)  # interpolatable train
+                train = proc(train)
+                # explicit domain conversion test to catch exceptions that would
+                # otherwise be silently handled in TestOnTestData
+                _ = test.transform(train.domain)
+                aucnow = AUC(TestOnTestData()(train, test, [learner]))
+                self.assertAlmostEqual(aucnow, aucorig, delta=0.03, msg="Preprocessor " + str(proc))
+                test = Interpolate(points=getx(test) - 1.)(test)  # also do a shift
+                _ = test.transform(train.domain)  # explicit call again
+                aucnow = AUC(TestOnTestData()(train, test, [learner]))
+                # the difference should be slight
+                self.assertAlmostEqual(aucnow, aucorig, delta=0.05, msg="Preprocessor " + str(proc))
 
 
 class _RemoveNaNRows(Orange.preprocess.preprocess.Preprocess):

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -28,58 +28,63 @@ class TestAllPreprocessors(WidgetTest):
     def test_allpreproc_indv(self):
         data = SMALLER_COLLAGEN
         for p in PREPROCESSORS:
-            self.widget = self.create_widget(OWPreprocess)
-            self.send_signal("Data", data)
-            self.widget.add_preprocessor(p)
-            self.widget.commit.now()
-            wait_for_preview(self.widget)
-            self.wait_until_finished(timeout=10000)
+            with self.subTest(p.viewclass):
+                self.widget = self.create_widget(OWPreprocess)
+                self.send_signal("Data", data)
+                self.widget.add_preprocessor(p)
+                self.widget.commit.now()
+                wait_for_preview(self.widget)
+                self.wait_until_finished(timeout=10000)
 
     def test_allpreproc_indv_empty(self):
         data = SMALLER_COLLAGEN
         for p in PREPROCESSORS:
-            self.widget = self.create_widget(OWPreprocess)
-            self.send_signal("Data", data[:0])
-            self.widget.add_preprocessor(p)
-            self.widget.commit.now()
-            wait_for_preview(self.widget)
-            self.wait_until_finished(timeout=10000)
+            with self.subTest(p.viewclass):
+                self.widget = self.create_widget(OWPreprocess)
+                self.send_signal("Data", data[:0])
+                self.widget.add_preprocessor(p)
+                self.widget.commit.now()
+                wait_for_preview(self.widget)
+                self.wait_until_finished(timeout=10000)
         # no attributes
         data = data.transform(
             Orange.data.Domain([],
                                class_vars=data.domain.class_vars,
                                metas=data.domain.metas))
         for p in PREPROCESSORS:
-            self.widget = self.create_widget(OWPreprocess)
-            self.send_signal("Data", data)
-            self.widget.add_preprocessor(p)
-            self.widget.commit.now()
-            wait_for_preview(self.widget)
-            self.wait_until_finished(timeout=10000)
+            with self.subTest(p.viewclass, type="no attributes"):
+                self.widget = self.create_widget(OWPreprocess)
+                self.send_signal("Data", data)
+                self.widget.add_preprocessor(p)
+                self.widget.commit.now()
+                wait_for_preview(self.widget)
+                self.wait_until_finished(timeout=10000)
 
     def test_allpreproc_indv_ref(self):
         data = SMALLER_COLLAGEN
         for p in PREPROCESSORS:
-            self.widget = self.create_widget(OWPreprocess)
-            self.send_signal("Data", data)
-            self.send_signal("Reference", data)
-            self.widget.add_preprocessor(p)
-            self.widget.commit.now()
-            wait_for_preview(self.widget)
-            self.wait_until_finished(timeout=10000)
+            with self.subTest(p.viewclass):
+                self.widget = self.create_widget(OWPreprocess)
+                self.send_signal("Data", data)
+                self.send_signal("Reference", data)
+                self.widget.add_preprocessor(p)
+                self.widget.commit.now()
+                wait_for_preview(self.widget)
+                self.wait_until_finished(timeout=10000)
 
     def test_allpreproc_indv_ref_multi(self):
         """Test that preprocessors can handle references with multiple instances"""
         # len(data) must be > maximum preview size (10) to ensure test failure
         data = SMALLER_COLLAGEN
         for p in PREPROCESSORS:
-            self.widget = self.create_widget(OWPreprocess)
-            self.send_signal("Data", data)
-            self.send_signal("Reference", data)
-            self.widget.add_preprocessor(p)
-            self.widget.commit.now()
-            wait_for_preview(self.widget, timeout=10000)
-            self.wait_until_finished(timeout=10000)
+            with self.subTest(p.viewclass):
+                self.widget = self.create_widget(OWPreprocess)
+                self.send_signal("Data", data)
+                self.send_signal("Reference", data)
+                self.widget.add_preprocessor(p)
+                self.widget.commit.now()
+                wait_for_preview(self.widget, timeout=10000)
+                self.wait_until_finished(timeout=10000)
 
 
 class TestOWPreprocess(WidgetTest):

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -103,7 +103,10 @@ class AtmCorrEditor(BaseEditorOrange):
         self.update_reference_info()
 
     def set_preview_data(self, data):
-        self.preview_data_max = spectra_mean(data.X).max()
+        try:
+            self.preview_data_max = np.nanmax(spectra_mean(data.X))
+        except ValueError:  # if sequence is empty
+            self.preview_data_max = 1
         self.update_reference_info()
 
     def update_reference_info(self):


### PR DESCRIPTION
biolab/orange-widget-base/pull/204 pointed out an error that we did not catch before. @stuart-cls, remember when we were wondering why some exceptions in peak fitting did not fail the tests? Well, now they would.

I am surprised there was just a single error like this. 