### PR TITLE
[ENH] Implement equivalence of (some) spectral tranformations

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,15 +24,15 @@ requirements:
   run:
     - python >=3.8
     - numpy >=1.20.0
-    - orange3 >=3.32.0
-    - orange-canvas-core >=0.1.24
-    - orange-widget-base >=4.16.1
-    - scipy >=1.4.0
+    - orange3 >=3.34.0
+    - orange-canvas-core >=0.1.28
+    - orange-widget-base >=4.19.0
+    - scipy >=1.9.0
     - scikit-learn>=1.0.1
     - spectral >=0.22.3,!=0.23
     - serverfiles >=0.2
-    - AnyQt >=0.0.6
-    - pyqtgraph >=0.11.1,!=0.12.4
+    - AnyQt >=0.1.0
+    - pyqtgraph >=0.12.2,!=0.12.4
     - colorcet
     - h5py
     - extranormal3 >=0.0.3

--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -29,7 +29,7 @@ from orangecontrib.spectroscopy.preprocess.utils import SelectColumn, CommonDoma
 
 
 class PCADenoisingFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _PCAReconstructCommon(CommonDomain):
@@ -79,7 +79,7 @@ class PCADenoising(Preprocess):
 
 
 class GaussianFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _GaussianCommon(CommonDomainOrderUnknowns):
@@ -178,7 +178,7 @@ class SavitzkyGolayFiltering(Preprocess):
 
 
 class RubberbandBaselineFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _RubberbandBaselineCommon(CommonDomainOrder):
@@ -242,7 +242,7 @@ class RubberbandBaseline(Preprocess):
 
 
 class LinearBaselineFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _LinearBaselineCommon(CommonDomainOrderUnknowns):
@@ -545,7 +545,7 @@ class InterpolateToDomain(Preprocess):
 
 ######################################### XAS normalization ##########
 class XASnormalizationFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _XASnormalizationCommon(CommonDomainOrderUnknowns):
@@ -607,7 +607,7 @@ class NoEdgejumpProvidedException(PreprocessException):
 
 
 class ExtractEXAFSFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class EdgeJumpException(PreprocessException):
@@ -731,7 +731,7 @@ class ExtractEXAFS(Preprocess):
 
 
 class CurveShiftFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _CurveShiftCommon(CommonDomain):
@@ -759,7 +759,7 @@ class CurveShift(Preprocess):
 
 
 class DespikeFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _DespikeCommon(CommonDomainOrderUnknowns):
@@ -837,7 +837,7 @@ class Despike(Preprocess):
 
 
 class SpSubtractFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _SpSubtractCommon(CommonDomainRef):

--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -131,7 +131,7 @@ class Cut(Preprocess):
 
 
 class SavitzkyGolayFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _SavitzkyGolayCommon(CommonDomainOrderUnknowns):
@@ -146,6 +146,15 @@ class _SavitzkyGolayCommon(CommonDomainOrderUnknowns):
         return savgol_filter(X, window_length=self.window,
                              polyorder=self.polyorder,
                              deriv=self.deriv, mode="nearest")
+
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.window == other.window \
+               and self.polyorder == other.polyorder \
+               and self.deriv == other.deriv
+
+    def __hash__(self):
+        return hash((super().__hash__(), self.window, self.polyorder, self.deriv))
 
 
 class SavitzkyGolayFiltering(Preprocess):

