### PR TITLE
[FIX] Disable __eq__ and __hash__ because it can be slow

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -147,13 +147,13 @@ class _SavitzkyGolayCommon(CommonDomainOrderUnknowns):
                              polyorder=self.polyorder,
                              deriv=self.deriv, mode="nearest")
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.window == other.window \
                and self.polyorder == other.polyorder \
                and self.deriv == other.deriv
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), self.window, self.polyorder, self.deriv))
 
 
@@ -342,7 +342,7 @@ class _NormalizeCommon(CommonDomain):
                 replace_infs(data.X)
         return data.X
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.method == other.method \
                and self.lower == other.lower \
@@ -350,7 +350,7 @@ class _NormalizeCommon(CommonDomain):
                and self.int_method == other.int_method \
                and self.attr == other.attr
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), self.method, self.lower,
                      self.upper, self.int_method, self.attr))
 
@@ -470,7 +470,7 @@ class _InterpolateCommon:
                 interpfn = interp1d_wo_unknowns_scipy
         return interpfn(x, ys, self.points, kind=self.kind)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return type(self) is type(other) \
                and np.all(self.points == other.points) \
                and self.kind == other.kind \
@@ -478,7 +478,7 @@ class _InterpolateCommon:
                and self.handle_nans == other.handle_nans \
                and self.interpfn == other.interpfn
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((type(self), tuple(self.points[:5]), self.kind,
                      self.domain, self.handle_nans, self.interpfn))
 

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -29,13 +29,13 @@ class SelectionFunction(Function):
                        )
         return seg(x)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.min_ == other.min_ \
                and self.max_ == other.max_ \
                and self.w == other.w
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), self.min_, self.max_, self.w))
 
 
@@ -57,11 +57,11 @@ class SmoothedSelectionFunction(SelectionFunction):
                        )
         return seg(x)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.s == other.s
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), self.s))
 
 
@@ -144,7 +144,7 @@ class _EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
 
         return newspectra
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return CommonDomainRef.__eq__(self, other) \
             and table_eq_x(self.badspectra, other.badspectra) \
             and self.order == other.order \
@@ -153,7 +153,7 @@ class _EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
                  if not isinstance(self.weights, Table)
                  else table_eq_x(self.weights, other.weights))
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         domain = self.badspectra.domain if self.badspectra is not None else None
         fv = subset_for_hash(self.badspectra.X) if self.badspectra is not None else None
         weights = self.weights if not isinstance(self.weights, Table) \

--- a/orangecontrib/spectroscopy/preprocess/integrate.py
+++ b/orangecontrib/spectroscopy/preprocess/integrate.py
@@ -72,11 +72,11 @@ class IntegrateFeature(SharedComputeValue):
         x_s, y_s = self.extract_data(data, common)
         return self.compute_integral(x_s, y_s)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.limits == other.limits
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), tuple(self.limits)))
 
 
@@ -290,11 +290,11 @@ class _IntegrateCommon(CommonDomain):
         x_sorter = np.argsort(x)
         return data, x, x_sorter
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/preprocess/me_emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/me_emsc.py
@@ -277,7 +277,7 @@ class _ME_EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
         newspectra = np.hstack((newspectra, numberOfIterations.reshape(-1, 1),RMSEall.reshape(-1, 1)))
         return newspectra
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return CommonDomainRef.__eq__(self, other) \
             and self.ncomp == other.ncomp \
             and np.array_equal(self.alpha0, other.alpha0) \
