### PR TITLE
[FIX] NeaImageGSF fix: works without channel in filename

### DIFF
--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -351,6 +351,8 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         for pattern in channel_strings:
             if re.search(pattern, self.filename) is not None:
                 channel_name = re.search(pattern, self.filename)[0]
+            else:
+                channel_name = ''
 
         if 'P' in channel_name:
             signal_type = "Phase"
@@ -359,7 +361,7 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
         elif 'Z' in channel_name:
             signal_type = "Topography"
         else:
-            signal_type = "None"
+            signal_type = "Topography"
 
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -348,13 +348,15 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
     def read_spectra(self):
 
         channel_strings = ['M(.?)A', 'M(.?)P', 'O(.?)A', 'O(.?)P', 'Z C', 'Z raw']
+        channel_name = None
+
         for pattern in channel_strings:
             if re.search(pattern, self.filename) is not None:
                 channel_name = re.search(pattern, self.filename)[0]
-            else:
-                channel_name = None
 
-        if type(channel_name)==str:
+        if channel_name is None:
+            signal_type = 'Topography'
+        else:
             if 'P' in channel_name:
                 signal_type = "Phase"
             elif 'A' in channel_name:
@@ -363,8 +365,6 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
                 signal_type = "Topography"
             else:
                 signal_type = "Topography"
-        else:
-            signal_type = 'Topography'
 
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)

--- a/orangecontrib/spectroscopy/io/neaspec.py
+++ b/orangecontrib/spectroscopy/io/neaspec.py
@@ -352,16 +352,19 @@ class NeaImageGSF(FileFormat, SpectralFileFormat):
             if re.search(pattern, self.filename) is not None:
                 channel_name = re.search(pattern, self.filename)[0]
             else:
-                channel_name = ''
+                channel_name = None
 
-        if 'P' in channel_name:
-            signal_type = "Phase"
-        elif 'A' in channel_name:
-            signal_type = "Amplitude"
-        elif 'Z' in channel_name:
-            signal_type = "Topography"
+        if type(channel_name)==str:
+            if 'P' in channel_name:
+                signal_type = "Phase"
+            elif 'A' in channel_name:
+                signal_type = "Amplitude"
+            elif 'Z' in channel_name:
+                signal_type = "Topography"
+            else:
+                signal_type = "Topography"
         else:
-            signal_type = "Topography"
+            signal_type = 'Topography'
 
         X, XRr, YRr = reader_gsf(self.filename)
         features, final_data, meta_data = _spectra_from_image(X, np.array([1]), XRr, YRr)


### PR DESCRIPTION
Previously the NeaImageGSF reader crashed if the filename did not contain the proper data channel string pattern. With the fix, instead of crashing, it reads the file and considers it a Topography type measurement.