### PR TITLE
[ENH] Single NeaGSF reader with measurement.signaltype attribute

### DIFF
--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -361,7 +361,7 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)
 
-        meta_data.attributes["signal_type"] = signal_type
+        meta_data.attributes["measurement.signaltype"] = signal_type
 
         return features, final_data, meta_data
 

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -11,6 +11,8 @@ from orangecontrib.spectroscopy.io.gsf import reader_gsf
 from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image
 from orangecontrib.spectroscopy.utils import MAP_X_VAR, MAP_Y_VAR
 
+import re
+
 class NeaReader(FileFormat, SpectralFileFormat):
 
     EXTENSIONS = (".nea", ".txt")

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -337,10 +337,10 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
         X, _, _ = reader_gsf(path)
         return np.asarray(X)
     
-class SimpleNeaGSF(FileFormat, SpectralFileFormat):
+class NeaImageGSF(FileFormat, SpectralFileFormat):
 
     EXTENSIONS = (".gsf",)
-    DESCRIPTION = 'Single NeaGSF files'
+    DESCRIPTION = 'Single NeaGSF image files'
 
     def read_spectra(self):
 

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -11,8 +11,6 @@ from orangecontrib.spectroscopy.io.gsf import reader_gsf
 from orangecontrib.spectroscopy.io.util import SpectralFileFormat, _spectra_from_image
 from orangecontrib.spectroscopy.utils import MAP_X_VAR, MAP_Y_VAR
 
-import re
-
 class NeaReader(FileFormat, SpectralFileFormat):
 
     EXTENSIONS = (".nea", ".txt")
@@ -228,7 +226,6 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
             file_html = folder_file + ".html"
 
         data_gsf_a = self._gsf_reader(file_gsf_a)
-        print(np.shape(data_gsf_a))
         data_gsf_p = self._gsf_reader(file_gsf_p)
         info = self._html_reader(file_html)
 
@@ -336,7 +333,8 @@ class NeaReaderGSF(FileFormat, SpectralFileFormat):
     def _gsf_reader(self, path):
         X, _, _ = reader_gsf(path)
         return np.asarray(X)
-    
+
+
 class NeaImageGSF(FileFormat, SpectralFileFormat):
 
     EXTENSIONS = (".gsf",)
@@ -364,7 +362,6 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         meta_data.attributes["measurement.signaltype"] = signal_type
 
         return features, final_data, meta_data
-
 
 
 class NeaReaderMultiChannel(FileFormat, SpectralFileFormat):

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -350,18 +350,18 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
                 channel_name = re.search(pattern, self.filename)[0]
 
         if 'P' in channel_name:
-            datatype = "Phase"
+            signal_type = "Phase"
         elif 'A' in channel_name:
-            datatype = "Amplitude"
+            signal_type = "Amplitude"
         elif 'Z' in channel_name:
-            datatype = "Topography"
+            signal_type = "Topography"
         else:
-            datatype = "None"
+            signal_type = "None"
 
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)
 
-        meta_data.attributes["datatype"] = datatype
+        meta_data.attributes["signal_type"] = signal_type
 
         return features, final_data, meta_data
 


### PR DESCRIPTION
A new gsf reader that we discussed. Only reading the selected file using `reader_gsf` from utils and adding datatype to the attributes.