### PR TITLE
[FIX] owinterpolated: Call commit.deferred in line edit callbacks

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owinterpolate.py
+++ b/orangecontrib/spectroscopy/widgets/owinterpolate.py
@@ -71,11 +71,11 @@ class OWInterpolate(OWWidget):
         form.setLayout(formlayout)
         ibox.layout().addWidget(form)
 
-        self.xmin_edit = lineEditFloatOrNone(ibox, self, "xmin", callback=self.commit)
+        self.xmin_edit = lineEditFloatOrNone(ibox, self, "xmin", callback=self.commit.deferred)
         formlayout.addRow("Min", self.xmin_edit)
-        self.xmax_edit = lineEditFloatOrNone(ibox, self, "xmax", callback=self.commit)
+        self.xmax_edit = lineEditFloatOrNone(ibox, self, "xmax", callback=self.commit.deferred)
         formlayout.addRow("Max", self.xmax_edit)
-        self.dx_edit = lineEditFloatOrNone(ibox, self, "dx", callback=self.commit)
+        self.dx_edit = lineEditFloatOrNone(ibox, self, "dx", callback=self.commit.deferred)
         formlayout.addRow("Δ", self.dx_edit)
 
         gui.appendRadioButton(rbox, "Reference data")


### PR DESCRIPTION
I guess I don't use these boxes that often :)

I also noticed searching around for any other instances of this that OWAverage is still using the old commit style. I didn't touch it in this PR.