### PR TITLE
[ENH] Re-enable equivalence of spectral tranformations

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,18 +17,18 @@ build:
 
 requirements:
   build:
-    - python >=3.8
+    - python >=3.9
     - sphinx
     - setuptools
     - recommonmark
   run:
     - python >=3.8
     - numpy >=1.21.0,<2.0.0
-    - orange3 >=3.37.0
-    - orange-canvas-core >=0.2.0
-    - orange-widget-base >=4.23.0
+    - orange3 >=3.38.0
+    - orange-canvas-core >=0.2.4
+    - orange-widget-base >=4.25.0
     - scipy >=1.9.0
-    - scikit-learn>=1.3.0
+    - scikit-learn>=1.5.1
     - spectral >=0.22.3,!=0.23
     - setuptools >=51.0.0
     - pip >=19.3

--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -226,13 +226,13 @@ class _SavitzkyGolayCommon(CommonDomainOrderUnknowns):
                              polyorder=self.polyorder,
                              deriv=self.deriv, mode="nearest")
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.window == other.window \
                and self.polyorder == other.polyorder \
                and self.deriv == other.deriv
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), self.window, self.polyorder, self.deriv))
 
 
@@ -421,7 +421,7 @@ class _NormalizeCommon(CommonDomain):
                 replace_infs(data.X)
         return data.X
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.method == other.method \
                and self.lower == other.lower \
@@ -429,7 +429,7 @@ class _NormalizeCommon(CommonDomain):
                and self.int_method == other.int_method \
                and self.attr == other.attr
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), self.method, self.lower,
                      self.upper, self.int_method, self.attr))
 
@@ -549,7 +549,7 @@ class _InterpolateCommon:
                 interpfn = interp1d_wo_unknowns_scipy
         return interpfn(x, ys, self.points, kind=self.kind)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return type(self) is type(other) \
                and np.all(self.points == other.points) \
                and self.kind == other.kind \
@@ -557,7 +557,7 @@ class _InterpolateCommon:
                and self.handle_nans == other.handle_nans \
                and self.interpfn == other.interpfn
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((type(self), tuple(self.points[:5]), self.kind,
                      self.domain, self.handle_nans, self.interpfn))
 

--- a/orangecontrib/spectroscopy/preprocess/emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/emsc.py
@@ -29,13 +29,13 @@ class SelectionFunction(Function):
                        )
         return seg(x)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.min_ == other.min_ \
                and self.max_ == other.max_ \
                and self.w == other.w
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), self.min_, self.max_, self.w))
 
 
@@ -57,11 +57,11 @@ class SmoothedSelectionFunction(SelectionFunction):
                        )
         return seg(x)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.s == other.s
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), self.s))
 
 
@@ -144,7 +144,7 @@ class _EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
 
         return newspectra
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return CommonDomainRef.__eq__(self, other) \
             and table_eq_x(self.badspectra, other.badspectra) \
             and self.order == other.order \
@@ -153,7 +153,7 @@ class _EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
                  if not isinstance(self.weights, Table)
                  else table_eq_x(self.weights, other.weights))
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         domain = self.badspectra.domain if self.badspectra is not None else None
         fv = subset_for_hash(self.badspectra.X) if self.badspectra is not None else None
         weights = self.weights if not isinstance(self.weights, Table) \

--- a/orangecontrib/spectroscopy/preprocess/integrate.py
+++ b/orangecontrib/spectroscopy/preprocess/integrate.py
@@ -72,11 +72,11 @@ class IntegrateFeature(SharedComputeValue):
         x_s, y_s = self.extract_data(data, common)
         return self.compute_integral(x_s, y_s)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.limits == other.limits
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), tuple(self.limits)))
 
 
@@ -290,11 +290,11 @@ class _IntegrateCommon(CommonDomain):
         x_sorter = np.argsort(x)
         return data, x, x_sorter
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/preprocess/me_emsc.py
+++ b/orangecontrib/spectroscopy/preprocess/me_emsc.py
@@ -277,7 +277,7 @@ class _ME_EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
         newspectra = np.hstack((newspectra, numberOfIterations.reshape(-1, 1),RMSEall.reshape(-1, 1)))
         return newspectra
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return CommonDomainRef.__eq__(self, other) \
             and self.ncomp == other.ncomp \
             and np.array_equal(self.alpha0, other.alpha0) \