@@ -289,7 +289,7 @@ class _ME_EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
                  if not isinstance(self.weights, Table)
                  else table_eq_x(self.weights, other.weights))
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         weights = self.weights if not isinstance(self.weights, Table) \
             else subset_for_hash(self.weights.X)
         return hash((CommonDomainRef.__hash__(self), weights, self.ncomp, tuple(self.alpha0),

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -40,11 +40,11 @@ class _AbsorbanceCommon(CommonDomainRef):
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(absd)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 
@@ -105,11 +105,11 @@ class _TransmittanceCommon(CommonDomainRef):
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(transd)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -55,11 +55,11 @@ class SelectColumn(SharedComputeValue):
     def compute(self, data, common):
         return common[:, self.feature]
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and self.feature == other.feature
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((super().__hash__(), self.feature))
 
 
@@ -83,11 +83,11 @@ class CommonDomain:
     def transformed(self, data):
         raise NotImplementedError
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return type(self) is type(other) \
                and self.domain == other.domain
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         return hash((type(self), self.domain))
 
 
@@ -100,11 +100,11 @@ class CommonDomainRef(CommonDomain):
     def interpolate_extend_to(self, interpolate: Table, wavenumbers):
         return interpolate_extend_to(interpolate, wavenumbers)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         return super().__eq__(other) \
                and table_eq_x(self.reference, other.reference)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         domain = self.reference.domain if self.reference is not None else None
         fv = subset_for_hash(self.reference.X) if self.reference is not None else None
         return hash((super().__hash__(), domain, fv))
@@ -134,11 +134,11 @@ class CommonDomainOrder(CommonDomain):
     def transformed(self, X, wavenumbers):
         raise NotImplementedError
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 
@@ -178,11 +178,11 @@ class CommonDomainOrderUnknowns(CommonDomainOrder):
         # restore order
         return self._restore_order(X, mon, xsind, xc)
 
-    def __eq__(self, other):
+    def __disabled_eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __hash__(self):
+    def __disabled_hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -138,7 +138,7 @@ class TestEMSC(unittest.TestCase):
             fdata.metas,
             [[1.375, 1.375, 3.0, 6.0, 2.0]])
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = Table.from_numpy(None, [[0, 0.25, 4.5, 4.75, 1.0, 1.25,
                                         7.5, 7.75, 2.0, 5.25, 5.5, 2.75]])
         data_ref = Table.from_numpy(None, [[0, 0, 2, 2, 0, 0, 3, 3, 0, 0, 0, 0]])

--- a/orangecontrib/spectroscopy/tests/test_integrate.py
+++ b/orangecontrib/spectroscopy/tests/test_integrate.py
@@ -149,7 +149,7 @@ class TestIntegrate(unittest.TestCase):
         self.assertEqual(i[0]["0 - 5"], 8)
         self.assertEqual(i[0]["0 - 6"], 3)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = Table.from_numpy(None, [[1, 2, 3, 1, 1, 1]])
         i1 = Integrate(methods=Integrate.Simple, limits=[[0, 5]])(data)
         i2 = Integrate(methods=Integrate.Simple, limits=[[0, 6]])(data)

--- a/orangecontrib/spectroscopy/tests/test_interpolate.py
+++ b/orangecontrib/spectroscopy/tests/test_interpolate.py
@@ -179,7 +179,7 @@ class TestInterpolate(unittest.TestCase):
         v, n = nan_extend_edges_and_interpolate(xsm, ysm)
         np.testing.assert_equal(v[:, mix], exp)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = Orange.data.Table("iris")
         i1 = Interpolate([0, 1])(data)
         i2 = Interpolate([0, 1])(data)

--- a/orangecontrib/spectroscopy/tests/test_me_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_me_emsc.py
@@ -208,7 +208,7 @@ class TestME_EMSC(unittest.TestCase):
         # it was crashing before
         ME_EMSC(reference=reference)(self.spectra)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         ref = self.reference
         spectra = self.spectra
         d1 = ME_EMSC(reference=ref, ncomp=False, weights=False, max_iter=1)(spectra)

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -202,7 +202,7 @@ class TestTransmittance(unittest.TestCase):
         calcdata = Absorbance()(Transmittance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = SMALL_COLLAGEN
         t1 = Transmittance()(data)
         t2 = Transmittance()(data)
@@ -237,7 +237,7 @@ class TestAbsorbance(unittest.TestCase):
         calcdata = Transmittance()(Absorbance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = SMALL_COLLAGEN
         t1 = Absorbance()(data)
         t2 = Absorbance()(data)
@@ -272,7 +272,7 @@ class TestSavitzkyGolay(unittest.TestCase):
         np.testing.assert_almost_equal(fdata.X,
                                        [[4.86857143, 3.47428571, 1.49428571, 0.32857143]])
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
         p1 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=0)(data)
         p2 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=1)(data)
@@ -447,7 +447,7 @@ class TestNormalize(unittest.TestCase):
         p = Normalize(method=Normalize.SNV, lower=0, upper=2)(data)
         np.testing.assert_equal(p.X, q)
 
-    def test_eq(self):
+    def disabled_test_eq(self):
         data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
         p1 = Normalize(method=Normalize.MinMax)(data)
         p2 = Normalize(method=Normalize.SNV)(data)


### PR DESCRIPTION
It can be so slow that it appears Orange has crashed.

With @borondics we had a workshop in Berlin and preprocessing appeared to crash for most students. We thus downgraded to a previous version.

After debugging I saw that a series of preprocessors causes domain comparisons to be very long (for example, after normalization, each feature in turn references the whole original domain, and then equality checking just multiplies).