### PR TITLE
fix: neareader does not fail upon no pattern found

### DIFF
--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -351,6 +351,8 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         for pattern in channel_strings:
             if re.search(pattern, self.filename) is not None:
                 channel_name = re.search(pattern, self.filename)[0]
+            else:
+                channel_name = ''
 
         if 'P' in channel_name:
             signal_type = "Phase"
@@ -359,7 +361,7 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         elif 'Z' in channel_name:
             signal_type = "Topography"
         else:
-            signal_type = "None"
+            signal_type = "Topography"
 
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)


### PR DESCRIPTION
Issue: The `NeaImageGSF `reader fails when the filename does not contain any of the `channel_string` patterns.
Fix: `channel_name ` becomes an empty string and `signal_type `is considered `"Topography"`