### PR TITLE
On -latest tests, do not crash in case of OrangeDeprecationWarnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Test with Tox
         run: |
           tox -e ${{ matrix.tox_env }}
+        env:
+          # Raise deprecations as errors in our tests only when testing orange-oldest and orange-released.
+          ORANGE_DEPRECATIONS_ERROR: "${{ matrix.tox_env != 'py-orange-latest' && '1' || '' }}"
+          # Need this otherwise unittest installs a warning filter that overrides
+          # our desire to have OrangeDeprecationWarnings raised
+          PYTHONWARNINGS: module
 
       - name: Upload code coverage
         if: |

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,6 @@ passenv = *
 changedir =
     {envsitepackagesdir}
 setenv =
-    # Raise deprecations as errors in our tests
-    ORANGE_DEPRECATIONS_ERROR=y
-    # Need this otherwise unittest installs a warning filter that overrides
-    # our desire to have OrangeDeprecationWarnings raised
-    PYTHONWARNINGS=module
     # set coverage output and project config
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc


### PR DESCRIPTION
As described in #378, OrangeDeprecationWarnings that came into Qt's event loop caused segfaults (Qt does not like exceptions).

This PR disables crashes on OrangeDeprecationWarnings for unreleased Orange versions.