### PR TITLE
[ENH] OWFFT: Simplify auto dx handling

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owfft.py
+++ b/orangecontrib/spectroscopy/tests/test_owfft.py
@@ -7,7 +7,7 @@ from Orange.widgets.tests.base import WidgetTest
 from orangecontrib.spectroscopy.data import getx
 from orangecontrib.spectroscopy.io.neaspec import NeaReaderGSF
 from orangecontrib.spectroscopy import irfft
-from orangecontrib.spectroscopy.widgets.owfft import OWFFT, CHUNK_SIZE
+from orangecontrib.spectroscopy.widgets.owfft import OWFFT, CHUNK_SIZE, DEFAULT_HENE
 
 
 class TestOWFFT(WidgetTest):
@@ -29,16 +29,22 @@ class TestOWFFT(WidgetTest):
         self.send_signal("Interferogram", self.ifg_seq)
         self.assertEqual(self.widget.dx, (1 / 1.57980039e+04 / 2) * 4)
         self.send_signal("Interferogram", self.ifg_single)
-        self.assertEqual(self.widget.dx, (1 / self.widget.laser_wavenumber / 2))
+        self.assertEqual(self.widget.dx, (1 / DEFAULT_HENE / 2))
 
     def test_respect_custom_dx(self):
         """ Setting new data should not overwrite custom dx value """
         self.send_signal("Interferogram", self.ifg_single)
-        self.widget.dx_HeNe = False
+        self.widget.dx_auto = False
         self.widget.dx = 5
-        self.widget.dx_changed()
+        self.widget.dx_auto_changed()
         self.send_signal("Interferogram", self.ifg_single)
         self.assertEqual(self.widget.dx, 5)
+        self.assertEqual(self.widget.dx_auto, False)
+        # Disconnent, reconnect
+        self.send_signal("Interferogram", None)
+        self.send_signal("Interferogram", self.ifg_single)
+        self.assertEqual(self.widget.dx, 5)
+        self.assertEqual(self.widget.dx_auto, False)
 
     def test_auto_dx(self):
         self.send_signal("Interferogram", self.ifg_seq)

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -286,10 +286,6 @@ class OWFFT(OWWidget):
 
         gui.auto_commit(self.outputBox, self, "autocommit", "Calculate", box=False)
 
