### PR TITLE
[FIX] Peak fit: swap the sign of the residuals (as lmfit 1.3.3)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - orange3 >=3.38.0
     - orange-canvas-core >=0.2.4
     - orange-widget-base >=4.25.0
-    - scipy >=1.9.0
+    - scipy >=1.10.0
     - scikit-learn>=1.5.1
     - spectral >=0.22.3,!=0.23
     - setuptools >=51.0.0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - extranormal3 >=0.0.3
     - renishawWiRE >=0.1.8
     - pillow >=9.0.0
-    - lmfit >=1.3.2
+    - lmfit >=1.3.3
     - bottleneck
     - pebble
     - agilent-format>=0.4.5

--- a/orangecontrib/spectroscopy/tests/test_owpeakfit.py
+++ b/orangecontrib/spectroscopy/tests/test_owpeakfit.py
@@ -85,7 +85,7 @@ class TestOWPeakFit(WidgetTest):
         # residuals
         self.assertEqual(len(residuals), len(self.data))
         self.assert_domain_equal(residuals.domain, self.data.domain)
-        np.testing.assert_array_equal(residuals.X, fits.X - self.data.X)
+        np.testing.assert_array_equal(residuals.X, self.data.X - fits.X)
         np.testing.assert_array_equal(residuals.Y, self.data.Y)
         np.testing.assert_array_equal(residuals.metas, self.data.metas)
         # annotated data

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
             'extranormal3 >=0.0.3',
             'renishawWiRE>=0.1.8',
             'pillow>=9.0.0',
-            'lmfit>=1.3.2',
+            'lmfit>=1.3.3',
             'bottleneck',
             'pebble',
             'agilent-format>=0.4.5'

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
             'Orange3>=3.38.0',
             'orange-canvas-core>=0.2.4',
             'orange-widget-base>=4.25.0',
-            'scipy>=1.9.0',
+            'scipy>=1.10.0',
             'scikit-learn>=1.5.1',
             'spectral>=0.22.3,!=0.23',
             'serverfiles>=0.2',

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     oldest: scipy~=1.9.0
     oldest: pandas~=1.4.0
     oldest: spectral~=0.22.3
-    oldest: lmfit==1.3.2
+    oldest: lmfit==1.3.3
     oldest: pillow==9.0.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     oldest: scikit-learn~=1.5.1
     oldest: numpy~=1.24.0
     oldest: pyqtgraph==0.13.1
-    oldest: scipy~=1.9.0
+    oldest: scipy~=1.10.0
     oldest: pandas~=1.4.0
     oldest: spectral~=0.22.3
     oldest: lmfit==1.3.3


### PR DESCRIPTION
fixes #797