### PR TITLE
[FIX] owhyper: Show RGB limits settings in color box when selected

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1771,11 +1771,8 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         splitter.setOrientation(Qt.Vertical)
         self.imageplot = ImagePlot(self)
         self.imageplot.selection_changed.connect(self.output_image_selection)
-        # add image settings to the main panne after ImagePlot.__init__
-        iabox.layout().addWidget(self.imageplot.axes_settings_box)
-        icbox.layout().addWidget(self.imageplot.color_settings_box)
 
-        # add image settings to the main panne after ImagePlot.__init__
+        # add image settings to the main pane after ImagePlot.__init__
         iabox.layout().addWidget(self.imageplot.axes_settings_box)
         icbox.layout().addWidget(self.imageplot.color_settings_box)
         ivbox.layout().addWidget(self.imageplot.setup_vector_plot_controls())

--- a/orangecontrib/spectroscopy/widgets/owhyper.py
+++ b/orangecontrib/spectroscopy/widgets/owhyper.py
@@ -1775,6 +1775,7 @@ class OWHyper(OWWidget, SelectionOutputsMixin):
         # add image settings to the main pane after ImagePlot.__init__
         iabox.layout().addWidget(self.imageplot.axes_settings_box)
         icbox.layout().addWidget(self.imageplot.color_settings_box)
+        icbox.layout().addWidget(self.imageplot.rgb_settings_box)
         ivbox.layout().addWidget(self.imageplot.setup_vector_plot_controls())
 
         self.data = None


### PR DESCRIPTION
Following up #777 to show RGB limits in the "Image colors" group in the controls area.

<img width="292" height="533" alt="image" src="https://github.com/user-attachments/assets/b466e4a4-f063-4ba2-902a-3fad3c90d9bc" />

This also fixes a weird bug where the RGB limits were visible in the inset Menu only on old installs, but not if you ran OWHyper stand-alone or started Quasar with `--clear-widget-settings`. Settings, amirite
