### PR TITLE
CurvePlot: Markings count as Items (for bounds corrections) 

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owspectra.py
+++ b/orangecontrib/spectroscopy/widgets/owspectra.py
@@ -1506,7 +1506,7 @@ class CurvePlot(QWidget, OWComponent, SelectionGroupMixin):
 
     def add_marking(self, item):
         self.markings.append(item)
-        self.plot.addItem(item, ignoreBounds=True)
+        self.plot.addItem(item, ignoreBounds=False)
 
     def in_markings(self, item):
         return item in self.markings


### PR DESCRIPTION
Fixes #592

Originally I was going to only change the `ignoreBounds` kwarg for PeakFit, but actually I can't find any reason why not to do it in general. I tested on all the widgets that use markings (Preprocess, Hyper, Integrate) and they all seem to do the right thing?

Of course now if your initial guesses in the fit are way off, that will be shown and the only way to get back to your data is to zoom in.

@markotoplak the override of `ignoreBounds` seems to be quite old, perhaps the reason for it is no longer relevant?