--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -412,7 +412,7 @@ def features_with_interpolation(points, kind="linear", domain=None, handle_nans=
 
 
 class InterpolatedFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _InterpolateCommon:
@@ -448,6 +448,18 @@ class _InterpolateCommon:
             else:
                 interpfn = interp1d_wo_unknowns_scipy
         return interpfn(x, ys, self.points, kind=self.kind)
+
+    def __eq__(self, other):
+        return type(self) is type(other) \
+               and np.all(self.points == other.points) \
+               and self.kind == other.kind \
+               and self.domain == other.domain \
+               and self.handle_nans == other.handle_nans \
+               and self.interpfn == other.interpfn
+
+    def __hash__(self):
+        return hash((type(self), tuple(self.points[:5]), self.kind,
+                     self.domain, self.handle_nans, self.interpfn))
 
 
 class Interpolate(Preprocess):

--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -276,7 +276,7 @@ class LinearBaseline(Preprocess):
 
 
 class NormalizeFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _NormalizeCommon(CommonDomain):
@@ -332,6 +332,18 @@ class _NormalizeCommon(CommonDomain):
                 data.X = data.X / (max - min)
                 replace_infs(data.X)
         return data.X
+
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.method == other.method \
+               and self.lower == other.lower \
+               and self.upper == other.upper \
+               and self.int_method == other.int_method \
+               and self.attr == other.attr
+
+    def __hash__(self):
+        return hash((super().__hash__(), self.method, self.lower,
+                     self.upper, self.int_method, self.attr))
 
 
 class Normalize(Preprocess):

--- a/orangecontrib/spectroscopy/preprocess/als/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/als/__init__.py
@@ -11,7 +11,7 @@ from orangecontrib.spectroscopy.preprocess.als.baseline import als, arpls, \
 
 
 class ALSFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class ALSCommon(CommonDomainOrderUnknowns):
@@ -54,7 +54,7 @@ class ALSP(Preprocess):
 
 
 class ARPLSFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class ARPLSCommon(CommonDomainOrderUnknowns):
@@ -100,7 +100,7 @@ class ARPLS(Preprocess):
 
 
 class AIRPLSFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class AIRPLSCommon(CommonDomainOrderUnknowns):

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -54,11 +54,11 @@ def weighted_wavenumbers(weights, wavenumbers):
 
 
 class EMSCFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class EMSCModel(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _EMSC(CommonDomainOrderUnknowns):

--- a/orangecontrib/spectroscopy/preprocess/integrate.py
+++ b/orangecontrib/spectroscopy/preprocess/integrate.py
@@ -72,17 +72,25 @@ class IntegrateFeature(SharedComputeValue):
         x_s, y_s = self.extract_data(data, common)
         return self.compute_integral(x_s, y_s)
 
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.limits == other.limits
+
+    def __hash__(self):
+        return hash((super().__hash__(), tuple(self.limits)))
+
 
 class IntegrateFeatureEdgeBaseline(IntegrateFeature):
     """ A linear edge-to-edge baseline subtraction. """
 
     name = "Integral from baseline"
+    InheritEq = True
 
     @staticmethod
     def parameters():
         return (("Low limit", "Low limit for integration (inclusive)"),
                 ("High limit", "High limit for integration (inclusive)"),
-            )
+                )
 
     def compute_baseline(self, x, y):
         if np.any(np.isnan(y)):
@@ -105,6 +113,7 @@ class IntegrateFeatureEdgeBaseline(IntegrateFeature):
 class IntegrateFeatureSeparateBaseline(IntegrateFeature):
 
     name = "Integral from separate baseline"
+    InheritEq = True
 
     @staticmethod
     def parameters():
@@ -148,6 +157,7 @@ class IntegrateFeatureSimple(IntegrateFeatureEdgeBaseline):
     """ A simple y=0 integration on the provided data window. """
 
     name = "Integral from 0"
+    InheritEq = True
 
     def compute_baseline(self, x_s, y_s):
         return np.zeros(y_s.shape)
@@ -157,12 +167,13 @@ class IntegrateFeaturePeakEdgeBaseline(IntegrateFeature):
     """ The maximum baseline-subtracted peak height in the provided window. """
 
     name = "Peak from baseline"
+    InheritEq = True
 
     @staticmethod
     def parameters():
         return (("Low limit", "Low limit for integration (inclusive)"),
                 ("High limit", "High limit for integration (inclusive)"),
-            )
+                )
 
     def compute_baseline(self, x, y):
         return edge_baseline(x, y)
@@ -186,6 +197,7 @@ class IntegrateFeaturePeakSimple(IntegrateFeaturePeakEdgeBaseline):
     """ The maximum peak height in the provided data window. """
 
     name = "Peak from 0"
+    InheritEq = True
 
     def compute_baseline(self, x_s, y_s):
         return np.zeros(y_s.shape)
@@ -195,12 +207,13 @@ class IntegrateFeaturePeakXEdgeBaseline(IntegrateFeature):
     """ The X-value of the maximum baseline-subtracted peak height in the provided window. """
 
     name = "X-value of maximum from baseline"
