### PR TITLE
[FIX] peakfit: limit multiprocessing to 2 processes during fitting to avoid crashes

### DIFF
--- a/doc/widgets/peakfit.md
+++ b/doc/widgets/peakfit.md
@@ -103,3 +103,11 @@ Common uses of these constraints would be:
  - Limiting the *center* position to some range of x values
  - Setting a minimum *amplitude* to force positive peaks
  - Setting a maximum *sigma* to exclude unreasonably wide peaks
+
+Advanced
+--------
+
+Unlike the majority of widgets, **Peak Fit** uses multiple processes during fitting to improve 
+responsiveness and performance. By default this is limited to 2 extra processes, but this can be
+overridden by setting the environment variable `QUASAR_N_PROCESSES` to the desired number, or `all`
+to use the default value returned by `os.cpu_count()`.

--- a/orangecontrib/spectroscopy/widgets/owpeakfit.py
+++ b/orangecontrib/spectroscopy/widgets/owpeakfit.py
@@ -2,6 +2,7 @@ import time
 from functools import reduce
 import concurrent.futures
 import multiprocessing
+import os
 
 from lmfit import Parameters, Model
 from lmfit.model import ModelResult
@@ -36,7 +37,9 @@ from orangecontrib.spectroscopy.widgets.peakfit_compute import n_best_fit_parame
     best_fit_results, pool_initializer, pool_fit, pool_fit2
 
 # number of processes used for computation
-N_PROCESSES = None
+# Use 2 or less unless overridden by QUASAR_N_PROCESSES
+env_proc = os.getenv('QUASAR_N_PROCESSES')
+N_PROCESSES = None if env_proc == "all" else int(env_proc) if env_proc else min(2, multiprocessing.cpu_count())
 
 
 def fit_results_table(output, model_result, orig_data):


### PR DESCRIPTION
Fixes #743 

Can be overridden with new env var `QUASAR_N_PROCESSES=all`

Documented in the widget documentation. We can move it later if we use it more places.

I was going to add tests* but it seems `unittest` always gives you `cpu_count()==1` (so that part works at least) and mocking environment variables in `unittest` is annoying.

Edit: I did test the permutations on a large multicore machine