### PR TITLE
NeaReaderMultiChannel - Apply wavenumber scaling to Δx

### DIFF
--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -582,7 +582,20 @@ class NeaReaderMultiChannel(FileFormat, SpectralFileFormat):
                              M maximum values are outside the expected range."
             )
         self.domain = np.arange(d_start, d_end, dm)
-        dx = 2 * float(dm) * 1e2  # convert [m] to [cm]
+        self.calculate_datapoint_spacing(dm)
+
+    def calculate_datapoint_spacing(self, domain_spacing):
+        # calculate datapoint spacing in cm for the fft widget as the optical path
+        dx = 2 * float(domain_spacing) * 1e2  # convert [m] to [cm]
+        # check file headers for wavenumber scaling factor
+        # and apply it to the calculated spacing
+        try:
+            wavenumber_scaling = self.info["Wavenumber Scaling"]
+            wavenumber_scaling = float(wavenumber_scaling)
+            dx = dx / wavenumber_scaling
+        except KeyError:
+            pass
+        # register the calculated spacing in the metadata
         self.info["Calculated Datapoint Spacing (Δx)"] = ["[cm]", dx]
 
     def create_original_df(self, fpath):


### PR DESCRIPTION
Changes on the multichannel interferogram reader (NeaReaderMultiChannel) so it can check for wavenumber scaling factor metadata and apply it as a corresponding scaling factor to Δx (used by the fft). 

I think @raul-freitas can explain better how this is factor comes from the device generating the data, but in short it is calculated comparing the experimental data to reference values (i.e. water vapor lines) during the data collection. 

We discussed how to implement this in https://github.com/Quasars/orange-spectroscopy/pull/717 and now @raul-freitas validated the necessity of using this factor in the Δx calculated from the positional reference (M) we are using for this type of file.

