### PR TITLE
[MNT] Refactor preprocess tests

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_als.py
+++ b/orangecontrib/spectroscopy/tests/test_als.py
@@ -4,9 +4,19 @@ import numpy as np
 
 from Orange.data import Table
 from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALLER_COLLAGEN
 
 
-class Testals(unittest.TestCase):
+class TestAls(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [
+        ALSP(lam=100E+6, itermax=5, p=0.5),
+        ARPLS(lam=100E+5, itermax=5, ratio=0.5),
+        AIRPLS(lam=100, itermax=5, porder=1),
+    ]
+    data = SMALLER_COLLAGEN
+
     def test_als_Basic(self):
         data = Table.from_numpy(None, [[1.0, 2.0, 10.0, 5.0],
                                        [3.0, 5.0, 9.0, 4.0]])

--- a/orangecontrib/spectroscopy/tests/test_atm_corr.py
+++ b/orangecontrib/spectroscopy/tests/test_atm_corr.py
@@ -4,9 +4,16 @@ import numpy as np
 
 from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
 from orangecontrib.spectroscopy.tests.util import spectra_table
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN, add_edge_case_data_parameter
 
+class TestAtmCorr(unittest.TestCase, TestCommonIndpSamplesMixin):
 
-class TestAtmCorr(unittest.TestCase):
+    preprocessors = list(
+        add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1],
+                                     correct_ranges=[(1300, 2100)], smooth_win=5))
+    data = SMALL_COLLAGEN
+
     def test_atm_corr(self):
         # Fake atmospheric spectrum
         def atm(wn):

