### PR TITLE
[WIP][FIX] irfft: ramp correction and apodization fix for asymmetric interferograms

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_irfft.py
+++ b/orangecontrib/spectroscopy/tests/test_irfft.py
@@ -111,8 +111,8 @@ class TestIRFFT(unittest.TestCase):
         # Calculate absorbance from ssc and rsc
         ab = np.log10(rsc / ssc)
         # Compare to agilent absorbance
-        # NB 4 mAbs error
-        np.testing.assert_allclose(ab[limits[0]:limits[1]], dat, atol=0.004)
+        # NB 0.4 mAbs max error
+        np.testing.assert_allclose(ab[limits[0]:limits[1]], dat, rtol=2.5e-04)
 
     def test_multi(self):
         dx_ag = (1 / 1.57980039e+04 / 2) * 4
@@ -148,8 +148,8 @@ class TestIRFFT(unittest.TestCase):
         # Calculate absorbance from ssc and rsc
         ab = np.log10(rsc / ssc)
         # Compare to agilent absorbance
-        # NB 4 mAbs error
-        np.testing.assert_allclose(ab[:, limits[0]:limits[1]], dat, atol=0.004)
+        # NB 0.4 mAbs max error
+        np.testing.assert_allclose(ab[:, limits[0]:limits[1]], dat, rtol=2.5e-04)
 
     def test_apodization(self):
         for apod_func in ApodFunc:


### PR DESCRIPTION
Fixes an old error in the apodization function generation for asymmetric interferograms, found while adding a ramp correction to avoid double-counting in the symmetric section. Illustration of the issue:

![new-apod-ramp](https://user-images.githubusercontent.com/19228847/199354875-ab42fdd2-52d7-4616-b125-c056a3b732db.png)

The above figure illustrates how the original apodization code was handling the taper to zero needed in asymmetric interferograms. While it does bring the amplitude to zero at the edge of the short side, it obviously badly violates the symmetry requirements. This would not have been obvious on the original symmetric test interferograms.