### PR TITLE
[FIX] HyperSpectra now works with integrals with separate baselines

### DIFF
--- a/orangecontrib/spectroscopy/__init__.py
+++ b/orangecontrib/spectroscopy/__init__.py
@@ -4,7 +4,6 @@ import os.path
 
 # Remove this when we require Orange 3.34
 if not hasattr(Orange.data.Table, "get_column"):
-    print("WORKAROUND")
     def get_column(self, column):
         col, _ = self.get_column_view(column)
         if self.domain[column].is_primitive():

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -14,7 +14,7 @@ from Orange.data import DiscreteVariable, Domain, Table
 from Orange.widgets.tests.base import WidgetTest
 
 from orangecontrib.spectroscopy.data import _spectra_from_image, build_spec_table
-from orangecontrib.spectroscopy.preprocess.integrate import IntegrateFeaturePeakSimple
+from orangecontrib.spectroscopy.preprocess.integrate import IntegrateFeaturePeakSimple, Integrate
 from orangecontrib.spectroscopy.widgets import owhyper
 from orangecontrib.spectroscopy.widgets.owhyper import \
     OWHyper
@@ -134,6 +134,24 @@ class TestOWHyper(WidgetTest):
         self.assertEqual(self.widget.rgb_red_value, attr1)
         self.assertEqual(self.widget.rgb_green_value, attr1)
         self.assertEqual(self.widget.rgb_blue_value, attr1)
+
+    def test_integral_lines(self):
+        w = self.widget
+        self.send_signal(OWHyper.Inputs.data, self.iris)
+        icombo = w.controls.integration_method
+        for i in range(icombo.count()):
+            icombo.setCurrentIndex(i)
+            icombo.activated.emit(i)
+            wait_for_image(w)
+            imethod = w.integration_methods[w.integration_method]
+            if imethod == Integrate.PeakAt:
+                correct = [False, False, True, False, False]
+            elif imethod == Integrate.Separate:
+                correct = [True, True, False, True, True]
+            else:
+                correct = [True, True, False, False, False]
+            visible = [a.isVisible() for a in [w.line1, w.line2, w.line3, w.line4, w.line5]]
+            self.assertEqual(visible, correct)
 
     def try_big_selection(self):
         self.widget.imageplot.select_square(QPointF(-100, -100), QPointF(100, 100))

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -970,7 +970,7 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
     curveplot = SettingProvider(CurvePlotHyper)
 
     integration_method = Setting(0)
-    integration_methods = Integrate.INTEGRALS
+    integration_methods = Integrate.INTEGRALS[:-1]  # without SeparateBaseline
     value_type = Setting(0)
     attr_value = ContextSetting(None)
     rgb_red_value = ContextSetting(None)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1101,9 +1101,11 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         self.line2.sigMoved.connect(lambda v: setattr(self, "highlim", v))
         self.line3 = MovableVline(position=self.choose, label="", report=self.curveplot)
         self.line3.sigMoved.connect(lambda v: setattr(self, "choose", v))
-        self.line4 = MovableVline(position=self.choose, label="baseline", report=self.curveplot)
+        self.line4 = MovableVline(position=self.choose, label="baseline", report=self.curveplot,
+                                  color=(255, 140, 26))
         self.line4.sigMoved.connect(lambda v: setattr(self, "lowlimb", v))
-        self.line5 = MovableVline(position=self.choose, label="baseline", report=self.curveplot)
+        self.line5 = MovableVline(position=self.choose, label="baseline", report=self.curveplot,
+                                  color=(255, 140, 26))
         self.line5.sigMoved.connect(lambda v: setattr(self, "highlimb", v))
         for line in [self.line1, self.line2, self.line3, self.line4, self.line5]:
             line.sigMoveFinished.connect(self.changed_integral_range)

--- a/orangecontrib/spectroscopy/widgets/owintegrate.py
+++ b/orangecontrib/spectroscopy/widgets/owintegrate.py
@@ -59,7 +59,11 @@ class IntegrateOneEditor(BaseEditorOrange):
             self.__editors[name] = e
             layout.addRow(name, e)
 
-            l = MovableVline(position=v, label=name)
+            color = (225, 0, 0)
+            if "baseline" in name:
+                color = (255, 140, 26)
+
+            l = MovableVline(position=v, label=name, color=color)
             def set_rounded(_, line=l, name=name):
                 cf(float(line.rounded_value()), name)
             l.sigMoved.connect(set_rounded)


### PR DESCRIPTION
Thanks to @clsandt for pointing out the bug. At first I just wanted to disable this functionality, but then I decided to actually support it.