### PR TITLE
[FIX] Fix opening GSF files in Multifile

### DIFF
--- a/orangecontrib/spectroscopy/io/gsf.py
+++ b/orangecontrib/spectroscopy/io/gsf.py
@@ -51,5 +51,5 @@ class GSFReader(FileFormat, SpectralFileFormat):
 
     def read_spectra(self):
         X, XRr, YRr = reader_gsf(self.filename)
-        data = _spectra_from_image(X, [1], XRr, YRr)
+        data = _spectra_from_image(X, np.array([1]), XRr, YRr)
         return data

--- a/orangecontrib/spectroscopy/io/util.py
+++ b/orangecontrib/spectroscopy/io/util.py
@@ -52,7 +52,7 @@ def _spectra_from_image(X, features, x_locs, y_locs):
     x_loc = np.tile(np.arange(X.shape[1]), X.shape[0])
     meta_table = _metatable_maplocs(x_locs[x_loc], y_locs[y_loc])
 
-    return features, spectra, meta_table
+    return np.asarray(features), spectra, meta_table
 
 
 def _spectra_from_image_2d(X, wn, x_locs, y_locs):


### PR DESCRIPTION
The problem was actually a misbehaving reader that did not return the correct types.

The problem:
```
Traceback (most recent call last):
  File "/home/marko/dev/orange-spectroscopy/orangecontrib/spectroscopy/widgets/owmultifile.py", line 415, in browse_files
    self.load_files(filenames, reader)
  File "/home/marko/dev/orange-spectroscopy/orangecontrib/spectroscopy/widgets/owmultifile.py", line 426, in load_files
    self.load_data()
  File "/home/marko/dev/orange-spectroscopy/orangecontrib/spectroscopy/widgets/owmultifile.py", line 487, in load_data
    data = concatenate_data(data_list, fnok_list, self.label)
  File "/home/marko/dev/orange-spectroscopy/orangecontrib/spectroscopy/widgets/owmultifile.py", line 98, in concatenate_data
    xs = reduce(numpy_union_keep_order, xss, np.array([]))
  File "/home/marko/dev/orange-spectroscopy/orangecontrib/spectroscopy/widgets/owmultifile.py", line 40, in numpy_union_keep_order
    to_add = B[sorted(orig_sind[indices])]
TypeError: list indices must be integers or slices, not list
```