### PR TITLE
Phase unwrapping

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,7 @@ Widgets
    widgets/peakfit
    widgets/snr
    widgets/polar
+   widgets/unwrap
 
 Indices and tables
 ------------------

--- a/doc/widgets/unwrap.md
+++ b/doc/widgets/unwrap.md
@@ -1,0 +1,10 @@
+Unwrap signal
+=============
+
+This widget is a wrapper for the [NumPy signal unwrapping function](https://numpy.org/doc/stable/reference/generated/numpy.unwrap.html). It uses the default arguments of:
+
+```
+wrapped signal = unwrap(input signal, discont = pi, period = 2*pi)
+```
+
+This unwrapping is calculated for every row of the input data table.

--- a/orangecontrib/spectroscopy/tests/test_owunwrap.py
+++ b/orangecontrib/spectroscopy/tests/test_owunwrap.py
@@ -1,0 +1,30 @@
+from Orange.data import Table
+import numpy as np
+from Orange.widgets.tests.base import WidgetTest
+from orangecontrib.spectroscopy.widgets.owunwrap import OWUnwrap
+
+class TestOWReplace(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWUnwrap)
+        self.t = np.linspace(0, 25, 801)
+        self.signal = 1.5 * np.sin(1.1 * self.t + 0.26) * (1 - self.t / 6 + (self.t / 23) ** 3)
+    
+    def test_expected_wrap(self):
+        input = np.mod(self.signal, 2*np.pi) - 1
+        self.input_data = [input]
+        self.send_signal("Data", Table.from_numpy(None, self.input_data))
+        self.widget.commit.now()
+        self.wait_until_finished(timeout=10000)
+        data = self.get_output(self.widget.Outputs.data, wait=10000)
+        expected = np.unwrap(input, discont=np.pi, period=2*np.pi)
+        self.assertTrue(np.all(np.isclose(data, expected)))
+    
+    def test_expected_no_wrap(self):
+        input = self.signal - 1
+        self.input_data = [input]
+        self.send_signal("Data", Table.from_numpy(None, self.input_data))
+        self.widget.commit.now()
+        self.wait_until_finished(timeout=10000)
+        data = self.get_output(self.widget.Outputs.data, wait=10000)
+        expected = input
+        self.assertTrue(np.all(np.isclose(data, expected)))

--- a/orangecontrib/spectroscopy/widgets/icons/unwrap.svg
+++ b/orangecontrib/spectroscopy/widgets/icons/unwrap.svg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.7mm"
+   height="12.7mm"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="unwrap.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="11.588215"
+     inkscape:cx="22.911207"
+     inkscape:cy="28.779237"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:page
+       x="0"
+       y="0"
+       width="12.7"
+       height="12.7"
+       id="page1"
+       margin="0 0 0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect13"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect11"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect10"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <linearGradient
+       id="swatch3"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3" />
+    </linearGradient>
+    <linearGradient
+       id="swatch2"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect2"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect13-1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-26.302583,-50.413284)">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#7f7f7f;stroke-width:0.2;stroke-dasharray:0.40000001, 0.2;stroke-opacity:1;stroke-dashoffset:0"
+       d="m 27.718173,52.993312 c 3.318266,0 6.636532,0 9.954797,0"
+       id="path12"
+       inkscape:path-effect="#path-effect13"
+       inkscape:original-d="m 27.718173,52.993312 c 3.318266,0 6.636532,0 9.954797,0" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.2;stroke-dasharray:0.4, 0.2;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 27.718173,52.993312 c 3.318266,0 6.636532,0 9.954797,0"
+       id="path12-3"
+       inkscape:path-effect="#path-effect13-1"
+       inkscape:original-d="m 27.718173,52.993312 c 3.318266,0 6.636532,0 9.954797,0"
+       transform="translate(-0.00403588,7.5512994)" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 27.78667,57.491236 2.123385,-4.086946 -0.0685,6.803966 3.219327,-6.940959 -0.0685,6.666974 2.968174,-6.575646 -0.04566,6.895295 1.689576,-3.904289"
+       id="path14" />
+  </g>
+</svg>

--- a/orangecontrib/spectroscopy/widgets/owunwrap.py
+++ b/orangecontrib/spectroscopy/widgets/owunwrap.py
@@ -3,6 +3,7 @@ import numpy as np
 import Orange.data
 from Orange.widgets import gui, settings, widget
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin
+from Orange.data import Table
 
 class OWUnwrap(widget.OWWidget, ConcurrentWidgetMixin):
     name = "Unwrap"
@@ -70,14 +71,22 @@ class OWUnwrap(widget.OWWidget, ConcurrentWidgetMixin):
     @staticmethod
     def unwrap_table(table, discont=DEFAULT_DISCONT, period=DEFAULT_PERIOD):
         new_table = table.copy()
-        new_table.X = OWUnwrap.unwrap(table.X, discont=discont, period=period)
-        return new_table
+        new_table_X = OWUnwrap.unwrap(new_table.X, discont=discont, period=period)
+    
+        return Table.from_numpy(
+            domain=table.domain,
+            X=new_table_X,
+            Y=table.Y.copy(),
+            metas=table.metas.copy(),
+            W=table.W.copy() 
+        )
     
 
     @staticmethod
     def unwrap(data, discont=DEFAULT_DISCONT, period=DEFAULT_PERIOD):
         new_data = data.copy()
 
+        # todo: I think this could be done as new_data = np.unwrap(data[~np.isnan(data)], axis=1, discont=discont, period=period) ? needs some testing.
         for row_i in range(data.shape[0]):
             valid = ~np.isnan(data[row_i, :])
             new_data[row_i, valid] = np.unwrap(data[row_i, valid], discont=discont, period=period)

--- a/orangecontrib/spectroscopy/widgets/owunwrap.py
+++ b/orangecontrib/spectroscopy/widgets/owunwrap.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+import Orange.data
+from Orange.widgets import gui, settings, widget
+from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin
+
+class OWUnwrap(widget.OWWidget, ConcurrentWidgetMixin):
+    name = "Unwrap"
+    description = "Unwrap signal (phase correction)."
+    icon = "icons/unwrap.svg"
+    id = "orangecontrib.signal.widgets.owunwrap"
+    priority = 10
+
+    class Inputs:
+        data = widget.Input("Data", Orange.data.Table, default=True)
+
+    class Outputs:
+        data = widget.Output("Data", Orange.data.Table, default=True)
+
+    want_main_area = False
+    want_control_area = True
+    resizing_enabled = False
+
+    settingsHandler = settings.DomainContextHandler()
+
+    autocommit = settings.Setting(True)
+
+    DEFAULT_DISCONT = np.pi
+    DEFAULT_PERIOD = 2 * np.pi
+
+    discont = settings.Setting(DEFAULT_DISCONT)
+    period = settings.Setting(DEFAULT_PERIOD)
+
+
+    def __init__(self):
+        widget.OWWidget.__init__(self)
+        ConcurrentWidgetMixin.__init__(self)
+
+        self.data = None
+        self.discont = OWUnwrap.DEFAULT_DISCONT
+        self.period = OWUnwrap.DEFAULT_PERIOD
+
+        # Todo: Add discont and period options?
+        """
+        CSB note: apparently this is not needed, but again, could be required in the future?
+
+        Difficult to know exactly how this should look, given we probably want both in multiples of \pi. Slider? Slider overriding default tick boxes? Spinbox?
+
+        """
+
+        gui.auto_commit(self.controlArea, self, "autocommit", "Send Data")
+
+
+    @Inputs.data
+    def set_data(self, data):
+        self.data = data
+        self.commit.now()
+
+
+    @gui.deferred
+    def commit(self):
+        out_data = None
+
+        if self.data is not None:
+            out_data = OWUnwrap.unwrap_table(self.data, discont=self.discont, period=self.period)
+
+        self.Outputs.data.send(out_data)
+
+
+    @staticmethod
+    def unwrap_table(table, discont=DEFAULT_DISCONT, period=DEFAULT_PERIOD):
+        new_table = table.copy()
+        new_table.X = OWUnwrap.unwrap(table.X, discont=discont, period=period)
+        return new_table
+    
+
+    @staticmethod
+    def unwrap(data, discont=DEFAULT_DISCONT, period=DEFAULT_PERIOD):
+        new_data = data.copy()
+
+        for row_i in range(data.shape[0]):
+            valid = ~np.isnan(data[row_i, :])
+            new_data[row_i, valid] = np.unwrap(data[row_i, valid], discont=discont, period=period)
+
+        return new_data
+
+
+if __name__ == "__main__":  # pragma: no cover
+    from Orange.widgets.utils.widgetpreview import WidgetPreview
+    WidgetPreview(OWUnwrap).run()

--- a/orangecontrib/spectroscopy/widgets/owunwrap.py
+++ b/orangecontrib/spectroscopy/widgets/owunwrap.py
@@ -86,7 +86,6 @@ class OWUnwrap(widget.OWWidget, ConcurrentWidgetMixin):
     def unwrap(data, discont=DEFAULT_DISCONT, period=DEFAULT_PERIOD):
         new_data = data.copy()
 
-        # todo: I think this could be done as new_data = np.unwrap(data[~np.isnan(data)], axis=1, discont=discont, period=period) ? needs some testing.
         for row_i in range(data.shape[0]):
             valid = ~np.isnan(data[row_i, :])
             new_data[row_i, valid] = np.unwrap(data[row_i, valid], discont=discont, period=period)


### PR DESCRIPTION
This PR adds an unwrapping widget, originally developed at DLS by Ben Nicholson. The widget is a wrapper around the [numpy unwrap function](https://numpy.org/doc/stable/reference/generated/numpy.unwrap.html). 

For the moment, it uses default values for the function as documented. I've been assured that these are sufficient, but we could have the option of varying them. However, I'm unsure atm what would be the best route for this. Some possible options from the top of my head - 

- radio buttons with 'default' and 'custom', where `custom` then has activated input boxes
- sliders with default values. This may be tricky because I imagine we really want regular intervals (1/4,1/2..1, 2, etc) of \pi, rather than arbitrary float values

The user feedback on the widget is happy with it as it is, so potentially adding more functionality to the GUI could be out of scope of this PR and can be added later once the basic widget is integrated.