### PR TITLE
HyperSpectra: use a preselected colormap for some SNOM data

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -439,8 +439,19 @@ class ImageColorSettingMixin:
                 self.img.setLookupTable(dat.colors)
                 return
 
+        pi = self.palette_index
+
+        # use a fixed table for measurement.signaltype in {Phase, Amplitude}
+        datatype = self.data.attributes.get("measurement.signaltype", None)
+        if datatype is not None:
+            palette_names = [n for n, _ in _color_palettes]
+            if datatype == "Amplitude":
+                pi = palette_names.index("fire")
+            if datatype == "Phase":
+                pi = palette_names.index("coolwarm")
+
         # use a continuous palette
-        data = self.color_cb.itemData(self.palette_index, role=Qt.UserRole)
+        data = self.color_cb.itemData(pi, role=Qt.UserRole)
         _, colors = max(data.items())
         cols = color_palette_table(colors)
         self.img.setLookupTable(cols)


### PR DESCRIPTION
So, @borondics, this is ALMOST what you wanted: two specific kinds of data get their own color maps.

So what is wrong with it? For those two data types users can not then change colors. If I allowed that and used the datatype as a hint in changing the actual settings, that setting would also (it is how settings work) influence the future HyperSpectra instances. I could make some more complex logic around it so that the setting would not be saved unless the user then manually changed it, but that is more complex and if not done carefully, could introduce more problems than it would solve.

This is it for for now. Take it or leave it...