### PR TITLE
[FIX] OWTileFile warn on preprocessor change

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owtilefile.py
+++ b/orangecontrib/spectroscopy/widgets/owtilefile.py
@@ -82,6 +82,8 @@ class OWTilefile(widget.OWWidget, RecentPathsWComboMixin):
     class Warning(widget.OWWidget.Warning):
         no_preprocessor = Msg("No preprocessor on input."
                               " Press Reload to load anyway.")
+        new_preprocessor = Msg("Preprocessor has changed."
+                               " Press Reload to apply.")
         file_too_big = widget.Msg("The file is too large to load automatically."
                                   " Press Reload to load.")
         load_warning = widget.Msg("Read warning:\n{}")
@@ -490,12 +492,14 @@ class OWTilefile(widget.OWWidget, RecentPathsWComboMixin):
 
     def warn_preprocessor(self):
         self.Warning.no_preprocessor.clear()
+        self.Warning.new_preprocessor.clear()
         if not any(self._is_preproc(p) for p in self.preprocessor.preprocessors):
             self.info_preproc.setText("No preprocessor on input.")
             self.Warning.no_preprocessor()
             return True
         self.info_preproc.setText("New preprocessor, reload file to use.\n" +
                                   self._format_preproc_str(self.preprocessor))
+        self.Warning.new_preprocessor()
         return False
 
     @Inputs.preprocessor.insert


### PR DESCRIPTION
Following #638 

[Edit: Left None bug for another day, see #648]

I found a bug where the code that runs the preprocessor() wasn't checking for `PreprocessorList`s with None in them (or empty lists), so `PreprocessorList` tries to call None(). But I kept thinking of more weird edge cases from the multiple inputs, so I decided instead to just not add None in the first place (which is cleaner, I think).

But now when you have a `None` connected (empty Preprocess Spectra), and then change it to a preprocessor (Add an editor to the Preprocess Spectra), it crashes because the index state from the `MultiInput` doesn't match the PreprocessorList length.

@markotoplak  Before I go any further down this rabbit hole, any thoughts?