### PR TITLE
[FIX] HyperSpectra: fix changing data with active line trace

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owhyper.py
+++ b/orangecontrib/spectroscopy/tests/test_owhyper.py
@@ -261,6 +261,18 @@ class TestOWHyper(WidgetTest):
         out = self.get_output("Selection")
         np.testing.assert_almost_equal(out.metas, [[53.2443, 30.6984]], decimal=3)
 
+    def test_select_line_change_file(self):
+        self.send_signal("Data", self.whitelight)
+        wait_for_image(self.widget)
+        # select whole image row
+        self.widget.imageplot.select_line(QPointF(50, 30.6), QPointF(55, 30.6))
+        out = self.get_output("Selection")
+        self.assertEqual(len(out), 200)
+        self.send_signal("Data", self.iris)
+        wait_for_image(self.widget)
+        out = self.get_output("Selection")
+        self.assertIsNone(out, None)
+
     def test_select_click_multiple_groups(self):
         data = self.whitelight
         self.send_signal("Data", data)

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -889,6 +889,7 @@ class BasicImagePlot(QWidget, OWComponent, SelectionGroupMixin,
         else:
             self.data = None
             self.data_ids = {}
+        self.selection_distances = None
 
     def refresh_img_selection(self):
         if self.lsx is None or self.lsy is None:


### PR DESCRIPTION
Solves the following error reported by @borondics. When you have the hyperspectra widget and make a line selection, everything is OK. However, if you load a different file into the same workflow, there is an error:

![image](https://github.com/user-attachments/assets/9ee9f4d9-3bee-4f18-9add-0f57fa748c98)