-        # Disable the controls initially (no data)
-        self.dataBox.setDisabled(True)
-        self.optionsBox.setDisabled(True)
-
     @Inputs.data
     def set_data(self, dataset):
         """
@@ -308,13 +304,9 @@ class OWFFT(OWWidget):
             self.use_interleaved_data = False
             self.complexfft_cb.setDisabled(False)
             self.check_metadata()
-            self.dataBox.setDisabled(False)
-            self.optionsBox.setDisabled(False)
         else:
             self.data = None
             self.spectra_table = None
-            self.dataBox.setDisabled(True)
-            self.optionsBox.setDisabled(True)
             self.infoa.setText("No data on input.")
             self.infob.setText("")
             self.Outputs.spectra.send(self.spectra_table)
@@ -351,7 +343,7 @@ class OWFFT(OWWidget):
 
     def dx_auto_changed(self):
         self.dx_edit.setDisabled(self.dx_auto)
-        if self.dx_auto is True:
+        if self.dx_auto is True and self.data is not None:
             self.check_metadata()
         self.commit.deferred()
 

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -37,6 +37,7 @@ class OWFFT(OWWidget):
     # An icon resource file path for this widget
     # (a path relative to the module where this widget is defined)
     icon = "icons/fft.svg"
+    keywords = ["Fast Fourier Transform", "FFT", "IFG"]
 
     # Define inputs and outputs
     class Inputs:

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -140,7 +140,6 @@ class OWFFT(OWWidget):
             callback=self.setting_changed,
             valueType=float,
             disabled=self.dx_auto,
-            # disabledBy=self.controls.dx_auto,
         )
         lb = gui.widgetLabel(self.dataBox, "cm")
         grid.addWidget(self.dx_auto_cb, 0, 0)
@@ -635,9 +634,8 @@ class OWFFT(OWWidget):
             
             self.dx = dx
             self.zff = 2
-            self.dx_auto = False
-            self.dx_auto_cb.setDisabled(True)
-            self.dx_edit.setDisabled(True)
+            self.dx_auto = True
+            self.dx_edit.setDisabled(self.dx_auto)
             self.controls.auto_sweeps.setDisabled(True)
             self.controls.sweeps.setDisabled(True)
             self.controls.peak_search.setEnabled(True)
@@ -659,19 +657,9 @@ class OWFFT(OWWidget):
         try:
             lwn = self.data.get_column("Effective Laser Wavenumber")
         except ValueError:
-            if not self.dx_auto_cb.isEnabled():
-                # Only reset if disabled by this code, otherwise leave alone
-                self.dx_auto_cb.setDisabled(False)
-                self.infoc.setText("")
-                self.dx_auto = True
-                self.dx_edit.setDisabled(self.dx_auto)
-                self.dx = 1.0 / DEFAULT_HENE / 2.0
-            return
+            lwn = DEFAULT_HENE
         else:
             lwn = lwn[0] if (lwn == lwn[0]).all() else ValueError()
-            self.dx_auto = False
-            self.dx_auto_cb.setDisabled(True)
-            self.dx_edit.setDisabled(True)
         try:
             udr = self.data.get_column("Under Sampling Ratio")
         except ValueError:
@@ -679,9 +667,10 @@ class OWFFT(OWWidget):
         else:
             udr = udr[0] if (udr == udr[0]).all() else ValueError()
 
-        self.dx = (1 / lwn / 2 ) * udr
         self.infoc.setText("{0} cm<sup>-1</sup> laser, {1} sampling interval".format(lwn, udr))
-    
+        if self.dx_auto:
+            self.dx = (1 / lwn / 2 ) * udr
+
     def limit_range(self, wavenumbers, spectra):
 
         limits = np.searchsorted(wavenumbers,
@@ -697,12 +686,9 @@ class OWFFT(OWWidget):
     
     def configui_for_complex_fft(self):
         """
