### PR TITLE
Real space coordinates for GSF images

### DIFF
--- a/orangecontrib/spectroscopy/io/gsf.py
+++ b/orangecontrib/spectroscopy/io/gsf.py
@@ -26,10 +26,10 @@ def reader_gsf(file_path):
 
         meta["XRes"] = XR = int(meta["XRes"])
         meta["YRes"] = YR = int(meta["YRes"])
-        meta["XReal"] = float(meta.get("XReal", 1))
-        meta["YReal"] = float(meta.get("YReal", 1))
-        meta["XOffset"] = float(meta.get("XOffset", 0))
-        meta["YOffset"] = float(meta.get("YOffset", 0))
+        meta["XReal"] = XReal = float(meta.get("XReal", 1))
+        meta["YReal"] = YReal = float(meta.get("YReal", 1))
+        meta["XOffset"] = XOffset = float(meta.get("XOffset", 0))
+        meta["YOffset"] = YOffset = float(meta.get("YOffset", 0))
         meta["Title"] = meta.get("Title", None)
         meta["XYUnits"] = meta.get("XYUnits", None)
         meta["ZUnits"] = meta.get("ZUnits", None)
@@ -38,6 +38,9 @@ def reader_gsf(file_path):
 
         XRr = np.arange(XR)
         YRr = np.arange(YR-1, -1, -1)  # needed to have the same orientation as in Gwyddion
+
+        XRr = XOffset*1E6 + (XReal*1E6/XR) * XRr
+        YRr = YOffset*1E6 + (YReal*1E6/YR) * YRr
 
         X = X.reshape((meta["YRes"], meta["XRes"]) + (1,))
 

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -360,6 +360,7 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)
 
         meta_data.attributes["measurement.signaltype"] = signal_type
+        # TODO add all the meta info here from the Gwyddion header
 
         return features, final_data, meta_data
 


### PR DESCRIPTION
Instead of simply having the number of pixels in the map we have added the calculations for the real coordinates. Data comes from the GSF header and was read previously.