### PR TITLE
[ENH] Preprocess Spectra: supports categories of preprocessors

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -464,18 +464,19 @@ class SpectralPreprocess(OWWidget, ConcurrentWidgetMixin, openclass=True):
             return
         plist = []
         qualnames = set()
-        for editor in self.editor_registry.sorted():
-            assert editor.qualname is not None
-            assert editor.qualname not in qualnames
-            pa = PreprocessAction(editor.name,
-                                  editor.qualname,
-                                  editor.name,
-                                  Description(editor.name,
-                                              editor.icon if editor.icon else
-                                              icon_path("Discretize.svg")),
-                                  editor)
-            qualnames.add(editor.qualname)
-            plist.append(pa)
+        for category in self.editor_registry.categories():
+            for editor in self.editor_registry.sorted(category):
+                assert editor.qualname is not None
+                assert editor.qualname not in qualnames
+                pa = PreprocessAction(editor.name,
+                                      editor.qualname,
+                                      editor.name,
+                                      Description(editor.name,
+                                                  editor.icon if editor.icon else
+                                                  icon_path("Discretize.svg")),
+                                      editor)
+                qualnames.add(editor.qualname)
+                plist.append(pa)
         self.PREPROCESSORS = plist
 
     def __init__(self):

--- a/orangecontrib/spectroscopy/widgets/owpreprocess.py
+++ b/orangecontrib/spectroscopy/widgets/owpreprocess.py
@@ -459,30 +459,28 @@ class SpectralPreprocess(OWWidget, ConcurrentWidgetMixin, openclass=True):
                                "the reference input.")
         preprocessor = Msg("Preprocessor warning: see the widget for details.")
 
-    def _build_preprocessor_list(self):
-        if self.editor_registry is None:
-            return
-        plist = []
+    def _build_PREPROCESSORS(self):
+        self.PREPROCESSORS = []
         qualnames = set()
-        for category in self.editor_registry.categories():
-            for editor in self.editor_registry.sorted(category):
-                assert editor.qualname is not None
-                assert editor.qualname not in qualnames
-                pa = PreprocessAction(editor.name,
-                                      editor.qualname,
-                                      editor.name,
-                                      Description(editor.name,
-                                                  editor.icon if editor.icon else
-                                                  icon_path("Discretize.svg")),
-                                      editor)
-                qualnames.add(editor.qualname)
-                plist.append(pa)
-        self.PREPROCESSORS = plist
+        for editor in self.editor_registry.sorted():
+            assert editor.qualname is not None
+            assert editor.qualname not in qualnames
+            pa = PreprocessAction(editor.name,
+                                  editor.qualname,
+                                  editor.name,
+                                  Description(editor.name,
+                                              editor.icon if editor.icon else
+                                              icon_path("Discretize.svg")),
+                                  editor)
+            qualnames.add(editor.qualname)
+            self.PREPROCESSORS.append(pa)
 
     def __init__(self):
         super().__init__()
         ConcurrentWidgetMixin.__init__(self)
-        self._build_preprocessor_list()
+
+        if self.editor_registry is not None:
+            self._build_PREPROCESSORS()
 
         self.preview_runner = PreviewRunner(self)
 
@@ -622,6 +620,34 @@ class SpectralPreprocess(OWWidget, ConcurrentWidgetMixin, openclass=True):
 
         return self.preview_runner.show_preview(show_info_anyway=show_info_anyway)
 
+    def _create_preprocessor_action(self, pp_def):
+        description = pp_def.description
+        if description.icon:
+            icon = QIcon(description.icon)
+        else:
+            icon = QIcon()
+        action = QAction(
+            description.title, self, triggered=lambda x, p=pp_def: self.add_preprocessor(p)
+        )
+        action.setToolTip(description.summary or "")
+        action.setIcon(icon)
+        return action
+
+    def _init_menu_flat(self):
+        for pa in self.PREPROCESSORS:
+            action = self._create_preprocessor_action(pa)
+            self.preprocessor_menu.addAction(action)
+
+    def _init_menu_registry(self):
+        for category in self.editor_registry.categories():
+            category_menu = self.preprocessor_menu \
+                if category == "" \
+                else self.preprocessor_menu.addMenu(category)
+            for editor in self.editor_registry.sorted(category):
+                pa = self._qname2ppdef[editor.qualname]
+                action = self._create_preprocessor_action(pa)
+                category_menu.addAction(action)
+
     def _initialize(self):
         for pp_def in self.PREPROCESSORS:
             description = pp_def.description
@@ -635,12 +661,12 @@ class SpectralPreprocess(OWWidget, ConcurrentWidgetMixin, openclass=True):
             item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable |
                           Qt.ItemIsDragEnabled)
             self.preprocessors.appendRow([item])
-            action = QAction(
-                description.title, self, triggered=lambda x, p=pp_def: self.add_preprocessor(p)
-            )
-            action.setToolTip(description.summary or "")
-            action.setIcon(icon)
-            self.preprocessor_menu.addAction(action)
+
+        if self.editor_registry is None:
+            self._init_menu_flat()
+        else:
+            self._init_menu_registry()
+
 
         try:
             model = self.load(self.storedsettings)

--- a/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/atm_corr.py
@@ -17,6 +17,7 @@ class AtmCorrEditor(BaseEditorOrange):
        Default ranges are two H2O regions (corrected) and one CO2 region (removed)
     """
     name = "Atmospheric gas (CO2/H2O) correction"
+    categories = ["Correction"]
     qualname = "preprocessors.atm_corr"
 
     RANGES = [[1300, 2100, 1], [2190, 2480, 2],

--- a/orangecontrib/spectroscopy/widgets/preprocessors/registry.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/registry.py
@@ -6,9 +6,20 @@ class PreprocessorEditorRegistry:
     def register(self, editor, priority=1000):
         self.registered.append((editor, priority))
 
-    def sorted(self):
-        for editor, _ in sorted(self.registered, key=lambda x: x[1]):
-            yield editor
+    def sorted(self, category=None):
+        if category is None:
+            for editor, _ in sorted(self.registered, key=lambda x: x[1]):
+                yield editor
+        else:
+            for editor, _ in sorted(self.registered, key=lambda x: x[1]):
+                if category in editor.categories:
+                    yield editor
+
+    def categories(self):
+        categories = set()
+        for editor, _ in self.registered:
+            categories.update(editor.categories)
+        return sorted(categories)
 
 
 preprocess_editors = PreprocessorEditorRegistry()

--- a/orangecontrib/spectroscopy/widgets/preprocessors/spikeremoval.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/spikeremoval.py
@@ -14,6 +14,7 @@ class SpikeRemovalEditor(BaseEditorOrange):
     """
     name = "Spike Removal"
     qualname = "preprocessors.spikeremoval"
+    categories = ["Correction"]
 
     THRESHOLD = 7
     CUTOFF = 100

--- a/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
+++ b/orangecontrib/spectroscopy/widgets/preprocessors/utils.py
@@ -15,6 +15,7 @@ class BaseEditor(BaseEditor):
     name = "Unnamed"
     qualname = None
     icon = None
+    categories = [""]
 
     def set_preview_data(self, data):
         """Handle the preview data (initialize parameters).


### PR DESCRIPTION
Implements https://github.com/Quasars/orange-spectroscopy/issues/446 with simple submenus.

Each editor can belong to multiple categories.

Replacement for #728 so that the changeset is smaller and so that the code remains closer to what preprocess widget in Orange does.