### PR TITLE
github actions: run tests monthly and on-demand

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 1 * *'
 
 jobs:
   build:


### PR DESCRIPTION
The "oldest" tests in #632 aren't passing, but there's no way currently to check if the master branch CI tests pass. In travis we could trigger a run (and run on a schedule) so that's what this change does.

My cron-fu is not strong but I think it's set to run on the 1st of each month.