### PR TITLE
owoverlay: Don't set default input

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owoverlay.py
+++ b/orangecontrib/spectroscopy/widgets/owoverlay.py
@@ -71,7 +71,7 @@ class OWOverlay(OWWidget, ConcurrentWidgetMixin):
 
     # Define inputs and outputs
     class Inputs:
-        maindata = Input("Data", Table, default=True)
+        maindata = Input("Data", Table)
         data = Input("Overlay Data", Table)
 
     class Outputs:


### PR DESCRIPTION
Thanks for the overlay widget, it's great!

I spent way too long trying to figure out why it was broken for me. This small change forces the uninitiated user to think about whether the dataset they are connecting is the one to be added or added to.