### PR TITLE
[FIX] scipy>=1.7 compatibility

### DIFF
--- a/orangecontrib/spectroscopy/preprocess/atm_corr.py
+++ b/orangecontrib/spectroscopy/preprocess/atm_corr.py
@@ -125,6 +125,7 @@ class _AtmCorr(CommonDomainOrderUnknowns):
                         else (dhdy[:, r] / dh2[r])
                     )
             az2sum = (az * az).sum(0)
+            az2sum[az2sum == 0] = 1  # avoid NaNs after next division
             az = az**3 / az2sum
             for ia, atm in enumerate(atms):
                 for i, (p, q) in enumerate(ranges):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     'Orange3>=3.38.0',
     'orange-canvas-core>=0.2.4',
     'orange-widget-base>=4.25.0',
-    'scipy>=1.10.0,<1.17.0',
+    'scipy>=1.10.0',
     'scikit-learn>=1.5.1',
     'spectral>=0.22.3,!=0.23',
     'serverfiles>=0.2',


### PR DESCRIPTION
The problem appeared in atmospheric correction preprocessor because savgol from scipy now checks for nans in data.

Fixes #853