### PR TITLE
[FIX] Agilent Tile Reader: Generate correct y-axis positions

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_tile_reader.py
+++ b/orangecontrib/spectroscopy/tests/test_tile_reader.py
@@ -2,6 +2,8 @@ import os.path
 import unittest
 
 import Orange
+import numpy as np
+from Orange.data import Table
 from Orange.data.io import FileFormat
 from Orange.preprocess.preprocess import PreprocessorList
 from Orange.widgets.tests.base import WidgetTest
@@ -31,6 +33,15 @@ class TestTileReaders(unittest.TestCase):
         path = os.path.join(get_sample_datasets_dir(), AGILENT_TILE)
         reader = OWTilefile.get_tile_reader(path)
         reader.read()
+
+    def test_match_not_tiled(self):
+        path = os.path.join(get_sample_datasets_dir(), AGILENT_TILE)
+        reader = OWTilefile.get_tile_reader(path)
+        t = reader.read()
+        t_orig = Table(path)
+        np.testing.assert_array_equal(t.X, t_orig.X)
+        np.testing.assert_array_equal(t[:, ["map_x", "map_y"]].metas,
+                                      t_orig[:, ["map_x", "map_y"]].metas)
 
 
 class TestTilePreprocessors(unittest.TestCase):


### PR DESCRIPTION
I found that the `agilentMosaicTileReader` had an error in the way it calculated the y-axis positions. Although the agilent data xy positions are arbitrary from (0,0), it means the TileReader and the normal reader generate _different_ positions.

I'm asking for input because this has implications for backwards compatibility. In the case where someone uses the **OWTileFile** widget and then selects regions in **OWHyper**, the selection will be incorrect when that workflow is loaded with this code.

Thoughts?

Edit: This now fixes both the coordinates and the table row ordering so that the two readers result in identical output.