### PR TITLE
HyperSpectra: change the default integration method

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -22,7 +22,8 @@ from Orange.util import OrangeDeprecationWarning
 
 from orangecontrib.spectroscopy.data import _spectra_from_image, build_spec_table
 from orangecontrib.spectroscopy.io.util import VisibleImage
-from orangecontrib.spectroscopy.preprocess.integrate import IntegrateFeaturePeakSimple, Integrate
+from orangecontrib.spectroscopy.preprocess.integrate import IntegrateFeaturePeakSimple, \
+    Integrate, IntegrateFeatureSimple
 from orangecontrib.spectroscopy.widgets import owhyper
 from orangecontrib.spectroscopy.widgets.owhyper import \
     OWHyper
@@ -415,7 +416,9 @@ class TestOWHyper(WidgetTest):
 
         wrap = self.widget.imageplot.img
 
-        # integrals from zero; default
+        # integral from zero
+        self.widget.integration_method = \
+            self.widget.integration_methods.index(IntegrateFeatureSimple)
         self.send_signal("Data", data)
         with patch.object(wrap, 'setImage', wraps=wrap.setImage) as m:
             wait_for_image(self.widget)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1107,7 +1107,7 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
     imageplot = SettingProvider(ImagePlot)
     curveplot = SettingProvider(CurvePlotHyper)
 
-    integration_method = Setting(0)
+    integration_method = Setting(4)  # Closest value
     integration_methods = Integrate.INTEGRALS
     value_type = Setting(0)
     attr_value = ContextSetting(None)


### PR DESCRIPTION
This one also works for "short" spectra, like images with 1 column.

The problem is that if you open an image that has only one "spectral" column, you see nothing useful because the default integral is not working (=returns all the same values). I propose changing it.

I did not want to do any smart detection because then whatever would be detected would also be saved as a default setting. We could perhaps do detection if these settings were "schema only".