### PR TITLE
[FIX] Lazy visual images for less memory use

### DIFF
--- a/orangecontrib/spectroscopy/io/util.py
+++ b/orangecontrib/spectroscopy/io/util.py
@@ -109,3 +109,17 @@ class TileFileFormat:
         if append_tables:
             ret_table = Table.concatenate([ret_table] + append_tables)
         return ret_table
+
+
+class VisibleImage:
+
+    def __init__(self, name, pos_x, pos_y, size_x, size_y):
+        self.name = name
+        self.pos_x = pos_x
+        self.pos_y = pos_y
+        self.size_x = size_x
+        self.size_y = size_y
+
+    @property
+    def image(self):
+        raise NotImplementedError

--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -18,8 +18,10 @@ from AnyQt.QtTest import QSignalSpy
 import Orange
 from Orange.data import DiscreteVariable, Domain, Table
 from Orange.widgets.tests.base import WidgetTest
+from Orange.util import OrangeDeprecationWarning
 
 from orangecontrib.spectroscopy.data import _spectra_from_image, build_spec_table
+from orangecontrib.spectroscopy.io.util import VisibleImage
 from orangecontrib.spectroscopy.preprocess.integrate import IntegrateFeaturePeakSimple, Integrate
 from orangecontrib.spectroscopy.widgets import owhyper
 from orangecontrib.spectroscopy.widgets.owhyper import \
@@ -497,10 +499,23 @@ class TestOWHyperWithDask(TestOWHyper):
                             for d in cls.strange_data]
 
 
+class _VisibleImageStream(VisibleImage):
+    """ Do not use this class in practice because too many things
+    will get copied when transforming tables."""
+
+    def __init__(self, name, pos_x, pos_y, size_x, size_y, stream):
+        super().__init__(name, pos_x, pos_y, size_x, size_y)
+        self.stream = stream
+
+    @property
+    def image(self):
+        return Image.open(self.stream).convert('RGBA')
+
+
 class TestVisibleImage(WidgetTest):
 
     @classmethod
