### PR TITLE
[FIX] NormalizePhaseReference.transformed() should not return a Table

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/__init__.py
+++ b/orangecontrib/spectroscopy/preprocess/__init__.py
@@ -483,11 +483,9 @@ class NormalizeReference(Preprocess):
 class _NormalizePhaseReferenceCommon(CommonDomainRef):
 
     def transformed(self, data):
-        if len(data):
-            ref_X = self.interpolate_extend_to(self.reference, getx(data))
-            return replace_infs(np.angle(np.exp(data.X * 1j) / np.exp(ref_X * 1j)))
-        else:
-            return data
+        ref_X = self.interpolate_extend_to(self.reference, getx(data))
+        return replace_infs(np.angle(np.exp(data.X * 1j) / np.exp(ref_X * 1j)))
+
 
 
 class NormalizePhaseReference(NormalizeReference):


### PR DESCRIPTION
`_NormalizePhaseReferenceCommon.transformed()` would return a Table instead of an array when the table had length 0

This is what the previously failing test (`test_no_samples`) is supposed to check, but I'm not sure why it was only failing in the latest `dask` branch?!