+    InheritEq = True
 
     @staticmethod
     def parameters():
         return (("Low limit", "Low limit for integration (inclusive)"),
                 ("High limit", "High limit for integration (inclusive)"),
-            )
+                )
 
     def compute_baseline(self, x, y):
         return edge_baseline(x, y)
@@ -231,6 +244,7 @@ class IntegrateFeaturePeakXSimple(IntegrateFeaturePeakXEdgeBaseline):
     """ The X-value of the maximum peak height in the provided data window. """
 
     name = "X-value of maximum from 0"
+    InheritEq = True
 
     def compute_baseline(self, x_s, y_s):
         return np.zeros(y_s.shape)
@@ -240,11 +254,12 @@ class IntegrateFeatureAtPeak(IntegrateFeature):
     """ Find the closest x and return the value there. """
 
     name = "Closest value"
+    InheritEq = True
 
     @staticmethod
     def parameters():
         return (("Closest to", "Nearest value"),
-            )
+                )
 
     def extract_data(self, data, common):
         data, x, x_sorter = common
@@ -274,6 +289,14 @@ class _IntegrateCommon(CommonDomain):
         x = getx(data)
         x_sorter = np.argsort(x)
         return data, x, x_sorter
+
+    def __eq__(self, other):
+        # pylint: disable=useless-parent-delegation
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # pylint: disable=useless-parent-delegation
+        return super().__hash__()
 
 
 class Integrate(Preprocess):

