### PR TITLE
Fix OmnicMap's reader getPositionFromIndexAndInfo

### DIFF
--- a/orangecontrib/spectroscopy/utils/pymca5/OmnicMap.py
+++ b/orangecontrib/spectroscopy/utils/pymca5/OmnicMap.py
@@ -309,7 +309,7 @@ class OmnicMap(DataObject.DataObject):
         x1, y1 = ddict['Last map location']
         deltaX = ddict['Mapping stage X step size']
         deltaY = ddict['Mapping stage Y step size']
-        nX = int(1 + ((x1 - x0) / deltaX))
+        nX = int(round(1 + ((x1 - x0) / deltaX)))
         x = x0 + (index % nX) * deltaX
         y = y0 + int(index / nX) * deltaY
         return x, y


### PR DESCRIPTION
@clsandt found a map where:
- deltaX = 49.97058868408203
- x0 = -815.0
- x1 = 884.0

The number of jumps (intervals) in X is ((x1 - x0) / deltaX) which is 33.9999996946446, which means that the number of measurements nX is 33.9999996946446 + 1.

The old code wrongly rounded this down. The new code rounds before converting to int so it is more robust to numeric inaccuracies.

The reading code comes from PyMCA so I also opened a pull request there: vasole/pymca#906