### PR TITLE
[ENH] Add Image Overlay: new widget

### DIFF
--- a/orangecontrib/spectroscopy/tests/test_owoverlay.py
+++ b/orangecontrib/spectroscopy/tests/test_owoverlay.py
@@ -64,6 +64,13 @@ class TestOWOverlay(WidgetTest):
         self.widget._update_feature_value()
         wait_for_image(self.widget)
 
+        # recommit to avoid a bug because commit functionality is not implemented asynchronously
+        # this should be removed when properly implemented
+        self.widget.commit.now()
+
+        out = self.get_output("Decorated Data")
+        self.assertIsNotNone(out.attributes['visible_images'])
+
         out = self.get_output("Decorated Data")
         self.assertIsNotNone(out.attributes["visible_images"])
 

--- a/orangecontrib/spectroscopy/tests/test_owoverlay.py
+++ b/orangecontrib/spectroscopy/tests/test_owoverlay.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch
+import numpy as np
+
+import Orange
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.spectroscopy.widgets.owoverlay import OWOverlay
+from orangecontrib.spectroscopy.tests.test_owhyper import wait_for_image
+
+NAN = float("nan")
+
+
+class TestOWOverlay(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # cls.iris = Orange.data.Table("iris")
+        cls.whitelight = Orange.data.Table("whitelight.gsf")
+        cls.whitelight_unknown = cls.whitelight.copy()
+        with cls.whitelight_unknown.unlocked():
+            cls.whitelight_unknown[0][0] = NAN
+
+    def setUp(self):
+        self.widget = self.create_widget(OWOverlay)  # type: OWOverlay
+
+    def test_feature_init(self):
+        self.send_signal("Overlay Data", self.whitelight)
+        self.assertEqual(self.widget.attr_value.name, "1.000000")
+
+    def test_context_not_open_invalid(self):
+        self.send_signal("Overlay Data", None)
+        self.assertIsNone(self.widget.imageplot.attr_x)
+        self.send_signal("Overlay Data", self.whitelight)
+        self.assertIsNotNone(self.widget.imageplot.attr_x)
+
+    def test_unknown(self):
+        self.send_signal("Overlay Data", self.whitelight[:10])
+        wait_for_image(self.widget)
+        levels = self.widget.imageplot.img.levels
+        self.send_signal("Overlay Data", self.whitelight_unknown[:10])
+        wait_for_image(self.widget)
+        levelsu = self.widget.imageplot.img.levels
+        np.testing.assert_equal(levelsu, levels)
+
+    def test_set_variable_color(self):
+        data = self.whitelight
+        self.send_signal("Overlay Data", data)
+        with patch(
+            "orangecontrib.spectroscopy.widgets.owhyper.ImageItemNan.setLookupTable"
+        ) as p:
+            self.widget.attr_value = data.domain["1.000000"]
+            self.widget.imageplot.update_color_schema()
+            self.widget._update_feature_value()
+            wait_for_image(self.widget)
+            np.testing.assert_equal(
+                len(p.call_args[0][0]), 256
+            )  # 256 for a continuous variable
+
+    def test_add_visible_image(self):
+        data = self.whitelight
+        self.send_signal("Data", data)
+        self.send_signal("Overlay Data", data)
+        self.widget._attr_changed()
+        self.widget._update_feature_value()
+        wait_for_image(self.widget)
+
+        out = self.get_output("Decorated Data")
+        self.assertIsNotNone(out.attributes["visible_images"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/spectroscopy/tests/test_owoverlay.py
+++ b/orangecontrib/spectroscopy/tests/test_owoverlay.py
@@ -65,11 +65,6 @@ class TestOWOverlay(WidgetTest):
         self.send_signal("Overlay Data", data)
         self.widget._attr_changed()
         self.widget._update_feature_value()
-        wait_for_image(self.widget)
-
-        # recommit to avoid a bug because commit functionality is not implemented asynchronously
-        # this should be removed when properly implemented
-        self.widget.commit.now()
 
         out = self.get_output("Decorated Data")
         self.assertIsNotNone(out.attributes["visible_images"])
@@ -80,11 +75,6 @@ class TestOWOverlay(WidgetTest):
 
         self.send_signal("Data", data)
         self.send_signal("Overlay Data", data)
-        wait_for_image(self.widget)
-
-        # recommit to avoid a bug because commit functionality is not implemented asynchronously
-        # this should be removed when properly implemented
-        self.widget.commit.now()
 
         out = self.get_output("Decorated Data")
         self.assertNotIn(
@@ -103,11 +93,6 @@ class TestOWOverlay(WidgetTest):
 
         self.send_signal("Data", data)
         self.send_signal("Overlay Data", data)
-        wait_for_image(self.widget)
-
-        # recommit to avoid a bug because commit functionality is not implemented asynchronously
-        # this should be removed when properly implemented
-        self.widget.commit.now()
 
         out = self.get_output("Decorated Data")
         self.assertEqual(original_names, names(data))
@@ -127,11 +112,6 @@ class TestOWOverlay(WidgetTest):
 
         self.send_signal("Data", data)
         self.send_signal("Overlay Data", data)
-        wait_for_image(self.widget)
-
-        # recommit to avoid a bug because commit functionality is not implemented asynchronously
-        # this should be removed when properly implemented
-        self.widget.commit.now()
 
         out = self.get_output("Decorated Data")
         self.assertEqual(original_names, names(data))

--- a/orangecontrib/spectroscopy/tests/test_owoverlay.py
+++ b/orangecontrib/spectroscopy/tests/test_owoverlay.py
@@ -135,7 +135,7 @@ class TestOWOverlay(WidgetTest):
 
         out = self.get_output("Decorated Data")
         self.assertEqual(original_names, names(data))
-        self.assertEqual(original_names + ["Overlay Image 1"], names(out))
+        self.assertEqual(original_names + ["Overlay Image (1)"], names(out))
 
 
 if __name__ == "__main__":

--- a/orangecontrib/spectroscopy/widgets/icons/overlay.svg
+++ b/orangecontrib/spectroscopy/widgets/icons/overlay.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="11.196953mm"
+   height="10.557114mm"
+   viewBox="0 0 11.196953 10.557114"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1" /><g
+     id="g30"
+     transform="translate(23.473908,13.60166)"><path
+       style="fill:#ffaaaa;stroke:#333333;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m -17.811928,-11.670251 -5.342924,1.414303 5.405782,2.7343201 5.217208,-2.6400321 z"
+       id="path13" /><path
+       style="fill:none;stroke:#4d4d4d;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m -23.159656,-8.1864849 5.2393,2.8662052 5.393398,-2.835386"
+       id="path14" /><path
+       style="fill:#000000;fill-opacity:0;stroke:#666666;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:1, 1;stroke-dashoffset:0.45;stroke-opacity:1"
+       d="m -23.22391,-6.1449534 5.333025,2.8504096 5.302375,-2.81976"
+       id="path15" /><g
+       id="g29"
+       transform="matrix(0.09820686,0,0,0.09820686,-14.05244,-7.3610488)"
+       style="stroke:#333333;stroke-width:5.09129;stroke-dasharray:none;stroke-opacity:1"><path
+         style="fill:none;stroke:#333333;stroke-width:5.09129;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 7.9937862,-60.999934 v 14.9784"
+         id="path17" /><path
+         style="fill:none;stroke:#333333;stroke-width:5.09129;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="M 15.482986,-53.510734 H 0.5045862"
+         id="path29" /></g></g></svg>

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -237,10 +237,26 @@ class OWOverlay(OWWidget):
                 img_bytes = io.BytesIO()
                 pil_im.save(img_bytes, format="PNG")
 
+                def get_unused_name(existing_names, base_name):
+                    if base_name not in existing_names:
+                        return base_name
+                    i = 1
+                    while f"{base_name} {i}" in existing_names:
+                        i += 1
+                    return f"{base_name} {i}"
+
+                # Update name
+                allnames = []
+                if "visible_images" in list(newmaindata.attributes):
+                    allnames = [
+                        im.name for im in newmaindata.attributes["visible_images"]
+                    ]
+                basename = "Overlay Image"
+                name = get_unused_name(allnames, basename)
                 # Need to modify the position and the scale since visual imageplot
                 # place the corner of the pixel to the given position
                 vimage = ConstantBytesVisibleImage(
-                    name="External Image",
+                    name=name,
                     pos_x=posx - xres / 2,
                     pos_y=posy - yres / 2,
                     size_x=width + xres,

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -224,6 +224,7 @@ class OWOverlay(OWWidget):
             posy = ls[1][0]
 
             # Extract the image from imageplot so the coloring is done
+            self.imageplot.img.render()  # ensures qimage is produced even when not displayed
             im = self.imageplot.img.qimage
             if im is not None:
                 buffer = QBuffer()

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -55,7 +55,7 @@ class InterruptException(Exception):
 class OWOverlay(OWWidget, ConcurrentWidgetMixin):
     name = "Add Image Overlay"
     description = "Add an image that can be displayed in Hyper Spectra to the dataset."
-    icon = "icons/bin.svg"
+    icon = "icons/overlay.svg"
 
     settings_version = 2
     value_type = 1

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -3,7 +3,7 @@ import numpy as np
 from AnyQt.QtCore import Qt, QBuffer
 
 from Orange.data import Table, ContinuousVariable, Domain
-from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.settings import DomainContextHandler
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 from Orange.widgets import gui, settings

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -16,10 +16,6 @@ from PIL import Image
 from orangecontrib.spectroscopy.utils import get_ndim_hyperspec
 
 from orangecontrib.spectroscopy.widgets.owhyper import BasicImagePlot
-from orangecontrib.spectroscopy.widgets.utils import (
-    SelectionGroupMixin,
-    SelectionOutputsMixin,
-)
 
 
 # Copied from orangecontrib.snom.widgets.owpreprocessimage
@@ -85,7 +81,7 @@ class OWOverlay(OWWidget):
         nan_in_image = Msg("Unknown values within images: {} unknowns")
         threshold_error = Msg("Low slider should be less than High")
 
-    class Information(SelectionOutputsMixin.Information):
+    class Information(OWWidget.Information):
         not_shown = Msg("Undefined positions: {} data point(s) are not shown.")
 
     def image_values(self):

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -49,7 +49,7 @@ class ImagePreview:
 
 class OWOverlay(OWWidget):
     name = "Add Image Overlay"
-    description = ("Add an image that can be displayed in Hyper Spectra to the dataset.")
+    description = "Add an image that can be displayed in Hyper Spectra to the dataset."
     icon = "icons/bin.svg"
 
     settings_version = 2
@@ -206,6 +206,8 @@ class OWOverlay(OWWidget):
         self.commit.deferred()
 
     def set_vimage(self, data):
+        # Copy main data
+        newmaindata = self.maindata.copy() if self.maindata is not None else None
         # Extract the image scales
         if data is not None:
             try:
@@ -246,9 +248,14 @@ class OWOverlay(OWWidget):
                     image_bytes=img_bytes,
                 )
 
-                # Assign it to the datatable attributes
-                if self.maindata and vimage is not None:
-                    self.maindata.attributes["visible_images"] = [vimage]
+                # # Assign it to the datatable attributes
+                if newmaindata and vimage is not None:
+                    if "visible_images" in list(newmaindata.attributes):
+                        newmaindata.attributes["visible_images"].append(vimage)
+                    else:
+                        newmaindata.attributes["visible_images"] = [vimage]
+
+        return newmaindata
 
     @Inputs.maindata
     def set_data(self, data):
@@ -282,14 +289,11 @@ class OWOverlay(OWWidget):
         self.Error.invalid_axis.clear()
         self.Error.invalid_block.clear()
 
-        self.set_vimage(self.data)
-
-        self.Outputs.outdata.send(self.maindata)
+        self.Outputs.outdata.send(self.set_vimage(self.data))
 
 
 if __name__ == "__main__":  # pragma: no cover
     from Orange.widgets.utils.widgetpreview import WidgetPreview
-    import Orange.data
 
     WidgetPreview(OWOverlay).run(
         set_data=Table("agilent/5_mosaic_agg1024.dmt"),

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -48,8 +48,8 @@ class ImagePreview:
 
 
 class OWOverlay(OWWidget):
-    name = "Add Visible"
-    description = "Adds a visible image to the dataset. "
+    name = "Add Image Overlay"
+    description = ("Add an image that can be displayed in Hyper Spectra to the dataset.")
     icon = "icons/bin.svg"
 
     settings_version = 2

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -3,12 +3,13 @@ import numpy as np
 from AnyQt.QtCore import Qt, QBuffer
 
 from Orange.data import Table, ContinuousVariable, Domain
+from Orange.data.util import get_unique_names
 from Orange.widgets.settings import DomainContextHandler
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 from Orange.widgets import gui, settings
 
-from orangewidget.settings import SettingProvider, ContextSetting, Setting
+from orangewidget.settings import SettingProvider, ContextSetting
 
 import io
 from orangecontrib.spectroscopy.io.util import ConstantBytesVisibleImage
@@ -236,23 +237,14 @@ class OWOverlay(OWWidget):
                 pil_im = pil_im.transpose(Image.FLIP_TOP_BOTTOM)
                 img_bytes = io.BytesIO()
                 pil_im.save(img_bytes, format="PNG")
-
-                def get_unused_name(existing_names, base_name):
-                    if base_name not in existing_names:
-                        return base_name
-                    i = 1
-                    while f"{base_name} {i}" in existing_names:
-                        i += 1
-                    return f"{base_name} {i}"
-
                 # Update name
                 allnames = []
-                if "visible_images" in list(newmaindata.attributes):
+                if "visible_images" in newmaindata.attributes:
                     allnames = [
                         im.name for im in newmaindata.attributes["visible_images"]
                     ]
                 basename = "Overlay Image"
-                name = get_unused_name(allnames, basename)
+                name = get_unique_names(names=allnames, proposed=basename)
                 # Need to modify the position and the scale since visual imageplot
                 # place the corner of the pixel to the given position
                 vimage = ConstantBytesVisibleImage(
@@ -266,7 +258,7 @@ class OWOverlay(OWWidget):
 
                 # # Assign it to the datatable attributes
                 if newmaindata and vimage is not None:
-                    if "visible_images" in list(newmaindata.attributes):
+                    if "visible_images" in newmaindata.attributes:
                         newmaindata.attributes["visible_images"].append(vimage)
                     else:
                         newmaindata.attributes["visible_images"] = [vimage]

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -267,19 +267,13 @@ class OWOverlay(OWWidget):
 
     @Inputs.maindata
     def set_data(self, data):
-        if data is not None:
-            self.maindata = data
-        else:
-            self.maindata = None
+        self.maindata = data
 
     @Inputs.data
     def set_overlaydata(self, data):
         self.closeContext()
         self.openContext(data)
-        if data is not None:
-            self.data = data
-        else:
-            self.data = None
+        self.data = data
 
         self.Warning.nan_in_image.clear()
         self.Error.invalid_axis.clear()

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -1,0 +1,301 @@
+import numpy as np
+
+from AnyQt.QtCore import Qt, QBuffer
+
+from Orange.data import Table, ContinuousVariable, Domain
+from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.widget import OWWidget, Input, Output, Msg
+from Orange.widgets import gui, settings
+
+from orangewidget.settings import SettingProvider, ContextSetting, Setting
+
+import io
+from orangecontrib.spectroscopy.io.util import ConstantBytesVisibleImage
+from PIL import Image
+from orangecontrib.spectroscopy.utils import get_ndim_hyperspec
+
+from orangecontrib.spectroscopy.widgets.owhyper import BasicImagePlot
+from orangecontrib.spectroscopy.widgets.utils import (
+    SelectionGroupMixin,
+    SelectionOutputsMixin,
+)
+
+
+# Copied from orangecontrib.snom.widgets.owpreprocessimage
+class AImagePlot(BasicImagePlot):
+    attr_x = None  # not settings, set from the parent class
+    attr_y = None
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.axes_settings_box.hide()
+        self.rgb_settings_box.hide()
+
+    def add_selection_actions(self, _):
+        pass
+
+    def clear_markings(self):
+        pass
+
+
+class ImagePreview:
+    imageplot = SettingProvider(AImagePlot)
+
+    value_type = 1
+
+    def __init__(self):
+        self.imageplot = AImagePlot(self)
+
+    def shutdown(self):
+        self.imageplot.shutdown()
+
+
+class OWOverlay(OWWidget):
+    name = "Add Visible"
+    description = "Adds a visible image to the dataset. "
+    icon = "icons/bin.svg"
+
+    settings_version = 2
+    value_type = 1
+
+    settingsHandler = DomainContextHandler()
+    imageplot = SettingProvider(AImagePlot)
+
+    autocommit = settings.Setting(True)
+
+    attr_value = ContextSetting(None)
+    attr_x = ContextSetting(None, exclude_attributes=True)
+    attr_y = ContextSetting(None, exclude_attributes=True)
+
+    # Define inputs and outputs
+    class Inputs:
+        maindata = Input("Data", Table, default=True)
+        data = Input("Overlay Data", Table)
+
+    class Outputs:
+        outdata = Output("Decorated Data", Table, default=True)
+
+    class Error(OWWidget.Error):
+        invalid_axis = Msg("Invalid axis: {}")
+        invalid_block = Msg("Bin block size not compatible with dataset: {}")
+        image_too_big = Msg("Image for chosen features is too big ({} x {}).")
+
+    class Warning(OWWidget.Warning):
+        nan_in_image = Msg("Unknown values within images: {} unknowns")
+        threshold_error = Msg("Low slider should be less than High")
+
+    class Information(SelectionOutputsMixin.Information):
+        not_shown = Msg("Undefined positions: {} data point(s) are not shown.")
+
+    def image_values(self):
+        attr_value = self.attr_value.name if self.attr_value else None
+        return lambda data, attr=attr_value: data.transform(Domain([data.domain[attr]]))
+
+    def image_values_fixed_levels(self):
+        return None
+
+    def __init__(self):
+        super().__init__()
+
+        self.maindata = None
+        self.data = None
+
+        # Imageplot for mainarea
+        self.imageplot = AImagePlot(self)
+        self.mainArea.layout().addWidget(self.imageplot)
+
+        # Control area box
+        self.imagebox = gui.widgetBox(self.controlArea, "Image")
+
+        self.xy_model = DomainModel(
+            DomainModel.METAS | DomainModel.CLASSES, valid_types=ContinuousVariable
+        )
+
+        self.feature_value_model = DomainModel(
+            order=(
+                DomainModel.ATTRIBUTES,
+                DomainModel.Separator,
+                DomainModel.CLASSES,
+                DomainModel.Separator,
+                DomainModel.METAS,
+            ),
+            valid_types=ContinuousVariable,
+        )
+
+        self.contextAboutToBeOpened.connect(lambda x: self._init_interface_data(x[0]))
+
+        common_options = dict(
+            labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True
+        )
+
+        box = gui.vBox(self.imagebox)
+
+        self.feature_value = gui.comboBox(
+            box,
+            self,
+            "attr_value",
+            label="Feature:",
+            contentsLength=12,
+            searchable=True,
+            callback=self._update_feature_value,
+            model=self.feature_value_model,
+            **common_options,
+        )
+
+        gui.comboBox(
+            box,
+            self,
+            f"attr_x",
+            label=f"Axis X:",
+            callback=self._attr_changed,
+            model=self.xy_model,
+            **common_options,
+        )
+        gui.comboBox(
+            box,
+            self,
+            f"attr_y",
+            label=f"Axis Y:",
+            callback=self._attr_changed,
+            model=self.xy_model,
+            **common_options,
+        )
+
+        colorsbox = gui.widgetBox(self.controlArea, "Image colors")
+        colorsbox.layout().addWidget(self.imageplot.color_settings_box)
+
+        gui.rubber(self.controlArea)
+        gui.auto_commit(self.controlArea, self, "autocommit", "Send Data")
+
+        self.imageplot.color_cb.activated.connect(self.commit.deferred)
+        self.imageplot._threshold_low_slider.sliderReleased.connect(
+            self.commit.deferred
+        )
+        self.imageplot._threshold_high_slider.sliderReleased.connect(
+            self.commit.deferred
+        )
+        self.imageplot._level_high_le.editingFinished.connect(self.commit.deferred)
+        self.imageplot._level_low_le.editingFinished.connect(self.commit.deferred)
+        self._init_attr_values(self.data)
+
+    def _attr_changed(self):
+        self._update_attrs()
+        self.commit.deferred()
+
+    def _init_attr_values(self, data):
+        domain = data.domain if data is not None else None
+        self.feature_value_model.set_domain(domain)
+        self.attr_value = (
+            self.feature_value_model[0] if self.feature_value_model else None
+        )
+        self.xy_model.set_domain(domain)
+        self.attr_x = self.xy_model[0] if self.xy_model else None
+        self.attr_y = self.xy_model[1] if len(self.xy_model) >= 2 else self.attr_x
+
+    def _init_interface_data(self, data):
+        self._init_attr_values(data)
+        self.imageplot.init_interface_data(data)
+
+    def _update_feature_value(self):
+        self.redraw_data()
+
+    def _update_attrs(self):
+        self.imageplot.attr_x = self.attr_x
+        self.imageplot.attr_y = self.attr_y
+        self.redraw_data()
+
+    def redraw_data(self):
+        self.imageplot.update_view()
+        self.commit.deferred()
+
+    def set_vimage(self, data):
+        # Extract the image scales
+        if data is not None:
+            try:
+                hypercube, ls = get_ndim_hyperspec(
+                    data, (self.imageplot.attr_x, self.imageplot.attr_y)
+                )
+            except Exception as e:
+                self.Error.invalid_axis(str(e))
+                return
+
+            width = np.abs(ls[0][1] - ls[0][0])
+            height = np.abs(ls[1][1] - ls[1][0])
+            xres = width / hypercube.shape[:2][0]
+            yres = height / hypercube.shape[:2][1]
+            posx = ls[0][0]
+            posy = ls[1][0]
+
+            # Extract the image from imageplot so the coloring is done
+            im = self.imageplot.img.qimage
+            if im is not None:
+                buffer = QBuffer()
+                buffer.open(QBuffer.ReadWrite)
+                im.save(buffer, "PNG")
+                pil_im = Image.open(io.BytesIO(buffer.data()))
+                pil_im = pil_im.transpose(Image.FLIP_TOP_BOTTOM)
+                img_bytes = io.BytesIO()
+                pil_im.save(img_bytes, format="PNG")
+
+                # Need to modify the position and the scale since visual imageplot
+                # place the corner of the pixel to the given position
+                vimage = ConstantBytesVisibleImage(
+                    name="External Image",
+                    pos_x=posx - xres / 2,
+                    pos_y=posy - yres / 2,
+                    size_x=width + xres,
+                    size_y=height + yres,
+                    image_bytes=img_bytes,
+                )
+
+                # Assign it to the datatable attributes
+                if self.maindata and vimage is not None:
+                    self.maindata.attributes["visible_images"] = [vimage]
+
+    @Inputs.maindata
+    def set_data(self, data):
+        if data is not None:
+            self.maindata = data
+        else:
+            self.maindata = None
+
+        self.commit.deferred()
+
+    @Inputs.data
+    def set_overlaydata(self, data):
+        self.closeContext()
+        self.openContext(data)
+        if data is not None:
+            self.data = data
+        else:
+            self.data = None
+
+        self.Warning.nan_in_image.clear()
+        self.Error.invalid_axis.clear()
+        self.Error.invalid_block.clear()
+
+        self.imageplot.set_data(data)
+        self.imageplot.update_view()
+
+        self.commit.deferred()
+
+    @gui.deferred
+    def commit(self):
+        self.Warning.nan_in_image.clear()
+        self.Error.invalid_axis.clear()
+        self.Error.invalid_block.clear()
+
+        self.set_vimage(self.data)
+
+        self.Outputs.outdata.send(self.maindata)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from Orange.widgets.utils.widgetpreview import WidgetPreview
+    import Orange.data
+
+    WidgetPreview(OWOverlay).run(
+        set_data=Table("agilent/5_mosaic_agg1024.dmt"),
+        set_overlaydata=Table("agilent/5_mosaic_agg1024.dmt"),
+    )

--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -256,8 +256,6 @@ class OWOverlay(OWWidget):
         else:
             self.maindata = None
 
-        self.commit.deferred()
-
     @Inputs.data
     def set_overlaydata(self, data):
         self.closeContext()
@@ -274,6 +272,7 @@ class OWOverlay(OWWidget):
         self.imageplot.set_data(data)
         self.imageplot.update_view()
 
+    def handleNewSignals(self):
         self.commit.deferred()
 
     @gui.deferred


### PR DESCRIPTION
## New widget: OWOverlay

### Functionality: 

The user can choose a feature from the "Overlay Data" input, which is added to the attributes of the "Data" input table as a "visible image". This way, it is possible to add a visible image overlay even if the reader cannot read it from the original data file, or if it is stored separately. 

The widget creates an RGB overlay image from the displayed image. Thus, changing the display parameters directly affects the assigned visible overlay image.

### Outstanding issues:
- [ ] New icon
- [x] Weird test problem

One of the tests does not seem to run correctly, even though in a real application, the same thing works. Somehow, during `test_add_visible_image`, the image acquired from the imageplot is None, because `im = self.imageplot.img.qimage` in `set_vimage` of the OWOverlay. However, everything runs correctly when the widget is used. 

@markotoplak : Could you please assist us with this? What could cause this weird issue with the tests?