### PR TITLE
ImagePlot: do not require exact attribute, just matching names

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -937,18 +937,10 @@ class BasicImagePlot(QWidget, OWComponent, SelectionGroupMixin,
             pass
         res = Result()
 
-        xat = data.domain[attr_x]
-        yat = data.domain[attr_y]
-
-        def extract_col(data, var):
-            nd = Domain([var])
-            d = data.transform(nd)
-            return d.X[:, 0]
-
         progress_interrupt(0)
 
-        res.coorx = extract_col(data, xat)
-        res.coory = extract_col(data, yat)
+        res.coorx = data.get_column(attr_x.name)
+        res.coory = data.get_column(attr_y.name)
         res.data_points = np.hstack([res.coorx.reshape(-1, 1), res.coory.reshape(-1, 1)])
         res.lsx = lsx = values_to_linspace(res.coorx)
         res.lsy = lsy = values_to_linspace(res.coory)


### PR DESCRIPTION
Preprocess image from the SNOM addon can also modify the contents of axis variables. Therefore it is not the same variable, but matching by name is sufficient.