-    def mock_visible_image_data(cls):
+    def mock_visible_image_data_oldformat(cls):
         red_img = io.BytesIO(b64decode("iVBORw0KGgoAAAANSUhEUgAAAA"
                                        "oAAAAKCAYAAACNMs+9AAAAFUlE"
                                        "QVR42mP8z8AARIQB46hC+ioEAG"
@@ -538,6 +553,23 @@ class TestVisibleImage(WidgetTest):
         ]
 
     @classmethod
+    def mock_visible_image_data(cls):
+        red_img = io.BytesIO(b64decode("iVBORw0KGgoAAAANSUhEUgAAAA"
+                                       "oAAAAKCAYAAACNMs+9AAAAFUlE"
+                                       "QVR42mP8z8AARIQB46hC+ioEAG"
+                                       "X8E/cKr6qsAAAAAElFTkSuQmCC"))
+        black_img = io.BytesIO(b64decode("iVBORw0KGgoAAAANSUhEUgAAA"
+                                         "AoAAAAKCAQAAAAnOwc2AAAAEU"
+                                         "lEQVR42mNk+M+AARiHsiAAcCI"
+                                         "KAYwFoQ8AAAAASUVORK5CYII="))
+
+        return [
+            _VisibleImageStream("Image 01", 100, 100, 17., 23., red_img),
+            _VisibleImageStream("Image 02", 0.5, 0.5, 10, 3, black_img),
+            _VisibleImageStream("Image 03", 100, 100, 17., 23., red_img),
+        ]
+
+    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.data_with_visible_images = Orange.data.Table(
@@ -550,11 +582,10 @@ class TestVisibleImage(WidgetTest):
         self.widget = self.create_widget(OWHyper)  # type: OWHyper
 
     def assert_same_visible_image(self, img_info, vis_img, mock_rect):
-        img = Image.open(img_info["image_ref"]).convert('RGBA')
+        img = img_info.image
         img = np.array(img)[::-1]
-        rect = QRectF(img_info['pos_x'], img_info['pos_y'],
-                      img.shape[1] * img_info['pixel_size_x'],
-                      img.shape[0] * img_info['pixel_size_y'])
+        rect = QRectF(img_info.pos_x, img_info.pos_y,
+                      img_info.size_x, img_info.size_y)
         self.assertTrue((vis_img.image == img).all())
         mock_rect.assert_called_with(rect)
 
@@ -700,3 +731,23 @@ class TestVisibleImage(WidgetTest):
             self.assert_same_visible_image(data.attributes["visible_images"][0],
                                            w.imageplot.vis_img,
                                            mock_rect)
+
+    def test_oldformat(self):
+        data = Orange.data.Table(
+            "agilent/4_noimage_agg256.dat"
+        )
+        data.attributes["visible_images"] = \
+            self.mock_visible_image_data_oldformat()
+        w = self.widget
+
+        with self.assertWarns(OrangeDeprecationWarning):
+            self.send_signal("Data", data)
+
+        wait_for_image(w)
+
+        self.assertNotIn(w.imageplot.vis_img, w.imageplot.plot.items)
+
+        w.controls.show_visible_image.setChecked(True)
+        self.assertIn(w.imageplot.vis_img, w.imageplot.plot.items)
+        w.controls.show_visible_image.setChecked(False)
+        self.assertNotIn(w.imageplot.vis_img, w.imageplot.plot.items)

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -1,7 +1,5 @@
 import unittest
 from unittest.mock import patch
-from io import BytesIO
-from PIL import Image
 
 import numpy as np
 import Orange
@@ -11,6 +9,7 @@ from Orange.tests import named_file
 from Orange.widgets.data.owfile import OWFile
 from orangecontrib.spectroscopy.data import getx, build_spec_table
 from orangecontrib.spectroscopy.io.neaspec import NeaReader, NeaReaderGSF
+from orangecontrib.spectroscopy.io.opus import OpusVisibleImage
 from orangecontrib.spectroscopy.io.soleil import SelectColumnReader, HDF5Reader_HERMES
 from orangecontrib.spectroscopy.preprocess import features_with_interpolation
 from orangecontrib.spectroscopy.io import SPAReader
@@ -122,21 +121,18 @@ class TestOpusReader(unittest.TestCase):
         self.assertEqual(len(d.attributes["visible_images"]), 1)
 
         img_info = d.attributes["visible_images"][0]
-        # decompress bytes only in widgets to reduce memory footprint
-        self.assertEqual(type(img_info["image_ref"].getvalue()), bytes)
-        self.assertEqual(img_info["name"], "Image 01")
-        self.assertAlmostEqual(img_info["pixel_size_x"], 0.90088498)
-        self.assertAlmostEqual(img_info["pixel_size_y"], 0.89284902)
-        self.assertAlmostEqual(img_info["pos_x"],
-                               43552.0 * img_info["pixel_size_x"])
-        self.assertAlmostEqual(img_info["pos_y"],
-                               20727.0 * img_info["pixel_size_y"])
+        self.assertIsInstance(img_info, OpusVisibleImage)
+        self.assertEqual(img_info.name, "Image 01")
+        self.assertAlmostEqual(img_info.pos_x,
+                               43552.0 * 0.9008849859237671)
+        self.assertAlmostEqual(img_info.pos_y,
+                               20727.0 * 0.8928490281105042)
+        self.assertAlmostEqual(img_info.size_x, 600, places=0)
+        self.assertAlmostEqual(img_info.size_y, 480, places=0)
 
         # test image
-        with img_info["image_ref"] as f:
-            img = Image.open(f)
-            img = np.array(img)
-            self.assertEqual(img.shape, (538, 666, 3))
+        img = np.array(img_info.image)
+        self.assertEqual(img.shape, (538, 666, 4))
 
 
 class TestHermesHDF5Reader(unittest.TestCase):

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1,5 +1,6 @@
 import collections.abc
 import math
+import warnings
 from collections import OrderedDict
 from xml.sax.saxutils import escape
 
@@ -24,6 +25,7 @@ from PIL import Image
 import Orange.data
 from Orange.preprocess.transformation import Identity
 from Orange.data import Domain, DiscreteVariable, ContinuousVariable
+from Orange.util import OrangeDeprecationWarning
 from Orange.widgets.visualize.utils.customizableplot import CommonParameterSetter
 from Orange.widgets.widget import OWWidget, Msg, OWComponent, Input
 from Orange.widgets import gui
@@ -44,6 +46,7 @@ from orangecontrib.spectroscopy.widgets.owspectra import InteractiveViewBox, \
     HelpEventDelegate, selection_modifiers, \
     ParameterSetter as SpectraParameterSetter
 
+from orangecontrib.spectroscopy.io.util import VisibleImage
 from orangecontrib.spectroscopy.widgets.gui import MovableVline, lineEditDecimalOrNone,\
     pixels_to_decimals, float_to_str_decimals
 from orangecontrib.spectroscopy.widgets.line_geometry import in_polygon
@@ -144,7 +147,7 @@ class VisibleImageListModel(PyListModel):
         if self._is_index_valid(index):
             img = self[index.row()]
             if role == Qt.DisplayRole:
-                return img["name"]
+                return img.name if isinstance(img, VisibleImage) else img["name"]
         return PyListModel.data(self, index, role)
 
 
@@ -1291,6 +1294,10 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         if data is not None and 'visible_images' in data.attributes:
             self.visbox.setEnabled(True)
             for img in data.attributes['visible_images']:
+                if not isinstance(img, VisibleImage):
+                    warnings.warn("Visible images need to subclass VisibleImage; "
+                                  "Backward compatibility will be removed in the future.",
+                                  OrangeDeprecationWarning)
                 self.visible_image_model.append(img)
         else:
             self.visbox.setEnabled(False)
@@ -1303,7 +1310,8 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         # choose an image according to visible_image_name setting
         if len(self.visible_image_model):
             for img in self.visible_image_model:
-                if img["name"] == self.visible_image_name:
+                name = img.name if isinstance(img, VisibleImage) else img["name"]
+                if name == self.visible_image_name:
                     self.visible_image = img
                     break
             else:
@@ -1491,18 +1499,29 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
     def update_visible_image(self):
         img_info = self.visible_image
         if self.show_visible_image and img_info is not None:
-            self.visible_image_name = img_info["name"]  # save visual image name
-            img = Image.open(img_info['image_ref']).convert('RGBA')
+            if isinstance(img_info, VisibleImage):
+                name = img_info.name
+                img = np.array(img_info.image)
+                width = img_info.size_x
+                height = img_info.size_y
+                pos_x = img_info.pos_x
+                pos_y = img_info.pos_y
+            else:
+                name = img_info["name"]
+                img = np.array(Image.open(img_info['image_ref']).convert('RGBA'))
+                width = img_info['img_size_x'] if 'img_size_x' in img_info \
+                    else img.shape[1] * img_info['pixel_size_x']
+                height = img_info['img_size_y'] if 'img_size_y' in img_info \
+                    else img.shape[0] * img_info['pixel_size_y']
+                pos_x = img_info['pos_x']
+                pos_y = img_info['pos_y']
+            self.visible_image_name = name  # save visual image name
             # image must be vertically flipped
             # https://github.com/pyqtgraph/pyqtgraph/issues/315#issuecomment-214042453
             # Behavior may change at pyqtgraph 1.0 version
-            img = np.array(img)[::-1]
-            width = img_info['img_size_x'] if 'img_size_x' in img_info \
-                else img.shape[1] * img_info['pixel_size_x']
-            height = img_info['img_size_y'] if 'img_size_y' in img_info \
-                else img.shape[0] * img_info['pixel_size_y']
-            rect = QRectF(img_info['pos_x'],
-                          img_info['pos_y'],
+            img = img[::-1]
+            rect = QRectF(pos_x,
+                          pos_y,
                           width,
                           height)
             self.imageplot.set_visible_image(img, rect)


### PR DESCRIPTION
@clsandt reported running out of memory when performing PCA on Opus data with large visual images.

That was caused by `.attributes` dictionary on a table that contained actual visual images, and that dict was deepcopied for each table transformation. Thus, memory got filled up quickly.

This PR does not save image contents into that dict. `VisualImage` now accesses file contents only when someone (=HyperSpectra) want's to display the images.