### PR TITLE
HyperSpectra: handle degenerate (all nan) coordinates and data

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -116,8 +116,16 @@ class TestOWHyper(WidgetTest):
         irisunknown = Interpolate(np.arange(20))(cls.iris)
         # dataset without any attributes, but XY
         whitelight0 = cls.whitelight.transform(
-            Orange.data.Domain([], None, metas=cls.whitelight.domain.metas))
-        cls.strange_data = [None, cls.iris1, iris0, empty, irisunknown, whitelight0]
+            Orange.data.Domain([], None, metas=cls.whitelight.domain.metas))[:100]
+        unknowns = cls.iris.copy()
+        with unknowns.unlocked():
+            unknowns.X[:, :] = float("nan")
+        single_pixel = cls.iris[:50]  # all image coordinates map to one spot
+        unknown_pixel = single_pixel.copy()
+        with unknown_pixel.unlocked():
+            unknown_pixel.Y[:] = float("nan")
+        cls.strange_data = [None, cls.iris1, iris0, empty, irisunknown, whitelight0,
+                            unknowns, single_pixel, unknown_pixel]
 
     def setUp(self):
         self.widget = self.create_widget(OWHyper)  # type: OWHyper
@@ -159,7 +167,9 @@ class TestOWHyper(WidgetTest):
 
     def test_strange(self):
         for data in self.strange_data:
+            self.widget = self.create_widget(OWHyper)
             self.send_signal("Data", data)
+            wait_for_image(self.widget)
             self.try_big_selection()
 
     def test_context_not_open_invalid(self):

--- a/orangecontrib/spectroscopy/utils/__init__.py
+++ b/orangecontrib/spectroscopy/utils/__init__.py
@@ -43,11 +43,14 @@ def values_to_linspace(vals):
 
 def location_values(vals, linspace):
     vals = np.asarray(vals)
-    if linspace[2] == 1:  # everything is the same value
+    if linspace is None or linspace[2] == 1:  # everything is the same value
         width = 1
     else:
         width = (linspace[1] - linspace[0]) / (linspace[2] - 1)
-    return (vals - linspace[0]) / width
+    start = 0
+    if linspace is not None:
+        start = linspace[0]
+    return (vals - start) / width
 
 
 def index_values(vals, linspace):


### PR DESCRIPTION
Fixes #686

Handle (and also test) degenerate inputs.

#686 described errors that happened for the SNR widget because the widget is not meant to be used on normal data (without data point repetitions). HyperSpectra now does not crash but in the (before crashing) cases does not do anything useful either.