### PR TITLE
Replace deprecated get_column_view

### DIFF
--- a/orangecontrib/spectroscopy/__init__.py
+++ b/orangecontrib/spectroscopy/__init__.py
@@ -2,6 +2,17 @@ import Orange.data
 import os.path
 
 
+# Remove this when we require Orange 3.34
+if not hasattr(Orange.data.Table, "get_column"):
+    print("WORKAROUND")
+    def get_column(self, column):
+        col, _ = self.get_column_view(column)
+        if self.domain[column].is_primitive():
+            col = col.astype(float)
+        return col
+
+    Orange.data.Table.get_column = get_column
+
 from . import io  # register file formats
 
 

--- a/orangecontrib/spectroscopy/__init__.py
+++ b/orangecontrib/spectroscopy/__init__.py
@@ -2,15 +2,6 @@ import Orange.data
 import os.path
 
 
-# a no-op workaround so that table unlocking does not crash with older Orange
-# remove when the minimum supported version is 3.31
-from Orange.data import Table
-from contextlib import nullcontext
-if not hasattr(Table, "unlocked"):
-    Table.unlocked = nullcontext
-    Table.unlocked_reference = nullcontext
-
-
 from . import io  # register file formats
 
 

--- a/orangecontrib/spectroscopy/widgets/owaverage.py
+++ b/orangecontrib/spectroscopy/widgets/owaverage.py
@@ -90,22 +90,14 @@ class OWAverage(OWWidget):
         with avg_table.unlocked():
             for var in cont_vars:
                 index = table.domain.index(var)
-                col, _ = table.get_column_view(index)
-                try:
-                    avg_table[0, index] = np.nanmean(col)
-                except AttributeError:
-                    # numpy.lib.nanfunctions._replace_nan just guesses and returns
-                    # a boolean array mask for object arrays because object arrays
-                    # do not support `isnan` (numpy-gh-9009)
-                    # Since we know that ContinuousVariable values must be np.float64
-                    # do an explicit cast here
-                    avg_table[0, index] = np.nanmean(col, dtype=np.float64)
+                col = table.get_column(index)
+                avg_table[0, index] = np.nanmean(col)
 
             other_vars = [var for var in table.domain.class_vars + table.domain.metas
                           if not isinstance(var, Orange.data.ContinuousVariable)]
             for var in other_vars:
                 index = table.domain.index(var)
-                col, _ = table.get_column_view(index)
+                col = table.get_column(index)
                 val = var.to_val(avg_table[0, var])
                 if not np.all(col == val):
                     avg_table[0, var] = Orange.data.Unknown

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -594,7 +594,7 @@ class OWFFT(OWWidget):
             return
 
         try:
-            lwn, _ = self.data.get_column_view("Effective Laser Wavenumber")
+            lwn = self.data.get_column("Effective Laser Wavenumber")
         except ValueError:
             if not self.dx_HeNe_cb.isEnabled():
                 # Only reset if disabled by this code, otherwise leave alone
@@ -610,7 +610,7 @@ class OWFFT(OWWidget):
             self.dx_HeNe_cb.setDisabled(True)
             self.dx_edit.setDisabled(True)
         try:
-            udr, _ = self.data.get_column_view("Under Sampling Ratio")
+            udr = self.data.get_column("Under Sampling Ratio")
         except ValueError:
             udr = 1
         else:

--- a/orangecontrib/spectroscopy/widgets/owsnr.py
+++ b/orangecontrib/spectroscopy/widgets/owsnr.py
@@ -114,7 +114,7 @@ class OWSNR(OWWidget):
         with new_table.unlocked():
             for var in cont_vars:
                 index = data_table.domain.index(var)
-                col, _ = data_table.get_column_view(index)
+                col = data_table.get_column(index)
                 val = var.to_val(new_table[0, var])
                 if not np.all(col == val):
                     new_table[0, var] = Orange.data.Unknown


### PR DESCRIPTION
The replacement, `get_column`, also takes care of the conversion into the correct data type.