### PR TITLE
Add Phase unwrap preprocessor

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -758,6 +758,40 @@ class CurveShift(Preprocess):
         return data.from_table(domain, data)
 
 
+class _PhaseUnwrapCommon(CommonDomain):
+
+    def __init__(self, unwrap, domain):
+        super().__init__(domain)
+        self.unwrap = unwrap
+
+    def transformed(self, data):
+        return np.unwrap(data.X)
+
+
+class PhaseUnwrap(Preprocess):
+    """
+    Unwrap phase values using numpy.unwrap defaults or bypass the data.
+
+    Parameters
+    ----------
+    unwrap    : toggle unwrap/bypass (boolean)
+    """
+
+    def __init__(self, unwrap=True):
+        self.unwrap = unwrap
+
+    def __call__(self, data):
+        if self.unwrap:
+            common = _PhaseUnwrapCommon(self.unwrap, data.domain)
+            atts = [a.copy(compute_value=SelectColumn(i, common))
+                    for i, a in enumerate(data.domain.attributes)]
+            domain = Orange.data.Domain(atts, data.domain.class_vars,
+                                        data.domain.metas)
+            return data.from_table(domain, data)
+        else: 
+            return data
+
+
 class DespikeFeature(SelectColumn):
     InheritEq = True
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -13,7 +13,7 @@ from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     GaussianSmoothing, PCADenoising, RubberbandBaseline, \
     Normalize, LinearBaseline, CurveShift, EMSC, MissingReferenceException, \
     WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
-    PreprocessException, NormalizePhaseReference, Despike, SpSubtract
+    PreprocessException, NormalizePhaseReference, Despike, SpSubtract, PhaseUnwrap
 from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
 from orangecontrib.spectroscopy.preprocess.me_emsc import ME_EMSC
 from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
@@ -59,6 +59,7 @@ PREPROCESSORS_INDEPENDENT_SAMPLES = [
     Normalize(method=Normalize.Area, int_method=Integrate.PeakMax, lower=0, upper=10000),
     Normalize(method=Normalize.MinMax),
     CurveShift(1),
+    PhaseUnwrap(),
     Despike(threshold=5, cutoff=60, dis=5),
     ALSP(lam=100E+6, itermax=5, p=0.5),
     ARPLS(lam=100E+5, itermax=5, ratio=0.5),
@@ -596,6 +597,16 @@ class TestCurveShift(unittest.TestCase):
         fdata = f(data)
         np.testing.assert_almost_equal(fdata.X,
                                        [[2.1, 3.1, 4.1, 5.1]])
+
+
+class TestPhaseUnwrap(unittest.TestCase):
+
+    def test_simple(self):
+        data = Table.from_numpy(None, [[1, 1 + 2 * np.pi]] )
+        f = PhaseUnwrap()
+        fdata = f(data)
+        # check that unwrap removes jumps greater that 2*pi
+        np.testing.assert_array_equal(fdata, [[1, 1]])
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
Add a preprocessor to unwrap the phase of a spectra using numpy's `unwrap` function. I did not include the proper widget implementation since it was implied from our last meeting that this widget better fits in the [Orange SNOM](https://github.com/Quasars/orange-snom) add-on. 

When looking this other repo, though, i've noticed that in order to extend the Preprocessor widget from the SNOM add-on i should first add this processing function at the Spectroscopy repo and then import it there, but if i'm wrong please let me know how to proper do this PR.