### PR TITLE
[FIX] Ascii column reader: allow comments starting with ";"

### DIFF
--- a/orangecontrib/spectroscopy/datasets/peach_juice.dpt
+++ b/orangecontrib/spectroscopy/datasets/peach_juice.dpt
@@ -1814,3 +1814,5 @@
 503.38973	0.75835
 501.46104	0.75783
 499.53234	0.75763
+# a comment
+; a different kind of comment (from Kazan viewer)

--- a/orangecontrib/spectroscopy/io/ascii.py
+++ b/orangecontrib/spectroscopy/io/ascii.py
@@ -20,7 +20,8 @@ class AsciiColReader(FileFormat, SpectralFileFormat):
         delimiters = [None, ";", ":", ","]
         for d in delimiters:
             try:
-                tbl = np.loadtxt(self.filename, ndmin=2, delimiter=d)
+                comments = [a for a in [";", "#"] if a != d]
+                tbl = np.loadtxt(self.filename, ndmin=2, delimiter=d, comments=comments)
                 break
             except ValueError:
                 pass


### PR DESCRIPTION
Such comments are contained in the files exported by the Kazan viewer.

This change does not break previous kind of comments (starting with "#")