### PR TITLE
Avoid spectral 0.23 due to problems on Windows

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - orange-widget-base >=4.16.1
     - scipy >=1.4.0
     - scikit-learn >0.23.0
-    - spectral >=0.18
+    - spectral >=0.18,!=0.23
     - serverfiles >=0.2
     - AnyQt >=0.0.6
     - pyqtgraph >=0.11.1,!=0.12.4

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -31,6 +31,7 @@ def initialize_reader(reader, fn):
     absolute_filename = FileFormat.locate(fn, Orange.data.table.dataset_dirs)
     return reader(absolute_filename)
 
+
 # pylint: disable=protected-access
 def check_attributes(table):
     """
@@ -78,7 +79,6 @@ class TestDat(unittest.TestCase):
         with named_file("15,500\n30,650\n", suffix=".dpt") as fn:
             d = Orange.data.Table(fn)
             np.testing.assert_equal(d.X, [[500., 650.]])
-
 
 
 try:
@@ -404,6 +404,19 @@ class TestNeaGSF(unittest.TestCase):
         check_attributes(data)
 
 
+class TestEnvi(unittest.TestCase):
+
+    def test_read(self):
+        data = Orange.data.Table("agilent/4_noimage_agg256.hdr")
+        self.assertEqual(len(data), 64)
+        xs = getx(data)
+        np.testing.assert_almost_equal(xs[:3], [1990.178230, 2005.605960, 2021.033700])
+        self.assertAlmostEqual(data[0][2], 1.30845487)
+        self.assertAlmostEqual(data[-1][3], 1.35767233)
+        np.testing.assert_equal(data.metas[:3], [[0, 0], [1, 0], [2, 0]])
+        np.testing.assert_equal(data.metas[-3:], [[5, 7], [6, 7], [7, 7]])
+
+
 class TestSpa(unittest.TestCase):
 
     def test_open(self):
@@ -536,6 +549,7 @@ class TestSelectColumn(unittest.TestCase):
         np.testing.assert_equal(d.X,
                                 [[0.91213142, 0.89539732, 0.87925428, 0.86225812]])
         np.testing.assert_equal(getx(d), [6870, 6880, 6890, 6900])
+
 
 class TestStxmHdrXim(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
             'orange-widget-base>=4.16.1',
             'scipy>=1.4.0',
             'scikit-learn>0.23.0',
-            'spectral>=0.18',
+            'spectral>=0.18,!=0.23',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.11.1,!=0.12.4',  # https://github.com/pyqtgraph/pyqtgraph/issues/2237


### PR DESCRIPTION
 Fixes #628.

Reference issue: #144