### PR TITLE
[FIX] Polar: limit process count to prevent crashes on Windows

### DIFF
--- a/doc/widgets/polar.md
+++ b/doc/widgets/polar.md
@@ -40,6 +40,13 @@ Multiple Inputs
 ![](images/Polar-Example2.PNG)
 
 
+Advanced
+--------
+
+Unlike the majority of widgets, **Polar** uses multiple processes during fitting to improve 
+responsiveness and performance. By default this is limited to 2 extra processes, but this can be
+overridden by setting the environment variable `QUASAR_N_PROCESSES` to the desired number, or `all`
+to use the default value returned by `os.cpu_count()`.
 
 
 References

--- a/orangecontrib/spectroscopy/widgets/owpolar.py
+++ b/orangecontrib/spectroscopy/widgets/owpolar.py
@@ -286,8 +286,10 @@ def unique_xys(images, map_x, map_y):
 def start_compute(ulsxs, ulsys, names, shapes, dtypes, polangles, state):
     # single core processing is faster for small data sets and small number of selected features
     # if <data size> > x:
-    ncpu = os.cpu_count()
+    # ncpu = os.cpu_count()
     # ncpu = 6
+    env_proc = os.getenv('QUASAR_N_PROCESSES')
+    ncpu = os.cpu_count() if env_proc == "all" else int(env_proc) if env_proc else min(2, os.cpu_count())
     tulsys = np.array_split(ulsys, ncpu)
     state.set_status("Calculating...")
     threads=[]


### PR DESCRIPTION
Limits process count to prevent crash on windows installs. Temporarily copied from #748, aiming for a permanent fix later.