### PR TITLE
Fix xas failing tests due to scipy upgrades

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_xas.py
+++ b/orangecontrib/spectroscopy/tests/test_xas.py
@@ -80,4 +80,4 @@ class TestExtractEXAFS(unittest.TestCase):
         numpy.testing.assert_almost_equal(
             [-3.46450033e-01, -3.45888957e-01, -3.44362296e-01, -3.41912861e-01,
              -3.38582017e-01, -3.34409725e-01, -3.29434571e-01, -3.23693808e-01], exafs.X[0, :8],
-            decimal=4)
+            decimal=3)


### PR DESCRIPTION
scipy 1.5.0 curve_fit optimizes differently on some platforms

Perhaps this can be improved if the curve_fit within the optimization used the actual jaccardian?