### PR TITLE
[FIX] Explicitely define utf8 encoding on open() for text files

### DIFF
--- a/orangecontrib/spectroscopy/io/maxiv.py
+++ b/orangecontrib/spectroscopy/io/maxiv.py
@@ -85,7 +85,7 @@ class HDRReader_STXM(FileFormat, SpectralFileFormat):
             assert self._lex.get_token() == ';'
 
     def read_spectra(self):
-        with open(self.filename, 'r') as f:
+        with open(self.filename, 'rt', encoding="utf8") as f:
             # Parse file contents into dictionaries/lists
             self._lex = shlex.shlex(instream=f)
             try:

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -16,7 +16,7 @@ class NeaReader(FileFormat, SpectralFileFormat):
 
     def read_v1(self):
 
-        with open(self.filename, "rt") as f:
+        with open(self.filename, "rt", encoding="utf8") as f:
             next(f)  # skip header
             l = next(f)
             l = l.strip()
@@ -120,7 +120,7 @@ class NeaReader(FileFormat, SpectralFileFormat):
 
         # Find line in which data begins
         count = 0
-        with open(self.filename, "r") as f:
+        with open(self.filename, "rt", encoding="utf8") as f:
             while f:
                 line = f.readline()
                 count = count + 1
@@ -185,7 +185,7 @@ class NeaReader(FileFormat, SpectralFileFormat):
 
     def read_spectra(self):
         version = 1
-        with open(self.filename, "rt") as f:
+        with open(self.filename, "rt", encoding="utf8") as f:
             if f.read(2) == '# ':
                 version = 2
         if version == 1:

--- a/orangecontrib/spectroscopy/io/soleil.py
+++ b/orangecontrib/spectroscopy/io/soleil.py
@@ -14,7 +14,7 @@ class SelectColumnReader(FileFormat, SpectralFileFormat):
     @property
     def sheets(self):
 
-        with open(self.filename, 'r') as dataf:
+        with open(self.filename, 'rt', encoding="utf8") as dataf:
             l = ""
             for l in dataf:
                 if not l.startswith('#'):

--- a/orangecontrib/spectroscopy/utils/spc/spc.py
+++ b/orangecontrib/spectroscopy/utils/spc/spc.py
@@ -619,7 +619,7 @@ class File:
         >>> f.writefile('/Users/home/output.txt', delimiter=',')
 
         """
-        with open(path, 'w') as f:
+        with open(path, 'wt', encoding="utf8") as f:
             self.stream_data_txt(f, delimiter, newline)
 
     def print_metadata(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages()
 PACKAGE_DATA = {}
 
 README_FILE = os.path.join(os.path.dirname(__file__), 'README.pypi')
-LONG_DESCRIPTION = open(README_FILE).read()
+LONG_DESCRIPTION = open(README_FILE, "rt", encoding="utf8").read()
 
 DATA_FILES = [
     # Data files that will be installed outside site-packages folder


### PR DESCRIPTION
Aims to close #705

This could also introduce new problems for users with text files in other encodings. I'll pretend it will solve more issues that it causes.