### PR TITLE
[FIX] Avoid some context crashes: exclude_attributes=True

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -386,12 +386,14 @@ class TestOWHyper(WidgetTest):
         self.assertTrue(self.widget.Information.not_shown.is_shown())
 
     def test_migrate_context_feature_color(self):
-        c = self.widget.settingsHandler.new_context(self.iris.domain,
-                                                    None, self.iris.domain.class_vars)
+        # avoid class_vars in tests, because the setting does not allow them
+        iris = self.iris.transform(
+            Domain(self.iris.domain.attributes, None, self.iris.domain.class_vars))
+        c = self.widget.settingsHandler.new_context(iris.domain, None, iris.domain.metas)
         c.values["curveplot"] = {"feature_color": ("iris", 1)}
         self.widget = self.create_widget(OWHyper,
                                          stored_settings={"context_settings": [c]})
-        self.send_signal("Data", self.iris)
+        self.send_signal("Data", iris)
         self.assertIsInstance(self.widget.curveplot.feature_color, DiscreteVariable)
 
     def test_image_computation(self):

--- a/orangecontrib/spectroscopy/tests/test_owspectra.py
+++ b/orangecontrib/spectroscopy/tests/test_owspectra.py
@@ -569,12 +569,14 @@ class TestOWSpectra(WidgetTest):
         self.assertTrue(vb.targetRect().bottom() > 800)
 
     def test_migrate_context_feature_color(self):
-        c = self.widget.settingsHandler.new_context(self.iris.domain,
-                                                    None, self.iris.domain.class_vars)
+        # avoid class_vars in tests, because the setting does not allow them
+        iris = self.iris.transform(
+            Domain(self.iris.domain.attributes, None, self.iris.domain.class_vars))
+        c = self.widget.settingsHandler.new_context(iris.domain, None, iris.domain.metas)
         c.values["curveplot"] = {"feature_color": ("iris", 1)}
         self.widget = self.create_widget(OWSpectra,
                                          stored_settings={"context_settings": [c]})
-        self.send_signal("Data", self.iris)
+        self.send_signal("Data", iris)
         self.assertIsInstance(self.widget.curveplot.feature_color, DiscreteVariable)
 
     def test_compat_no_group(self):

--- a/orangecontrib/spectroscopy/widgets/owbin.py
+++ b/orangecontrib/spectroscopy/widgets/owbin.py
@@ -46,7 +46,7 @@ class OWBin(OWWidget):
 
     settingsHandler = DomainContextHandler()
 
-    attrs = ContextSetting([None, None])
+    attrs = ContextSetting([None, None], exclude_attributes=True)
     bin_shape = settings.Setting((1, 1))
     square_bin = settings.Setting(True)
 

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -623,8 +623,8 @@ class ImagePlot(QWidget, OWComponent, SelectionGroupMixin,
                 ImageColorSettingMixin, ImageRGBSettingMixin,
                 ImageZoomMixin, ConcurrentMixin):
 
-    attr_x = ContextSetting(None)
-    attr_y = ContextSetting(None)
+    attr_x = ContextSetting(None, exclude_attributes=True)
+    attr_y = ContextSetting(None, exclude_attributes=True)
     gamma = Setting(0)
 
     selection_changed = Signal()

--- a/orangecontrib/spectroscopy/widgets/owsnr.py
+++ b/orangecontrib/spectroscopy/widgets/owsnr.py
@@ -31,8 +31,10 @@ class OWSNR(OWWidget):
                    'Standard Deviation': 2} # std
 
     settingsHandler = settings.DomainContextHandler()
-    group_x = settings.ContextSetting(None)
-    group_y = settings.ContextSetting(None)
+    group_x = settings.ContextSetting(None, exclude_attributes=True,
+                                      exclude_class_vars=True)
+    group_y = settings.ContextSetting(None, exclude_attributes=True,
+                                      exclude_class_vars=True)
     out_choiced = settings.Setting(0)
 
     autocommit = settings.Setting(True)

--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -892,7 +892,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
     sample_seed = Setting(0, schema_only=True)
     peak_labels_saved = Setting([], schema_only=True)
-    feature_color = ContextSetting(None)
+    feature_color = ContextSetting(None, exclude_attributes=True)
     color_individual = Setting(False)  # color individual curves (in a cycle) if no feature_color
     invertX = Setting(False)
     viewtype = Setting(INDIVIDUAL)

--- a/orangecontrib/spectroscopy/widgets/owspectralseries.py
+++ b/orangecontrib/spectroscopy/widgets/owspectralseries.py
@@ -33,7 +33,7 @@ from orangecontrib.spectroscopy.widgets.utils import \
 class LineScanPlot(QWidget, OWComponent, SelectionGroupMixin,
                    ImageColorSettingMixin, ImageZoomMixin):
 
-    attr_x = ContextSetting(None)
+    attr_x = ContextSetting(None, exclude_attributes=True)
     gamma = Setting(0)
 
     selection_changed = Signal()

--- a/orangecontrib/spectroscopy/widgets/owstackalign.py
+++ b/orangecontrib/spectroscopy/widgets/owstackalign.py
@@ -141,8 +141,8 @@ class OWStackAlign(OWWidget):
     settingsHandler = DomainContextHandler()
 
     sobel_filter = settings.Setting(False)
-    attr_x = ContextSetting(None)
-    attr_y = ContextSetting(None)
+    attr_x = ContextSetting(None, exclude_attributes=True)
+    attr_y = ContextSetting(None, exclude_attributes=True)
     ref_frame_num = settings.Setting(0)
 
     def __init__(self):


### PR DESCRIPTION
Some contexts match even though feature-selection combo boxes do not show the feature. Problematic settings are those where combo boxes are limited to specific parts of the table (attributes, class_vars, or metas).

This partial solution follows from https://github.com/biolab/orange3/issues/6721#issuecomment-1923826563. This does not solve the problem completely, but if problem appears, adding a new widget instance allows the user to continue.

Also, there is another minor issue: exclude_attributes won't allow users to reuse contexts where class vars were used in the fields (current implementation handles attributes and class vars in the same way), but saving and loading works properly (because of perfect matches).