### PR TITLE
Spectral python version number bump in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
             'orange-widget-base>=4.16.1',
             'scipy>=1.4.0',
             'scikit-learn>=1.0.1',
-            'spectral>=0.18,!=0.23',
+            'spectral>=0.22.3,!=0.23',
             'serverfiles>=0.2',
             'AnyQt>=0.0.6',
             'pyqtgraph>=0.11.1,!=0.12.4',  # https://github.com/pyqtgraph/pyqtgraph/issues/2237


### PR DESCRIPTION
Using spectral v0.22.1 I got deprecation warnings from numpy and Orange didn't add the spectroscopy package. I see that @markotoplak restricted v!=0.23 due to some bug on Windows but maybe that was fixed in the newest version, v0.23.1. For now I leave that condition but changed >=0.18 to >=0.22.3. This seems to solve the numpy deprecation issue.