### PR TITLE
io.ascii: Try to skip header rows without a comment delimiter

### DIFF
--- a/orangecontrib/spectroscopy/io/ascii.py
+++ b/orangecontrib/spectroscopy/io/ascii.py
@@ -19,13 +19,17 @@ class AsciiColReader(FileFormat, SpectralFileFormat):
     def read_spectra(self):
         tbl = None
         delimiters = [";", None, ":", ","]
-        for d in delimiters:
-            try:
-                comments = [a for a in [";", "#"] if a != d]
-                tbl = np.loadtxt(self.filename, ndmin=2, delimiter=d, comments=comments)
+        # Try skipping some rows in case there are headers without a comment delimiter
+        for skiprows in range(3):
+            for d in delimiters:
+                try:
+                    comments = [a for a in [";", "#"] if a != d]
+                    tbl = np.loadtxt(self.filename, ndmin=2, delimiter=d, comments=comments, skiprows=skiprows)
+                    break
+                except ValueError:
+                    pass
+            if tbl is not None:
                 break
-            except ValueError:
-                pass
         if tbl is None:
             raise ValueError('File should be delimited by <whitespace>, ";", ":", or ",".')
         wavenumbers = tbl.T[0]  # first column is attribute name

--- a/orangecontrib/spectroscopy/tests/test_readers.py
+++ b/orangecontrib/spectroscopy/tests/test_readers.py
@@ -90,6 +90,11 @@ class TestDat(unittest.TestCase):
             d = Orange.data.Table(fn)
             np.testing.assert_equal(d.X, [[500., 650.]])
 
+    def test_unlabeled_comment_row(self):
+        with named_file("Wavenumber,Intensity\n650.4205,39.928503\n651.3523,40.086846", suffix=".dpt") as fn:
+            d = Orange.data.Table(fn)
+            np.testing.assert_equal(d.X, [[39.928503, 40.086846]])
+
 
 try:
     no_visible_image = FileFormat.locate("opus/no_visible_images.0",


### PR DESCRIPTION
From the workshop, a spectrometer CSV export type with format

```
Wavenumber,Intensity
650.4205,39.928503
651.3523,40.086846
```

Fails to load since the header is not commented out in any way. 

I added an arbitrary `skiprows` range of 3, but 1 would be sufficient for the specific example.
I also used `.dpt` for the test to avoid the annoying `.csv` collision with Orange Table format.