### PR TITLE
[CI] Bump -oldest pandas version to 1.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
             'spectral>=0.22.3,!=0.23',
             'serverfiles>=0.2',
             'AnyQt>=0.2.0',
+            'pandas>=1.5.3',
             'pyqtgraph>=0.13.1',
             'colorcet',
             'h5py',

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     oldest: numpy~=1.24.0
     oldest: pyqtgraph==0.13.1
     oldest: scipy~=1.10.0
-    oldest: pandas~=1.4.0
+    oldest: pandas==1.5.3
     oldest: spectral~=0.22.3
     oldest: lmfit==1.3.3
     oldest: pillow==9.2.0


### PR DESCRIPTION
Fixes #845 , only changed pandas since the rest already match the oldest from when orange3==3.38.0 

(maybe the logic is unclear here?)