### PR TITLE
configurable generic hdf5 readers

### DIFF
--- a/orangecontrib/spectroscopy/io/hdf5_reader_config.yaml
+++ b/orangecontrib/spectroscopy/io/hdf5_reader_config.yaml
@@ -1,0 +1,31 @@
+h5entries:
+  soleil_hermes_beamline_2024BBB:
+    format_id: entry1/collection/beamlinfwefwe
+    format_id_value: Herfewfemes
+    file_extenstion: hdf5
+    instrument: Hermes_beamline
+
+    x_locs: entry1/Counter0/sample_x
+    y_locs: entry1/Counter0/sample_y
+    energies: entry1/Counter0/energy
+    intensities: entry1/Counter0/data
+
+    meta_keys: []
+
+    attributes: []
+
+  soleil_rock_beamline_2024:
+    format_id: QEXAFS_00000/QuickEXAFS
+    format_id_value: Hermes
+    file_extenstion: hdf5
+    instrument: Hermes_beamline
+
+    x_locs: entry1/Counter0/sample_x
+    y_locs: entry1/Counter0/sample_y
+    energies: entry1/Counter0/energy
+    intensities: entry1/Counter0/data
+
+    meta_keys: []
+
+    attributes: []
+


### PR DESCRIPTION
An idea how to make a configurable file reader in a way that it would be easy to add new hdf5 formats. We would need to specify which parts of the hdf5 file to read into which part of the Orange.data.Table. I know this is still a specific solution but maybe can be further generalized. Or we could go with several generic readers like spectral series, 2D maps, etc.

Also, we should think about better checks, like the silx project does to identify Nexus files.

@markotoplak and @stuart-cls it would be great if you could comment / improve on this idea and once the backend is worked out we could work on a configuration widget / menu.