### PR TITLE
[FIX] ASCII reader: fix ; as delimeters

### DIFF
--- a/orangecontrib/spectroscopy/io/ascii.py
+++ b/orangecontrib/spectroscopy/io/ascii.py
@@ -17,7 +17,7 @@ class AsciiColReader(FileFormat, SpectralFileFormat):
 
     def read_spectra(self):
         tbl = None
-        delimiters = [None, ";", ":", ","]
+        delimiters = [";", None, ":", ","]
         for d in delimiters:
             try:
                 comments = [a for a in [";", "#"] if a != d]

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -75,6 +75,16 @@ class TestDat(unittest.TestCase):
             d2 = Orange.data.Table(fn)
             np.testing.assert_equal(d1.X, d2.X)
 
+    def test_semicolon_comments(self):
+        with named_file("15 500;comment1\n30 650; comment2\n", suffix=".dpt") as fn:
+            d = Orange.data.Table(fn)
+            np.testing.assert_equal(d.X, [[500., 650.]])
+
+    def test_semicolon_delimiter(self):
+        with named_file("15;500\n30;650\n", suffix=".dpt") as fn:
+            d = Orange.data.Table(fn)
+            np.testing.assert_equal(d.X, [[500., 650.]])
+
     def test_comma_delim(self):
         with named_file("15,500\n30,650\n", suffix=".dpt") as fn:
             d = Orange.data.Table(fn)


### PR DESCRIPTION
Comment support in the ASCII reader broke the ";" as delimiter because then everything but the wavenumber becomes a comment which makes files valid and useless at the same time. Fixed by changing the delimiter order: now ";" is attempted before whitespace.