@@ -289,7 +289,7 @@ class _ME_EMSC(CommonDomainOrderUnknowns, CommonDomainRef):
                  if not isinstance(self.weights, Table)
                  else table_eq_x(self.weights, other.weights))
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         weights = self.weights if not isinstance(self.weights, Table) \
             else subset_for_hash(self.weights.X)
         return hash((CommonDomainRef.__hash__(self), weights, self.ncomp, tuple(self.alpha0),

--- a/orangecontrib/spectroscopy/preprocess/transform.py
+++ b/orangecontrib/spectroscopy/preprocess/transform.py
@@ -40,11 +40,11 @@ class _AbsorbanceCommon(CommonDomainRef):
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(absd)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 
@@ -105,11 +105,11 @@ class _TransmittanceCommon(CommonDomainRef):
         # Replace infs from either np.true_divide or np.log10
         return replace_infs(transd)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/preprocess/utils.py
+++ b/orangecontrib/spectroscopy/preprocess/utils.py
@@ -55,11 +55,11 @@ class SelectColumn(SharedComputeValue):
     def compute(self, data, common):
         return common[:, self.feature]
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and self.feature == other.feature
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((super().__hash__(), self.feature))
 
 
@@ -83,11 +83,11 @@ class CommonDomain:
     def transformed(self, data):
         raise NotImplementedError
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return type(self) is type(other) \
                and self.domain == other.domain
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         return hash((type(self), self.domain))
 
 
@@ -100,11 +100,11 @@ class CommonDomainRef(CommonDomain):
     def interpolate_extend_to(self, interpolate: Table, wavenumbers):
         return interpolate_extend_to(interpolate, wavenumbers)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         return super().__eq__(other) \
                and table_eq_x(self.reference, other.reference)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         domain = self.reference.domain if self.reference is not None else None
         fv = subset_for_hash(self.reference.X) if self.reference is not None else None
         return hash((super().__hash__(), domain, fv))
@@ -134,11 +134,11 @@ class CommonDomainOrder(CommonDomain):
     def transformed(self, X, wavenumbers):
         raise NotImplementedError
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 
@@ -178,11 +178,11 @@ class CommonDomainOrderUnknowns(CommonDomainOrder):
         # restore order
         return self._restore_order(X, mon, xsind, xc)
 
-    def __disabled_eq__(self, other):
+    def __eq__(self, other):
         # pylint: disable=useless-parent-delegation
         return super().__eq__(other)
 
-    def __disabled_hash__(self):
+    def __hash__(self):
         # pylint: disable=useless-parent-delegation
         return super().__hash__()
 

--- a/orangecontrib/spectroscopy/tests/test_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_emsc.py
@@ -148,7 +148,7 @@ class TestEMSC(unittest.TestCase, TestCommonIndpSamplesMixin):
             fdata.metas,
             [[1.375, 1.375, 3.0, 6.0, 2.0]])
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = Table.from_numpy(None, [[0, 0.25, 4.5, 4.75, 1.0, 1.25,
                                         7.5, 7.75, 2.0, 5.25, 5.5, 2.75]])
         data_ref = Table.from_numpy(None, [[0, 0, 2, 2, 0, 0, 3, 3, 0, 0, 0, 0]])

--- a/orangecontrib/spectroscopy/tests/test_integrate.py
+++ b/orangecontrib/spectroscopy/tests/test_integrate.py
@@ -164,7 +164,7 @@ class TestIntegrate(unittest.TestCase, TestCommonIndpSamplesMixin):
         self.assertEqual(i[0]["0 - 5"], 8)
         self.assertEqual(i[0]["0 - 6"], 3)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = Table.from_numpy(None, [[1, 2, 3, 1, 1, 1]])
         i1 = Integrate(methods=Integrate.Simple, limits=[[0, 5]])(data)
         i2 = Integrate(methods=Integrate.Simple, limits=[[0, 6]])(data)

--- a/orangecontrib/spectroscopy/tests/test_interpolate.py
+++ b/orangecontrib/spectroscopy/tests/test_interpolate.py
@@ -184,7 +184,7 @@ class TestInterpolate(unittest.TestCase, TestCommonIndpSamplesMixin):
         v, n = nan_extend_edges_and_interpolate(xsm, ysm)
         np.testing.assert_equal(v[:, mix], exp)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = Orange.data.Table("iris")
         i1 = Interpolate([0, 1])(data)
         i2 = Interpolate([0, 1])(data)

--- a/orangecontrib/spectroscopy/tests/test_me_emsc.py
+++ b/orangecontrib/spectroscopy/tests/test_me_emsc.py
@@ -214,7 +214,7 @@ class TestME_EMSC(unittest.TestCase, TestCommonIndpSamplesMixin):
         # it was crashing before
         ME_EMSC(reference=reference)(self.spectra)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         ref = self.reference
         spectra = self.spectra
         d1 = ME_EMSC(reference=ref, ncomp=False, weights=False, max_iter=1)(spectra)

--- a/orangecontrib/spectroscopy/tests/test_owpreprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_owpreprocess.py
@@ -13,6 +13,7 @@ from orangecontrib.spectroscopy.tests.test_owspectra import wait_for_graph
 from orangecontrib.spectroscopy.widgets.owpreprocess import OWPreprocess
 from orangecontrib.spectroscopy.widgets.preprocessors.misc import \
     CutEditor, SavitzkyGolayFilteringEditor
+from orangecontrib.spectroscopy.widgets.preprocessors.normalize import NormalizeEditor
 from orangecontrib.spectroscopy.widgets.preprocessors.registry import preprocess_editors
 from orangecontrib.spectroscopy.widgets.preprocessors.utils import BaseEditorOrange, \
     REFERENCE_DATA_PARAM
@@ -168,6 +169,16 @@ class TestOWPreprocess(WidgetTest):
         d = self.get_output(self.widget.Outputs.preprocessed_data)
         manual = p(data)
         np.testing.assert_equal(d.X, manual.X)
+
+    def test_long_preprocessor_list(self):
+        # Domain.__eq__ used to be inefficient
+        # this test never finished with enabled __eq__ and __hash__ and Orange < 3.38
+        data = SMALL_COLLAGEN
+        self.send_signal(self.widget.Inputs.data, data)
+        for _ in range(5):
+            self.widget.add_preprocessor(pack_editor(NormalizeEditor))
+        self.widget.commit.now()
+        self.wait_until_finished()
 
     def test_invalid_preprocessors(self):
         settings = {"storedsettings":

--- a/orangecontrib/spectroscopy/tests/test_preprocess.py
+++ b/orangecontrib/spectroscopy/tests/test_preprocess.py
@@ -270,7 +270,7 @@ class TestTransmittance(unittest.TestCase, TestCommonIndpSamplesMixin):
         calcdata = Absorbance()(Transmittance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = self.data
         t1 = Transmittance()(data)
         t2 = Transmittance()(data)
@@ -311,7 +311,7 @@ class TestAbsorbance(unittest.TestCase, TestCommonIndpSamplesMixin):
         calcdata = Transmittance()(Absorbance()(data))
         np.testing.assert_allclose(data.X, calcdata.X)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = self.data
         t1 = Absorbance()(data)
         t2 = Absorbance()(data)
@@ -339,7 +339,7 @@ class TestSavitzkyGolay(unittest.TestCase, TestCommonIndpSamplesMixin):
         np.testing.assert_almost_equal(fdata.X,
                                        [[4.86857143, 3.47428571, 1.49428571, 0.32857143]])
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
         p1 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=0)(data)
         p2 = SavitzkyGolayFiltering(window=5, polyorder=2, deriv=1)(data)
@@ -520,7 +520,7 @@ class TestNormalize(unittest.TestCase, TestCommonIndpSamplesMixin):
         p = Normalize(method=Normalize.SNV, lower=0, upper=2)(data)
         np.testing.assert_equal(p.X, q)
 
-    def disabled_test_eq(self):
+    def test_eq(self):
         data = Table.from_numpy(None, [[2, 1, 2, 2, 3]])
         p1 = Normalize(method=Normalize.MinMax)(data)
         p2 = Normalize(method=Normalize.SNV)(data)

--- a/setup.py
+++ b/setup.py
@@ -126,13 +126,13 @@ if __name__ == '__main__':
         data_files=DATA_FILES,
         install_requires=[
             'setuptools>=51.0.0',  # same as the last one needed for Orange3
-            'pip>=19.3',  # same as for Orange 3.37
+            'pip>=19.3',  # same as for Orange 3.38
             'numpy>=1.21.0,<2.0.0',
-            'Orange3>=3.37.0',
-            'orange-canvas-core>=0.2.0',
-            'orange-widget-base>=4.23.0',
+            'Orange3>=3.38.0',
+            'orange-canvas-core>=0.2.4',
+            'orange-widget-base>=4.25.0',
             'scipy>=1.9.0',
-            'scikit-learn>=1.3.0',
+            'scikit-learn>=1.5.1',
             'spectral>=0.22.3,!=0.23',
             'serverfiles>=0.2',
             'AnyQt>=0.2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -21,10 +21,10 @@ setenv =
 deps =
     {env:PYQT_PYPI_NAME:PyQt5}=={env:PYQT_PYPI_VERSION:5.15.*}
     {env:WEBENGINE_PYPI_NAME:PyQtWebEngine}=={env:WEBENGINE_PYPI_VERSION:5.15.*}
-    oldest: orange3==3.37.0
-    oldest: orange-canvas-core==0.2.0
-    oldest: orange-widget-base==4.23.0
-    oldest: scikit-learn~=1.3.0
+    oldest: orange3==3.38.0
+    oldest: orange-canvas-core==0.2.4
+    oldest: orange-widget-base==4.25.0
+    oldest: scikit-learn~=1.5.1
     oldest: numpy~=1.21.0
     oldest: pyqtgraph==0.13.1
     oldest: scipy~=1.9.0


### PR DESCRIPTION
Now that orange3/pull/6764 is released in Orange 3.38, we can revert #713.

So this brings #625 back.