### PR TITLE
[ENH] Improved the context menu display on Mac

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -677,7 +677,7 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
 
         choose_xy = QWidgetAction(self)
         box = gui.vBox(self)
-        box.setContentsMargins(20, 0, 10, 0)
+        box.setContentsMargins(10, 0, 10, 0)
         box.setFocusPolicy(Qt.TabFocus)
         self.xy_model = DomainModel(DomainModel.METAS | DomainModel.CLASSES,
                                     valid_types=DomainModel.PRIMITIVE)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -283,6 +283,7 @@ class ImageColorSettingMixin:
 
     def setup_color_settings_box(self):
         box = gui.vBox(self)
+        box.setContentsMargins(0, 0, 0, 5)
         self.color_cb = gui.comboBox(box, self, "palette_index", label="Color:",
                                      labelWidth=50, orientation=Qt.Horizontal)
         self.color_cb.setIconSize(QSize(64, 16))
@@ -295,7 +296,6 @@ class ImageColorSettingMixin:
 
         gui.checkBox(box, self, "show_legend", label="Show legend",
                      callback=self.update_legend_visible)
-
         form = QFormLayout(
             formAlignment=Qt.AlignLeft,
             labelAlignment=Qt.AlignLeft,
@@ -669,12 +669,15 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
 
         view_menu.addActions(actions)
         self.addActions(actions)
+        for a in actions:
+            a.setShortcutVisibleInContextMenu(True)
 
         common_options = dict(
             labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True)
 
         choose_xy = QWidgetAction(self)
         box = gui.vBox(self)
+        box.setContentsMargins(20, 0, 10, 0)
         box.setFocusPolicy(Qt.TabFocus)
         self.xy_model = DomainModel(DomainModel.METAS | DomainModel.CLASSES,
                                     valid_types=DomainModel.PRIMITIVE)

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -881,12 +881,15 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
         view_menu.addActions(actions)
         view_menu.addMenu(range_menu)
         self.addActions(actions)
+        for a in actions:
+            a.setShortcutVisibleInContextMenu(True)
 
         self.color_individual_menu = QAction(
             "Color individual curves", self, shortcut=Qt.Key_I, checkable=True,
             triggered=lambda x: self.color_individual_changed()
         )
         self.color_individual_menu.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+        self.color_individual_menu.setShortcutVisibleInContextMenu(True)
         view_menu.addAction(self.color_individual_menu)
         self.addAction(self.color_individual_menu)
 
@@ -908,7 +911,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
         labels_action = QWidgetAction(self)
         layout = QGridLayout()
-        labels_box = gui.widgetBox(self, margin=0, orientation=layout)
+        labels_box = gui.widgetBox(self, margin=5, orientation=layout)
         t = gui.lineEdit(None, self, "label_title", label="Title:",
                          callback=self.labels_changed, callbackOnType=self.labels_changed)
         layout.addWidget(QLabel("Title:"), 0, 0, Qt.AlignRight)


### PR DESCRIPTION
Previously, the context menu of OWSpectra didn't display keyboard shortcuts on Mac (Ventura) and the window edges were very close to the elements. 

![image](https://user-images.githubusercontent.com/6304794/231188046-473e42f6-1b44-4448-bc0e-51a2f139cfd6.png)

Now this is changed to the following:

![image](https://user-images.githubusercontent.com/6304794/231188196-94234df0-95d9-4f43-a1ad-a05d74870b11.png)

Needs testing on Linux and Windows.