### PR TITLE
Show an exception if preprocessors can not be loaded

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -1,5 +1,6 @@
 import numpy as np
-from scipy.signal import savgol_filter, tukey
+from scipy.signal import savgol_filter
+from scipy.signal.windows import tukey
 from scipy.interpolate import interp1d
 
 import Orange

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -4,6 +4,8 @@ import Orange
 from Orange.widgets.tests.base import WidgetTest
 from Orange.preprocess.preprocess import Preprocess
 
+from orangewidget.tests.utils import excepthook_catch
+
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.tests import spectral_preprocess
 from orangecontrib.spectroscopy.tests.spectral_preprocess import pack_editor, wait_for_preview
@@ -15,7 +17,6 @@ from orangecontrib.spectroscopy.widgets.preprocessors.registry import preprocess
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange, \
     REFERENCE_DATA_PARAM
 from orangecontrib.spectroscopy.tests.util import smaller_data
-
 
 PREPROCESSORS = list(map(pack_editor, preprocess_editors.sorted()))
 
@@ -167,6 +168,14 @@ class TestOWPreprocess(WidgetTest):
         d = self.get_output(self.widget.Outputs.preprocessed_data)
         manual = p(data)
         np.testing.assert_equal(d.X, manual.X)
+
+    def test_invalid_preprocessors(self):
+        settings = {"storedsettings":
+                        {"preprocessors": [("xyz.abc.notme", {})]}}
+        with self.assertRaises(KeyError):
+            with excepthook_catch(raise_on_exit=True):
+                widget = self.create_widget(OWPreprocess, settings)
+                self.assertTrue(widget.Error.loading.is_shown())
 
     def test_migrate_rubberband(self):
         settings = {"storedsettings":

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -863,7 +863,7 @@ class OWPreprocess(SpectralPreprocessReference):
     replaces = ["orangecontrib.infrared.widgets.owpreproc.OWPreprocess",
                 "orangecontrib.infrared.widgets.owpreprocess.OWPreprocess"]
 
-    settings_version = 8
+    settings_version = 9
 
     BUTTON_ADD_LABEL = "Add preprocessor..."
     editor_registry = preprocess_editors


### PR DESCRIPTION
Before, the exception was silently ignored, which prevented us from notifying users of incompatible workflows.