--- a/orangecontrib/spectroscopy/preprocess/me_emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/me_emsc.py
@@ -88,11 +88,11 @@ def cal_ncomp(reference, wavenumbers,  explainedVarLim, alpha0, gamma):
 
 
 class ME_EMSCFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class ME_EMSCModel(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _ME_EMSC(CommonDomainOrderUnknowns):

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -19,7 +19,7 @@ class SpecTypes(Enum):
 
 
 class AbsorbanceFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _AbsorbanceCommon(CommonDomainRef):
@@ -39,6 +39,14 @@ class _AbsorbanceCommon(CommonDomainRef):
             absd *= -1
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(absd)
+
+    def __eq__(self, other):
+        # pylint: disable=useless-parent-delegation
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # pylint: disable=useless-parent-delegation
+        return super().__hash__()
 
 
 class TransformOptionalReference(Preprocess):
@@ -76,7 +84,7 @@ class Absorbance(TransformOptionalReference):
 
 
 class TransmittanceFeature(SelectColumn):
-    pass
+    InheritEq = True
 
 
 class _TransmittanceCommon(CommonDomainRef):
@@ -96,6 +104,14 @@ class _TransmittanceCommon(CommonDomainRef):
             np.power(10, transd, transd)
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(transd)
+
+    def __eq__(self, other):
+        # pylint: disable=useless-parent-delegation
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # pylint: disable=useless-parent-delegation
+        return super().__hash__()
 
 
 class Transmittance(TransformOptionalReference):

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -58,7 +58,7 @@ class CommonDomain:
     SharedComputeValue features. It does the domain transformation
     (input domain needs to be the same as it was with training data).
     """
-    def __init__(self, domain):
+    def __init__(self, domain: Domain):
         self.domain = domain
 
     def __call__(self, data):
@@ -83,11 +83,11 @@ class CommonDomain:
 
 class CommonDomainRef(CommonDomain):
     """CommonDomain which also ensures reference domain transformation"""
-    def __init__(self, reference, domain):
+    def __init__(self, reference: Table, domain: Domain):
         super().__init__(domain)
         self.reference = reference
 
-    def interpolate_extend_to(self, interpolate, wavenumbers):
+    def interpolate_extend_to(self, interpolate: Table, wavenumbers):
         """
         Interpolate data to given wavenumbers and extend the possibly
         nan-edges with the nearest values.
@@ -97,6 +97,9 @@ class CommonDomainRef(CommonDomain):
         # we know that X is not NaN. same handling of reference as of X
         X, _ = nan_extend_edges_and_interpolate(wavenumbers, X)
         return X
+
+    # TODO: reference is a Table and therefor __eq__ and __hash__ should take
+    # this into account. As of now, Table does not have __eq__ or __hash__
 
 
 class CommonDomainOrder(CommonDomain):
@@ -122,6 +125,14 @@ class CommonDomainOrder(CommonDomain):
 
     def transformed(self, X, wavenumbers):
         raise NotImplemented
+
+    def __eq__(self, other):
+        # pylint: disable=useless-parent-delegation
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # pylint: disable=useless-parent-delegation
+        return super().__hash__()
 
 
 class CommonDomainOrderUnknowns(CommonDomainOrder):
@@ -158,6 +169,14 @@ class CommonDomainOrderUnknowns(CommonDomainOrder):
 
         # restore order
         return self._restore_order(X, mon, xsind, xc)
+
+    def __eq__(self, other):
+        # pylint: disable=useless-parent-delegation
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # pylint: disable=useless-parent-delegation
+        return super().__hash__()
 
 
 def nan_extend_edges_and_interpolate(xs, X):

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -73,6 +73,13 @@ class CommonDomain:
     def transformed(self, data):
         raise NotImplemented
 
+    def __eq__(self, other):
+        return type(self) is type(other) \
+               and self.domain == other.domain
+
+    def __hash__(self):
+        return hash((type(self), self.domain))
+
 
 class CommonDomainRef(CommonDomain):
     """CommonDomain which also ensures reference domain transformation"""

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -52,6 +52,13 @@ class SelectColumn(SharedComputeValue):
     def compute(self, data, common):
         return common[:, self.feature]
 
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.feature == other.feature
+
+    def __hash__(self):
+        return hash((super().__hash__(), self.feature))
+
 
 class CommonDomain:
     """A utility class that helps constructing common transformation for

--- a/orangecontrib/spectroscopy/tests/test_integrate.py
+++ b/orangecontrib/spectroscopy/tests/test_integrate.py
@@ -148,3 +148,24 @@ class TestIntegrate(unittest.TestCase):
         self.assertTrue("0 - 5" in metavars and "0 - 6" in metavars)
         self.assertEqual(i[0]["0 - 5"], 8)
         self.assertEqual(i[0]["0 - 6"], 3)
+
+    def test_eq(self):
+        data = Table.from_numpy(None, [[1, 2, 3, 1, 1, 1]])
+        i1 = Integrate(methods=Integrate.Simple, limits=[[0, 5]])(data)
+        i2 = Integrate(methods=Integrate.Simple, limits=[[0, 6]])(data)
+        self.assertNotEqual(i1.domain[0], i2.domain[0])
+        i3 = Integrate(methods=Integrate.Simple, limits=[[0, 6], [0, 5]])(data)
+        self.assertNotEqual(i1.domain[0], i3.domain[0])
+        self.assertEqual(i1.domain[0], i3.domain[1])
+        i4 = Integrate(methods=Integrate.Baseline, limits=[[0, 5]])(data)
+        self.assertNotEqual(i1.domain[0], i4.domain[0])
+
+        # different domain should mean different integrals
+        data2 = Table.from_numpy(None, [[1, 2, 3, 1, 1, 1, 1]])
+        ii1 = Integrate(methods=Integrate.Simple, limits=[[0, 5]])(data2)
+        self.assertNotEqual(i1.domain[0], ii1.domain[0])
+
+        # same domain -> same integrals
+        data3 = Table.from_numpy(None, [[1, 2, 3, 22, 1, 2]])
+        iii1 = Integrate(methods=Integrate.Simple, limits=[[0, 5]])(data3)
+        self.assertEqual(i1.domain[0], iii1.domain[0])

--- a/orangecontrib/spectroscopy/tests/test_interpolate.py
+++ b/orangecontrib/spectroscopy/tests/test_interpolate.py
@@ -179,6 +179,21 @@ class TestInterpolate(unittest.TestCase):
         v, n = nan_extend_edges_and_interpolate(xsm, ysm)
         np.testing.assert_equal(v[:, mix], exp)
 
+    def test_eq(self):
+        data = Orange.data.Table("iris")
+        i1 = Interpolate([0, 1])(data)
+        i2 = Interpolate([0, 1])(data)
+        self.assertEqual(i1.domain, i2.domain)
+        i3 = Interpolate([0, 1.1])(data)
+        self.assertNotEqual(i1.domain[0], i3.domain[0])
+        i4 = Interpolate([0, 1], kind="quadratic")(data)
+        self.assertNotEqual(i1.domain[0], i4.domain[0])
+
+        # different domain
+        titanic = Orange.data.Table("titanic")
+        it1 = Interpolate([0, 1])(titanic)
+        self.assertNotEqual(i1.domain[0], it1.domain[0])
+
 
 class TestInterpolateToDomain(unittest.TestCase):
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -242,6 +242,24 @@ class TestSavitzkyGolay(unittest.TestCase):
         np.testing.assert_almost_equal(fdata.X,
                                        [[4.86857143, 3.47428571, 1.49428571, 0.32857143]])
 
+    def test_eq(self):
+        data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
+        p1 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=0)(data)
+        p2 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=1)(data)
+        p3 = SavitzkyGolayFiltering(window=5, polyorder=3, deriv=0)(data)
+        p4 = SavitzkyGolayFiltering(window=7, polyorder=2, deriv=0)(data)
+        self.assertNotEqual(p1.domain, p2.domain)
+        self.assertNotEqual(p1.domain, p3.domain)
+        self.assertNotEqual(p1.domain, p4.domain)
+
+        s1 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=0)(data)
+        self.assertEqual(p1.domain, s1.domain)
+
+        # even if the data set is different features should be the same
+        data2 = Table.from_numpy(None, [[2, 1, 3, 4, 3]])
+        s2 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=0)(data2)
+        self.assertEqual(p1.domain, s2.domain)
+
 
 class TestGaussian(unittest.TestCase):
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -202,6 +202,22 @@ class TestTransmittance(unittest.TestCase):
         calcdata = Absorbance()(Transmittance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
+    def test_eq(self):
+        data = SMALL_COLLAGEN
+        t1 = Transmittance()(data)
+        t2 = Transmittance()(data)
+        self.assertEqual(t1.domain, t2.domain)
+        data2 = Table.from_numpy(None, [[1.0, 2.0, 3.0, 4.0]])
+        t3 = Transmittance()(data2)
+        self.assertNotEqual(t1.domain, t3.domain)
+        t4 = Transmittance(reference=data2)(data)
+        self.assertNotEqual(t1.domain, t4.domain)
+        t5 = Transmittance(reference=data2)(data[:1])
+        self.assertGreater(len(t4), len(t5))
+        self.assertEqual(t4.domain, t5.domain)
+        a = Absorbance()(data)
+        self.assertNotEqual(a.domain, t1.domain)
+
 
 class TestAbsorbance(unittest.TestCase):
 
@@ -220,6 +236,20 @@ class TestAbsorbance(unittest.TestCase):
         data = Transmittance()(SMALL_COLLAGEN)
         calcdata = Transmittance()(Absorbance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
+
+    def test_eq(self):
+        data = SMALL_COLLAGEN
+        t1 = Absorbance()(data)
+        t2 = Absorbance()(data)
+        self.assertEqual(t1.domain, t2.domain)
+        data2 = Table.from_numpy(None, [[1.0, 2.0, 3.0, 4.0]])
+        t3 = Absorbance()(data2)
+        self.assertNotEqual(t1.domain, t3.domain)
+        t4 = Absorbance(reference=data2)(data)
+        self.assertNotEqual(t1.domain, t4.domain)
+        t5 = Absorbance(reference=data2)(data[:1])
+        self.assertGreater(len(t4), len(t5))
+        self.assertEqual(t4.domain, t5.domain)
 
 
 class TestSavitzkyGolay(unittest.TestCase):

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -399,6 +399,26 @@ class TestNormalize(unittest.TestCase):
         p = Normalize(method=Normalize.SNV, lower=0, upper=2)(data)
         np.testing.assert_equal(p.X, q)
 
+    def test_eq(self):
+        data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
+        p1 = Normalize(method=Normalize.MinMax)(data)
+        p2 = Normalize(method=Normalize.SNV)(data)
+        p3 = Normalize(method=Normalize.MinMax)(data)
+        self.assertNotEqual(p1.domain, p2.domain)
+        self.assertEqual(p1.domain, p3.domain)
+
+        p1 = Normalize(method=Normalize.Area, int_method=Integrate.PeakMax,
+                       lower=0, upper=4)(data)
+        p2 = Normalize(method=Normalize.Area, int_method=Integrate.Baseline,
+                       lower=0, upper=4)(data)
+        p3 = Normalize(method=Normalize.Area, int_method=Integrate.PeakMax,
+                       lower=1, upper=4)(data)
+        p4 = Normalize(method=Normalize.Area, int_method=Integrate.PeakMax,
+                       lower=0, upper=4)(data)
+        self.assertNotEqual(p1.domain, p2.domain)
+        self.assertNotEqual(p1.domain, p3.domain)
+        self.assertEqual(p1.domain, p4.domain)
+
 
 class TestNormalizeReference(unittest.TestCase):
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess_utils.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess_utils.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from Orange.data import Table
+
+from orangecontrib.spectroscopy.preprocess.utils import reference_eq_X
+
+
+class TestEq(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.iris = Table("iris")
+        cls.iris2 = Table("iris")
+        cls.iris_changed = Table("iris")
+        with cls.iris_changed.unlocked():
+            cls.iris_changed[0][0] = 42
+
+    def test_reference_eq_X_none(self):
+        data = self.iris
+        self.assertTrue(reference_eq_X(None, None))
+        self.assertFalse(reference_eq_X(data, None))
+        self.assertFalse(reference_eq_X(None, data))
+
+    def test_reference_eq_X_same(self):
+        self.assertTrue(reference_eq_X(self.iris, self.iris))
+        self.assertTrue(reference_eq_X(self.iris, self.iris2))
+        self.assertFalse(reference_eq_X(self.iris, self.iris_changed))

--- a/setup.py
+++ b/setup.py
@@ -128,15 +128,15 @@ if __name__ == '__main__':
             'setuptools>=36.3',  # same as for Orange 3.28
             'pip>=9.0',  # same as for Orange 3.28
             'numpy>=1.20.0',
-            'Orange3>=3.32.0',
-            'orange-canvas-core>=0.1.24',
-            'orange-widget-base>=4.16.1',
-            'scipy>=1.4.0',
+            'Orange3>=3.34.0',
+            'orange-canvas-core>=0.1.28',
+            'orange-widget-base>=4.19.0',
+            'scipy>=1.9.0',
             'scikit-learn>=1.0.1',
             'spectral>=0.22.3,!=0.23',
             'serverfiles>=0.2',
-            'AnyQt>=0.0.6',
-            'pyqtgraph>=0.11.1,!=0.12.4',  # https://github.com/pyqtgraph/pyqtgraph/issues/2237
+            'AnyQt>=0.1.0',
+            'pyqtgraph>=0.12.2,!=0.12.4',  # https://github.com/pyqtgraph/pyqtgraph/issues/2237
             'colorcet',
             'h5py',
             'extranormal3 >=0.0.3',

--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,13 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: orange3==3.32.0
-    oldest: orange-canvas-core==0.1.24
-    oldest: orange-widget-base==4.16.1
+    oldest: orange3==3.34.0
+    oldest: orange-canvas-core==0.1.28
+    oldest: orange-widget-base==4.19.0
     oldest: scikit-learn~=1.0.1
     oldest: numpy~=1.20.0
-    oldest: pyqtgraph==0.11.1
-    oldest: scipy~=1.4.0
+    oldest: pyqtgraph==0.12.2
+    oldest: scipy~=1.9.0
     oldest: pandas~=1.3.0
     oldest: spectral~=0.22.3
     oldest: lmfit~=1.0.2


### PR DESCRIPTION
Two different Preprocess Spectra widgets with the same parameters for Savitzky-Golay produced transformations, that always gave equivalent results, but because nothing guaranteed that they were different they were regarded as incompatible. Implementing `__eq__` and `__hash__` on transformations educates Orange about equivalence. With Savitzky-Golay it now looks like this (both workflows would trigger a warning before the change):

![dif](https://user-images.githubusercontent.com/552182/200835276-9c0175f1-a284-4b4a-a912-818d35e2d057.png)

This feature builds on biolab/orange3#5985 and company.
