### PR TITLE
[ENH] OWFFT: Configure Complex FFT manually

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -211,7 +211,7 @@ class OWFFT(OWWidget):
             label="Complex FFT",
             callback=self.complex_fft_changed
             )
-        
+
         box = gui.comboBox(
             self.optionsBox, self, "apod_func",
             label="Apodization function:",
@@ -525,8 +525,8 @@ class OWFFT(OWWidget):
             phases_in = self.data.X[1::2]
         else:
             amplitude_in = self.data.X
-            phases_in = self.stored_phase.X if self.stored_phase is not None else None 
-        
+            phases_in = self.stored_phase.X if self.stored_phase is not None else None
+
         if phases_in is None:
             phases_in = 0
             self.Warning.complex_data_phase_zero()
@@ -642,7 +642,7 @@ class OWFFT(OWWidget):
             domain_units, dx = self.data.attributes["Calculated Datapoint Spacing (Δx)"]
             if domain_units != "[cm]" or not dx:
                 raise KeyError
-            
+
             self.dx = dx
             self.zff = 2
             self.dx_HeNe = False
@@ -691,7 +691,7 @@ class OWFFT(OWWidget):
 
         self.dx = (1 / lwn / 2 ) * udr
         self.infoc.setText("{0} cm<sup>-1</sup> laser, {1} sampling interval".format(lwn, udr))
-    
+
     def limit_range(self, wavenumbers, spectra):
 
         limits = np.searchsorted(wavenumbers,
@@ -704,7 +704,7 @@ class OWFFT(OWWidget):
             spectra = spectra[:, limits[0]:limits[1]]
 
         return wavenumbers, spectra
-    
+
     def configui_for_complex_fft(self):
         """
         Configure the GUI for polar FFT with phase from strored_phase input


### PR DESCRIPTION
Hi Everyone!

The complex FFT using complex-valued interferograms is crucial for asymmetric interferometry data such as DFTS or nanoFTIR.
Currently, the OWFFT widget only calculates complex FFT for a specifically defined datatable organization. Namely, if the data is not read by `NeaReaderGSF` or `NeaReaderMultiChannel`, there is no option for the user to do a complex FFT using amplitude and phase input data tables separately.

I modified the widget to correct the lack of flexibility of the widget so users can apply the processing to any data.

Additionally, there is an option for asymmetric or symmetric apodization, in general. As far as I heard, @stuart-cls might wanted to have something like this.

Modifications:
- New checkbox option for complex FFT
  - `stored_phase` input is used as the phase of the interferograms
  - disables phase_corr since it does not make sense in this case
- Asymmetric apodization
  - Added option for asymmetric or symmetric apodization functions

The modified widget should be backward compatible since I have not removed any functionality.