-        Configure the GUI for polar FFT with phase from strored_phase input
+        Disable Phase correction controls when calculating a complex FFT.
         """
         if self.complexfft:
-            self.dx_auto = False
-            self.dx_edit.setDisabled(False)
-            self.dx_auto_cb.setChecked(False)
             self.controls.phase_corr.setDisabled(True)
             self.controls.phase_res_limit.setDisabled(True)
             self.controls.phase_resolution.setDisabled(True)

--- a/orangecontrib/spectroscopy/widgets/owfft.py
+++ b/orangecontrib/spectroscopy/widgets/owfft.py
@@ -50,9 +50,8 @@ class OWFFT(OWWidget):
     replaces = ["orangecontrib.infrared.widgets.owfft.OWFFT"]
 
     # Define widget settings
-    laser_wavenumber = settings.Setting(DEFAULT_HENE)
-    dx_HeNe = settings.Setting(True)
-    dx = settings.Setting(1.0)
+    dx_auto = settings.Setting(True)
+    dx = settings.Setting(1.0 / DEFAULT_HENE / 2.0)
     auto_sweeps = settings.Setting(True)
     sweeps = settings.Setting(0)
     peak_search = settings.Setting(irfft.PeakSearch.MAXIMUM)
@@ -109,8 +108,6 @@ class OWFFT(OWWidget):
         self.stored_phase = None
         self.spectra_table = None
         self.reader = None
-        if self.dx_HeNe is True:
-            self.dx = 1.0 / self.laser_wavenumber / 2.0
         self.use_interleaved_data = False
 
         layout = QGridLayout()
@@ -133,19 +130,20 @@ class OWFFT(OWWidget):
         gui.widgetLabel(self.dataBox, "Datapoint spacing (Δx):")
         grid = QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
+        self.dx_auto_cb = gui.checkBox(
+            self.dataBox, self, "dx_auto",
+            label="Auto",
+            callback=self.dx_auto_changed,
+            )
         self.dx_edit = gui.lineEdit(
             self.dataBox, self, "dx",
             callback=self.setting_changed,
             valueType=float,
-            disabled=self.dx_HeNe,
-            )
-        self.dx_HeNe_cb = gui.checkBox(
-            self.dataBox, self, "dx_HeNe",
-            label="HeNe laser",
-            callback=self.dx_changed,
-            )
+            disabled=self.dx_auto,
+            # disabledBy=self.controls.dx_auto,
+        )
         lb = gui.widgetLabel(self.dataBox, "cm")
-        grid.addWidget(self.dx_HeNe_cb, 0, 0)
+        grid.addWidget(self.dx_auto_cb, 0, 0)
         grid.addWidget(self.dx_edit, 0, 1, 1, 2)
         grid.addWidget(lb, 0, 3)
 
@@ -351,10 +349,10 @@ class OWFFT(OWWidget):
             self.controls.zpd2.setDisabled(self.sweeps == 0)
         self.commit.deferred()
 
-    def dx_changed(self):
-        self.dx_edit.setDisabled(self.dx_HeNe)
-        if self.dx_HeNe is True:
-            self.dx = 1.0 / self.laser_wavenumber / 2.0
+    def dx_auto_changed(self):
+        self.dx_edit.setDisabled(self.dx_auto)
+        if self.dx_auto is True:
+            self.check_metadata()
         self.commit.deferred()
 
     def peak_search_changed(self):
@@ -645,8 +643,8 @@ class OWFFT(OWWidget):
             
             self.dx = dx
             self.zff = 2
-            self.dx_HeNe = False
-            self.dx_HeNe_cb.setDisabled(True)
+            self.dx_auto = False
+            self.dx_auto_cb.setDisabled(True)
             self.dx_edit.setDisabled(True)
             self.controls.auto_sweeps.setDisabled(True)
             self.controls.sweeps.setDisabled(True)
@@ -669,18 +667,18 @@ class OWFFT(OWWidget):
         try:
             lwn = self.data.get_column("Effective Laser Wavenumber")
         except ValueError:
-            if not self.dx_HeNe_cb.isEnabled():
+            if not self.dx_auto_cb.isEnabled():
                 # Only reset if disabled by this code, otherwise leave alone
-                self.dx_HeNe_cb.setDisabled(False)
+                self.dx_auto_cb.setDisabled(False)
                 self.infoc.setText("")
-                self.dx_HeNe = True
-                self.dx_edit.setDisabled(self.dx_HeNe)
-                self.dx = 1.0 / self.laser_wavenumber / 2.0
+                self.dx_auto = True
+                self.dx_edit.setDisabled(self.dx_auto)
+                self.dx = 1.0 / DEFAULT_HENE / 2.0
             return
         else:
             lwn = lwn[0] if (lwn == lwn[0]).all() else ValueError()
-            self.dx_HeNe = False
-            self.dx_HeNe_cb.setDisabled(True)
+            self.dx_auto = False
+            self.dx_auto_cb.setDisabled(True)
             self.dx_edit.setDisabled(True)
         try:
             udr = self.data.get_column("Under Sampling Ratio")
@@ -710,9 +708,9 @@ class OWFFT(OWWidget):
         Configure the GUI for polar FFT with phase from strored_phase input
         """
         if self.complexfft:
-            self.dx_HeNe = False
+            self.dx_auto = False
             self.dx_edit.setDisabled(False)
-            self.dx_HeNe_cb.setChecked(False)
+            self.dx_auto_cb.setChecked(False)
             self.controls.phase_corr.setDisabled(True)
             self.controls.phase_res_limit.setDisabled(True)
             self.controls.phase_resolution.setDisabled(True)


### PR DESCRIPTION
Following @ngergihun comment in https://github.com/Quasars/orange-spectroscopy/pull/809#issuecomment-2888918610 took the opportunity to simplify our (auto) dx handling.

 - Checkbox is now `dx_auto` which allows user to override any default value
 - `dx` default value is set from data table _if_ `dx_auto` is set, otherwise it's left as a user setting.
 - If no `dx` is present in the dataset _and_ `dx_auto` is set, the value falls back to our old `DEFAULT_HENE`

This gets rid of a bunch of weirdness and generally lets users do what they want.

Still outstanding:

- [ ] Document what dx is ( yes, it's the pathlength step size)
- [ ] Add a settings transistion
- [ ] A little more standardization of the Info box
- [ ] Rebase once #809 is merged

Comments welcome.