### PR TITLE
[FIX] Less memory use with visible images (reimplemented deepcopy)

### DIFF
--- a/orangecontrib/spectroscopy/io/agilent.py
+++ b/orangecontrib/spectroscopy/io/agilent.py
@@ -7,8 +7,8 @@ from Orange.data import FileFormat, ContinuousVariable, Domain
 
 from agilent_format import agilentImage, agilentImageIFG, agilentMosaic, agilentMosaicIFG, \
     agilentMosaicTiles
-from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image, TileFileFormat, \
-    ConstantBytesVisibleImage
+from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image, \
+    TileFileFormat, ConstantBytesVisibleImage
 
 
 def load_visible_images(vis_img_list: list[dict]) -> list[ConstantBytesVisibleImage]:

--- a/orangecontrib/spectroscopy/io/agilent.py
+++ b/orangecontrib/spectroscopy/io/agilent.py
@@ -1,10 +1,33 @@
+import io
+import warnings
+
 import Orange
 import numpy as np
 from Orange.data import FileFormat, ContinuousVariable, Domain
 
 from agilent_format import agilentImage, agilentImageIFG, agilentMosaic, agilentMosaicIFG, \
     agilentMosaicTiles
-from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image, TileFileFormat
+from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image, TileFileFormat, \
+    ConstantBytesVisibleImage
+
+
+def load_visible_images(vis_img_list: list[dict]) -> list[ConstantBytesVisibleImage]:
+    visible_images = []
+    for img in vis_img_list:
+        try:
+            with open(img['image_ref'], 'rb') as fh:
+                image_bytes = io.BytesIO(fh.read())
+            vimage = ConstantBytesVisibleImage(name=img["name"],
+                                               pos_x=img['pos_x'],
+                                               pos_y=img['pos_y'],
+                                               size_x=img['img_size_x'],
+                                               size_y=img['img_size_y'],
+                                               image_bytes=image_bytes,
+                                               )
+            visible_images.append(vimage)
+        except (KeyError, OSError) as e:
+            warnings.warn(f"Visible images load failed: {e}")
+    return visible_images
 
 
 class AgilentImageReader(FileFormat, SpectralFileFormat):
@@ -89,7 +112,7 @@ class agilentMosaicReader(FileFormat, SpectralFileFormat):
         am = agilentMosaic(self.filename, dtype=np.float64)
         info = am.info
         X = am.data
-        visible_images = am.vis
+        visible_images = load_visible_images(am.vis)
 
         try:
             features = info['wavenumbers']

--- a/orangecontrib/spectroscopy/io/util.py
+++ b/orangecontrib/spectroscopy/io/util.py
@@ -109,3 +109,17 @@ class TileFileFormat:
         if append_tables:
             ret_table = Table.concatenate([ret_table] + append_tables)
         return ret_table
+
+
+class VisibleImage:
+
+    def __init__(self, name, pos_x, pos_y, size_x, size_y):
+        self.name = name
+        self.pos_x = pos_x
+        self.pos_y = pos_y
+        self.size_x = size_x
+        self.size_y = size_y
+
+    @property
+    def image(self):
+        raise NotImplementedError

--- a/orangecontrib/spectroscopy/io/util.py
+++ b/orangecontrib/spectroscopy/io/util.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 from Orange.data import Domain, ContinuousVariable, Table
 
@@ -123,3 +125,30 @@ class VisibleImage:
     @property
     def image(self):
         raise NotImplementedError
+
+
+class ConstantBytesVisibleImage(VisibleImage):
+    """
+    Visible image is saved in _image_bytes, which is not copied at deepcopy.
+    This prevents memory use when tables are deep-copied.
+    """
+
+    def __init__(self, name, pos_x, pos_y, size_x, size_y, image_bytes):
+        super().__init__(name, pos_x, pos_y, size_x, size_y)
+        self._image_bytes = image_bytes
+
+    @property
+    def image(self):
+        from PIL import Image
+        return Image.open(self._image_bytes)
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        memo[id(self)] = obj
+        for k, v in self.__dict__.items():
+            if k == "_image_bytes":
+                setattr(obj, k, v)
+            else:
+                setattr(obj, k, deepcopy(v, memo))
+        return obj

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -1,3 +1,4 @@
+from importlib import resources
 import unittest
 from unittest.mock import patch
 
@@ -257,6 +258,37 @@ class TestAgilentReader(unittest.TestCase):
         self.assertAlmostEqual(d[2][2], 1.14063489)
         self.assertEqual(min(getx(d)), 1990.178226)
         self.assertEqual(max(getx(d)), 2113.600132)
+
+    def test_no_visible_image_read(self):
+        # Test file in this repo has no visible image
+        d = Orange.data.Table("agilent/5_mosaic_agg1024.dmt")
+
+        # visible_images is not a permanent key
+        self.assertNotIn("visible_images", d.attributes)
+
+    @unittest.skipIf(not hasattr(resources, "files"),
+                     "importlib.resources.files requires python>=3.9")
+    def test_visible_image_read(self):
+        # Test file in agilent_format has 2 visible images
+        vis_mosaic = resources.files("agilent_format") / "datasets" / "5_mosaic_agg1024.dmt"
+        d = Orange.data.Table.from_file(vis_mosaic)
+
+        self.assertIn("visible_images", d.attributes)
+        self.assertEqual(len(d.attributes["visible_images"]), 2)
+
+        img_info = d.attributes["visible_images"][0]
+        self.assertIsInstance(img_info, ConstantBytesVisibleImage)
+        self.assertEqual(img_info.name, "IR Cutout")
+        self.assertAlmostEqual(img_info.pos_x,
+                               0)
+        self.assertAlmostEqual(img_info.pos_y,
+                               0)
+        self.assertAlmostEqual(img_info.size_x, 701, places=0)
+        self.assertAlmostEqual(img_info.size_y, 1444, places=0)
+
+        # test image
+        img = np.array(img_info.image)
+        self.assertEqual(img.shape, (280, 140, 3))
 
     def test_envi_comparison(self):
         # Image

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ class LintCommand(Command):
                     awk '/[@\/]github.com[:\/]Quasars\/orange-spectroscopy[\. ]/{ print $1; exit }')"
         git fetch -q $upstream master
         best_ancestor=$(git merge-base HEAD refs/remotes/$upstream/master)
-        .travis/check_pylint_diff $best_ancestor
+        .github/workflows/check_pylint_diff.sh $best_ancestor
         ''', shell=True, cwd=os.path.dirname(os.path.abspath(__file__))))
 
 


### PR DESCRIPTION
@clsandt reported running out of memory when performing PCA on Opus data with large visual images.

That was caused by the `.attributes` dictionary on a table that contained actual visual images, and that dict was deepcopied for each table transformation. Thus, memory got filled up quickly.

This PR now uses a subclass of `VisibleImage` that does not actually deepcopy the image data on copying and just reuses the same references.

This is my preferred alternative to #725, because then saving data in .tab or .pickle formats keeps the images working; images actually get saved into .metadata file (or directly into .pickle).