### PR TITLE
[MNT] Fix pebble on py311 and for latest orange-widget-base

### DIFF
--- a/orangecontrib/spectroscopy/widgets/owmultifile.py
+++ b/orangecontrib/spectroscopy/widgets/owmultifile.py
@@ -237,7 +237,6 @@ class RelocatablePathsWidgetMixin(RecentPathsWidgetMixin):
 
     def add_path(self, filename, reader):
         """Add (or move) a file name to the top of recent paths"""
-        self._check_init()
         recent = RecentPath.create(filename, self._search_paths())
         if reader is not None:
             recent.file_format = reader.qualified_name()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     'pillow>=9.2.0',
     'lmfit>=1.3.3',
     'bottleneck',
-    'pebble',
+    'pebble<=5.2.0; python_version < "3.12"',
+    'pebble; python_version >= "3.12"',
     'agilent-format>=0.4.5',
     'pySNOM>=0.2.0',
 ]


### PR DESCRIPTION
Pebble 5.2.1 released on July 19 behaves funny.

Also, Multifile was adapted for changes in biolab/orange-widget-base/pull/291