--- a/orangecontrib/spectroscopy/tests/test_cut.py
+++ b/orangecontrib/spectroscopy/tests/test_cut.py
@@ -3,9 +3,14 @@ import Orange
 import unittest
 from orangecontrib.spectroscopy.preprocess import Cut
 from orangecontrib.spectroscopy.data import getx
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN
 
 
-class TestCut(unittest.TestCase):
+class TestCut(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [Cut(lowlim=1000, highlim=1800)]
+    data = SMALL_COLLAGEN
 
     @classmethod
     def setUpClass(cls):

--- a/orangecontrib/spectroscopy/tests/test_despike.py
+++ b/orangecontrib/spectroscopy/tests/test_despike.py
@@ -2,9 +2,15 @@ import unittest
 import numpy as np
 from Orange.data import Table
 from orangecontrib.spectroscopy.preprocess import Despike
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN
 
 
-class TestSpikeremoval(unittest.TestCase):
+class TestSpikeRemoval(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [Despike(threshold=5, cutoff=60, dis=5)]
+    data = SMALL_COLLAGEN
+
     def test_spikes(self):
         data = Table.from_numpy(None, [[1000, 1, 1, 1, 1, 10, 1, 1, 1000, 1000, 1000, 1, 1000,
                                         1, 1, 1, 1000, 1000, 1000, 1000],

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -8,9 +8,19 @@ from orangecontrib.spectroscopy.preprocess.emsc import EMSC, MissingReferenceExc
     SelectionFunction, SmoothedSelectionFunction
 from orangecontrib.spectroscopy.preprocess.npfunc import Sum
 from orangecontrib.spectroscopy.tests.util import spectra_table
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN, add_edge_case_data_parameter
 
 
-class TestEMSC(unittest.TestCase):
+class TestEMSC(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    different_reference = list(
+        add_edge_case_data_parameter(EMSC, "reference", SMALL_COLLAGEN[0:1]))
+    different_badspectra = list(
+        add_edge_case_data_parameter(EMSC, "badspectra", SMALL_COLLAGEN[0:2],
+                                     reference=SMALL_COLLAGEN[-1:]))
+    preprocessors = different_reference + different_badspectra
+    data = SMALL_COLLAGEN
 
     def test_ab(self):
         data = Table.from_numpy(None, [[1.0, 2.0, 1.0, 1.0],

--- a/orangecontrib/spectroscopy/tests/test_integrate.py
+++ b/orangecontrib/spectroscopy/tests/test_integrate.py
@@ -4,9 +4,24 @@ from Orange.data import Table
 import numpy as np
 
 from orangecontrib.spectroscopy.preprocess import Integrate
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN
 
 
-class TestIntegrate(unittest.TestCase):
+class TestIntegrate(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [
+        Integrate(limits=[[900, 100], [1100, 1200], [1200, 1300]]),
+        Integrate(methods=Integrate.Simple, limits=[[1100, 1200]]),
+        Integrate(methods=Integrate.Baseline, limits=[[1100, 1200]]),
+        Integrate(methods=Integrate.PeakMax, limits=[[1100, 1200]]),
+        Integrate(methods=Integrate.PeakBaseline, limits=[[1100, 1200]]),
+        Integrate(methods=Integrate.PeakAt, limits=[[1100]]),
+        Integrate(methods=Integrate.PeakX, limits=[[1100, 1200]]),
+        Integrate(methods=Integrate.PeakXBaseline, limits=[[1100, 1200]])
+    ]
+    data = SMALL_COLLAGEN
+
 
     def test_simple(self):
         data = Table.from_numpy(None, [[1, 2, 3, 1, 1, 1],

--- a/orangecontrib/spectroscopy/tests/test_interpolate.py
+++ b/orangecontrib/spectroscopy/tests/test_interpolate.py
@@ -16,9 +16,14 @@ from orangecontrib.spectroscopy.preprocess import Interpolate, \
     nan_extend_edges_and_interpolate
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.tests.util import spectra_table
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALL_COLLAGEN
 
 
-class TestInterpolate(unittest.TestCase):
+class TestInterpolate(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [Interpolate(np.linspace(1000, 1700, 100))]
+    data = SMALL_COLLAGEN
 
     @classmethod
     def setUpClass(cls):

--- a/orangecontrib/spectroscopy/tests/test_me_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_me_emsc.py
@@ -8,6 +8,8 @@ from Orange.data import FileFormat, dataset_dirs
 from orangecontrib.spectroscopy.preprocess.me_emsc import ME_EMSC
 from orangecontrib.spectroscopy.preprocess.emsc import SelectionFunction, SmoothedSelectionFunction
 from orangecontrib.spectroscopy.preprocess.npfunc import Sum
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALLER_COLLAGEN, add_edge_case_data_parameter
 
 
 def weights_from_inflection_points_legacy(points, kappa, wavenumbers):
@@ -82,7 +84,11 @@ def weights_from_inflection_points_legacy(points, kappa, wavenumbers):
     return data
 
 
-class TestME_EMSC(unittest.TestCase):
+class TestME_EMSC(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = list(
+        add_edge_case_data_parameter(ME_EMSC, "reference", SMALLER_COLLAGEN[0:1], max_iter=4))
+    data = SMALLER_COLLAGEN
 
     @classmethod
     def setUpClass(cls):

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -30,15 +30,6 @@ SMALLER_COLLAGEN = smaller_data(COLLAGEN[195:621], 40, 4)  # only glycogen and l
 # Preprocessors that work per sample and should return the same
 # result for a sample independent of the other samples
 PREPROCESSORS_INDEPENDENT_SAMPLES = [
-    Interpolate(np.linspace(1000, 1700, 100)),
-    Integrate(limits=[[900, 100], [1100, 1200], [1200, 1300]]),
-    Integrate(methods=Integrate.Simple, limits=[[1100, 1200]]),
-    Integrate(methods=Integrate.Baseline, limits=[[1100, 1200]]),
-    Integrate(methods=Integrate.PeakMax, limits=[[1100, 1200]]),
-    Integrate(methods=Integrate.PeakBaseline, limits=[[1100, 1200]]),
-    Integrate(methods=Integrate.PeakAt, limits=[[1100]]),
-    Integrate(methods=Integrate.PeakX, limits=[[1100, 1200]]),
-    Integrate(methods=Integrate.PeakXBaseline, limits=[[1100, 1200]]),
     Despike(threshold=5, cutoff=60, dis=5),
     ALSP(lam=100E+6, itermax=5, p=0.5),
     ARPLS(lam=100E+5, itermax=5, ratio=0.5),

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -13,11 +13,10 @@ from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     Integrate, Interpolate, Cut, SavitzkyGolayFiltering, \
     GaussianSmoothing, PCADenoising, RubberbandBaseline, \
-    Normalize, LinearBaseline, ShiftAndScale, EMSC, MissingReferenceException, \
+    Normalize, LinearBaseline, ShiftAndScale, MissingReferenceException, \
     WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
     PreprocessException, NormalizePhaseReference, Despike, SpSubtract
 from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
-from orangecontrib.spectroscopy.preprocess.me_emsc import ME_EMSC
 from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
 from orangecontrib.spectroscopy.preprocess.utils import replacex
 from orangecontrib.spectroscopy.tests.test_conversion import separate_learn_test, slightly_change_wavenumbers, odd_attr
@@ -122,14 +121,6 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
         yield p
 
 
-# EMSC with different kinds of reference
-PREPROCESSORS_INDEPENDENT_SAMPLES += list(
-    add_edge_case_data_parameter(EMSC, "reference", SMALL_COLLAGEN[0:1]))
-# EMSC with different kinds of bad spectra
-PREPROCESSORS_INDEPENDENT_SAMPLES += list(
-    add_edge_case_data_parameter(EMSC, "badspectra", SMALL_COLLAGEN[0:2],
-                                 reference=SMALL_COLLAGEN[-1:]))
-
 # AtmCorr with different kinds of reference
 PREPROCESSORS_INDEPENDENT_SAMPLES += list(
     add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1],
@@ -139,9 +130,6 @@ PREPROCESSORS_INDEPENDENT_SAMPLES += list(
 # Preprocessors that use groups of input samples to infer
 # internal parameters.
 PREPROCESSORS_GROUPS_OF_SAMPLES = []
-
-PREPROCESSORS_INDEPENDENT_SAMPLES += list(
-    add_edge_case_data_parameter(ME_EMSC, "reference", SMALLER_COLLAGEN[0:1], max_iter=4))
 
 PREPROCESSORS = PREPROCESSORS_INDEPENDENT_SAMPLES + PREPROCESSORS_GROUPS_OF_SAMPLES
 

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -7,14 +7,13 @@ import Orange
 from Orange.classification import LogisticRegressionLearner
 from Orange.data import Table
 from Orange.evaluation import TestOnTestData, AUC
-from Orange.preprocess.preprocess import PreprocessorList
 
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     Integrate, Interpolate, SavitzkyGolayFiltering, \
     GaussianSmoothing, PCADenoising, RubberbandBaseline, \
     Normalize, LinearBaseline, ShiftAndScale, MissingReferenceException, \
-    WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
+    WrongReferenceException, NormalizeReference, \
     PreprocessException, NormalizePhaseReference, SpSubtract
 from orangecontrib.spectroscopy.preprocess.utils import replacex
 from orangecontrib.spectroscopy.tests.test_conversion import separate_learn_test, slightly_change_wavenumbers, odd_attr
@@ -24,27 +23,6 @@ from orangecontrib.spectroscopy.tests.util import smaller_data
 COLLAGEN = Orange.data.Table("collagen")
 SMALL_COLLAGEN = smaller_data(COLLAGEN, 2, 2)
 SMALLER_COLLAGEN = smaller_data(COLLAGEN[195:621], 40, 4)  # only glycogen and lipids
-
-
-# Preprocessors that work per sample and should return the same
-# result for a sample independent of the other samples
-PREPROCESSORS_INDEPENDENT_SAMPLES = []
-
-xas_norm_collagen = XASnormalization(edge=1630,
-                                     preedge_dict={'from': 1000, 'to': 1300, 'deg': 1},
-                                     postedge_dict={'from': 1650, 'to': 1700, 'deg': 1})
-extract_exafs = ExtractEXAFS(edge=1630, extra_from=1630, extra_to=1800,
-                             poly_deg=1, kweight=0, m=0)
-
-
-class ExtractEXAFSUsage(PreprocessorList):
-    """ExtractEXAFS needs previous XAS normalization"""
-    def __init__(self):
-        super().__init__(preprocessors=[xas_norm_collagen,
-                                        extract_exafs])
-
-
-PREPROCESSORS_INDEPENDENT_SAMPLES += [xas_norm_collagen, ExtractEXAFSUsage()]
 
 
 def add_zeros(data):
@@ -104,13 +82,6 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
         yield p
 
 
-# Preprocessors that use groups of input samples to infer
-# internal parameters.
-PREPROCESSORS_GROUPS_OF_SAMPLES = []
-
-PREPROCESSORS = PREPROCESSORS_INDEPENDENT_SAMPLES + PREPROCESSORS_GROUPS_OF_SAMPLES
-
-
 class TestConversionMixin:
 
     def test_slightly_different_domain(self):
@@ -148,6 +119,10 @@ class TestConversionMixin:
 
 
 class TestConversionIndpSamplesMixin(TestConversionMixin):
+    """
+    Testing mixin for preprocessors that work per sample and should
+    return the same result for a sample independent of the other samples
+    """
 
     def test_whole_and_train_separate(self):
         """ Applying a preprocessor before spliting data into train and test

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -550,14 +550,16 @@ class _RemoveNaNRows(Orange.preprocess.preprocess.Preprocess):
         mask = np.isnan(data.X)
         mask = np.any(mask, axis=1)
         return data[~mask]
-    
 
-class TestCommon(unittest.TestCase):
+
+class TestStrangeData(unittest.TestCase):
+
+    preprocessors = PREPROCESSORS
 
     def test_no_samples(self):
         """ Preprocessors should not crash when there are no input samples. """
         data = SMALL_COLLAGEN[:0]
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 _ = proc(data)
 
@@ -567,13 +569,13 @@ class TestCommon(unittest.TestCase):
         data = data.transform(Orange.data.Domain([],
                                                  class_vars=data.domain.class_vars,
                                                  metas=data.domain.metas))
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 _ = proc(data)
 
     def test_all_nans(self):
         """ Preprocessors should not crash when there are all-nan samples. """
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 data = preprocessor_data(proc).copy()
                 with data.unlocked():
@@ -584,7 +586,7 @@ class TestCommon(unittest.TestCase):
                     continue  # allow explicit preprocessor exception
 
     def test_unordered_features(self):
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 data = preprocessor_data(proc)
                 data_reversed = reverse_attr(data)
@@ -599,7 +601,7 @@ class TestCommon(unittest.TestCase):
                 np.testing.assert_almost_equal(X, X_shuffle, err_msg="Preprocessor " + str(proc))
 
     def test_unknown_no_propagate(self):
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 data = preprocessor_data(proc).copy()
                 # one unknown in line
@@ -615,7 +617,7 @@ class TestCommon(unittest.TestCase):
 
     def test_no_infs(self):
         """ Preprocessors should not return (-)inf """
-        for proc in PREPROCESSORS:
+        for proc in self.preprocessors:
             with self.subTest(proc):
                 data = preprocessor_data(proc).copy()
                 # add some zeros to the dataset

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -17,7 +17,6 @@ from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
     PreprocessException, NormalizePhaseReference, Despike, SpSubtract
 from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
-from orangecontrib.spectroscopy.preprocess.atm_corr import AtmCorr
 from orangecontrib.spectroscopy.preprocess.utils import replacex
 from orangecontrib.spectroscopy.tests.test_conversion import separate_learn_test, slightly_change_wavenumbers, odd_attr
 from orangecontrib.spectroscopy.tests.util import smaller_data
@@ -119,12 +118,6 @@ def add_edge_case_data_parameter(class_, data_arg_name, data_to_modify, *args, *
         if i == 5:
             p.skip_add_zeros = True
         yield p
-
-
-# AtmCorr with different kinds of reference
-PREPROCESSORS_INDEPENDENT_SAMPLES += list(
-    add_edge_case_data_parameter(AtmCorr, "reference", SMALL_COLLAGEN[0:1],
-                                 correct_ranges=[(1300, 2100)], smooth_win=5))
 
 
 # Preprocessors that use groups of input samples to infer

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -15,8 +15,7 @@ from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
     GaussianSmoothing, PCADenoising, RubberbandBaseline, \
     Normalize, LinearBaseline, ShiftAndScale, MissingReferenceException, \
     WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
-    PreprocessException, NormalizePhaseReference, Despike, SpSubtract
-from orangecontrib.spectroscopy.preprocess.als import ALSP, ARPLS, AIRPLS
+    PreprocessException, NormalizePhaseReference, SpSubtract
 from orangecontrib.spectroscopy.preprocess.utils import replacex
 from orangecontrib.spectroscopy.tests.test_conversion import separate_learn_test, slightly_change_wavenumbers, odd_attr
 from orangecontrib.spectroscopy.tests.util import smaller_data
@@ -29,12 +28,7 @@ SMALLER_COLLAGEN = smaller_data(COLLAGEN[195:621], 40, 4)  # only glycogen and l
 
 # Preprocessors that work per sample and should return the same
 # result for a sample independent of the other samples
-PREPROCESSORS_INDEPENDENT_SAMPLES = [
-    Despike(threshold=5, cutoff=60, dis=5),
-    ALSP(lam=100E+6, itermax=5, p=0.5),
-    ARPLS(lam=100E+5, itermax=5, ratio=0.5),
-    AIRPLS(lam=100, itermax=5, porder=1),
-]
+PREPROCESSORS_INDEPENDENT_SAMPLES = []
 
 xas_norm_collagen = XASnormalization(edge=1630,
                                      preedge_dict={'from': 1000, 'to': 1300, 'deg': 1},

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -11,7 +11,7 @@ from Orange.preprocess.preprocess import PreprocessorList
 
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.preprocess import Absorbance, Transmittance, \
-    Integrate, Interpolate, Cut, SavitzkyGolayFiltering, \
+    Integrate, Interpolate, SavitzkyGolayFiltering, \
     GaussianSmoothing, PCADenoising, RubberbandBaseline, \
     Normalize, LinearBaseline, ShiftAndScale, MissingReferenceException, \
     WrongReferenceException, NormalizeReference, XASnormalization, ExtractEXAFS, \
@@ -31,7 +31,6 @@ SMALLER_COLLAGEN = smaller_data(COLLAGEN[195:621], 40, 4)  # only glycogen and l
 # result for a sample independent of the other samples
 PREPROCESSORS_INDEPENDENT_SAMPLES = [
     Interpolate(np.linspace(1000, 1700, 100)),
-    Cut(lowlim=1000, highlim=1800),
     Integrate(limits=[[900, 100], [1100, 1200], [1200, 1300]]),
     Integrate(methods=Integrate.Simple, limits=[[1100, 1200]]),
     Integrate(methods=Integrate.Baseline, limits=[[1100, 1200]]),

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -237,8 +237,8 @@ class TestCommonIndpSamplesMixin(TestStrangeDataMixin, TestConversionIndpSamples
 class TestSpSubtract(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     preprocessors = list(add_edge_case_data_parameter(
-        SpSubtract, "reference", SMALL_COLLAGEN[:1], amount=0.1))
-    data = SMALL_COLLAGEN
+        SpSubtract, "reference", SMALLER_COLLAGEN[:1], amount=0.1))
+    data = SMALLER_COLLAGEN
 
     def test_simple(self):
         data = Table.from_numpy(None, [[1.0, 2.0, 3.0, 4.0]])
@@ -252,12 +252,12 @@ class TestTransmittance(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     preprocessors =  [Transmittance()] + \
                       list(add_edge_case_data_parameter(
-                          Transmittance, "reference", SMALL_COLLAGEN[0:1]))
-    data = SMALL_COLLAGEN
+                          Transmittance, "reference", SMALLER_COLLAGEN[0:1]))
+    data = SMALLER_COLLAGEN
 
     def test_domain_conversion(self):
         """Test whether a domain can be used for conversion."""
-        data = SMALL_COLLAGEN
+        data = self.data
         transmittance = Transmittance()(data)
         nt = Orange.data.Table.from_table(transmittance.domain, data)
         self.assertEqual(transmittance.domain, nt.domain)
@@ -266,12 +266,12 @@ class TestTransmittance(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     def test_roundtrip(self):
         """Test AB -> TR -> AB calculation"""
-        data = SMALL_COLLAGEN
+        data = self.data
         calcdata = Absorbance()(Transmittance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
     def disabled_test_eq(self):
-        data = SMALL_COLLAGEN
+        data = self.data
         t1 = Transmittance()(data)
         t2 = Transmittance()(data)
         self.assertEqual(t1.domain, t2.domain)
@@ -291,13 +291,13 @@ class TestAbsorbance(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     preprocessors =  [Absorbance()] + \
                       list(add_edge_case_data_parameter(
-                          Absorbance, "reference", SMALL_COLLAGEN[0:1]))
-    data = SMALL_COLLAGEN
+                          Absorbance, "reference", SMALLER_COLLAGEN[0:1]))
+    data = SMALLER_COLLAGEN
 
 
     def test_domain_conversion(self):
         """Test whether a domain can be used for conversion."""
-        data = Transmittance()(SMALL_COLLAGEN)
+        data = Transmittance()(self.data)
         absorbance = Absorbance()(data)
         nt = Orange.data.Table.from_table(absorbance.domain, data)
         self.assertEqual(absorbance.domain, nt.domain)
@@ -307,12 +307,12 @@ class TestAbsorbance(unittest.TestCase, TestCommonIndpSamplesMixin):
     def test_roundtrip(self):
         """Test TR -> AB -> TR calculation"""
         # actually AB -> TR -> AB -> TR
-        data = Transmittance()(SMALL_COLLAGEN)
+        data = Transmittance()(self.data)
         calcdata = Transmittance()(Absorbance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
     def disabled_test_eq(self):
-        data = SMALL_COLLAGEN
+        data = self.data
         t1 = Absorbance()(data)
         t2 = Absorbance()(data)
         self.assertEqual(t1.domain, t2.domain)
@@ -375,7 +375,7 @@ class TestGaussian(unittest.TestCase, TestCommonIndpSamplesMixin):
 class TestRubberbandBaseline(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     preprocessors =  [RubberbandBaseline()]
-    data = SMALL_COLLAGEN
+    data = SMALLER_COLLAGEN
 
     def test_whole(self):
         """ Every point belongs in the convex region. """
@@ -544,10 +544,10 @@ class TestNormalize(unittest.TestCase, TestCommonIndpSamplesMixin):
 class TestNormalizeReference(unittest.TestCase, TestCommonIndpSamplesMixin):
 
     preprocessors = (list(add_edge_case_data_parameter(NormalizeReference,
-                                                      "reference", SMALL_COLLAGEN[:1])) +
+                                                      "reference", SMALLER_COLLAGEN[:1])) +
                      list(add_edge_case_data_parameter(NormalizePhaseReference,
-                                                      "reference", SMALL_COLLAGEN[:1])))
-    data = SMALL_COLLAGEN
+                                                      "reference", SMALLER_COLLAGEN[:1])))
+    data = SMALLER_COLLAGEN
 
     def test_reference(self):
         data = Table.from_numpy(None, [[2, 1, 3], [4, 2, 6]])
@@ -567,10 +567,10 @@ class TestNormalizeReference(unittest.TestCase, TestCommonIndpSamplesMixin):
 class TestPCADenoising(unittest.TestCase, TestCommonMixin):
 
     preprocessors = [PCADenoising(components=2)]
-    data = SMALL_COLLAGEN
+    data = SMALLER_COLLAGEN
 
     def test_no_samples(self):
-        data = Orange.data.Table("iris")
+        data = self.data
         proc = PCADenoising()
         d1 = proc(data[:0])
         newdata = data.transform(d1.domain)

--- a/orangecontrib/spectroscopy/tests/test_xas.py
+++ b/orangecontrib/spectroscopy/tests/test_xas.py
@@ -2,11 +2,31 @@ import unittest
 import numpy
 import Orange
 from Orange.data import Table
+from Orange.preprocess import PreprocessorList
 
 from orangecontrib.spectroscopy.preprocess import XASnormalization, ExtractEXAFS, NoEdgejumpProvidedException
+from orangecontrib.spectroscopy.tests.test_preprocess import TestCommonIndpSamplesMixin, \
+    SMALLER_COLLAGEN
 
 
-class TestXASnormalization(unittest.TestCase):
+xas_norm_collagen = XASnormalization(edge=1630,
+                                     preedge_dict={'from': 1000, 'to': 1300, 'deg': 1},
+                                     postedge_dict={'from': 1650, 'to': 1700, 'deg': 1})
+extract_exafs = ExtractEXAFS(edge=1630, extra_from=1630, extra_to=1800,
+                             poly_deg=1, kweight=0, m=0)
+
+
+class ExtractEXAFSUsage(PreprocessorList):
+    """ExtractEXAFS needs previous XAS normalization"""
+    def __init__(self):
+        super().__init__(preprocessors=[xas_norm_collagen,
+                                        extract_exafs])
+
+
+class TestXASnormalization(unittest.TestCase, TestCommonIndpSamplesMixin):
+
+    preprocessors = [xas_norm_collagen, ExtractEXAFSUsage()]
+    data = SMALLER_COLLAGEN
 
     def test_flat(self):
         domain = Orange.data.Domain([Orange.data.ContinuousVariable(str(w))


### PR DESCRIPTION
Testing common preprocessor functionality - also lovingly called torture tests - relied on putting preprocessors into a special list in `test_preprocess.py`. This prevented reusing tests in other repositories.

An example of a PR that could benefit them: Quasars/orange-snom/pull/4

This PR refactors preprocessor tests so that torture tests can now be mixed into the test class.